### PR TITLE
docs(backend-api): definir rutas API y guia de integracion frontend

### DIFF
--- a/apps/backend-api/README.md
+++ b/apps/backend-api/README.md
@@ -1,11 +1,51 @@
 # backend-api
 
-API principal usando Bun + Hono.
+API principal de TerraShare usando Bun + Hono.
 
-Responsabilidades iniciales:
-- Auth y RBAC
-- Modulo de terrenos
-- Modulo de solicitudes
-- Modulo de contratos
-- Modulo de pagos
-- Modulo de chat
+## Estado del modulo
+- Estado actual: contrato de API documentado para alineacion Frontend/Backend.
+- Implementacion de endpoints: en progreso.
+- Fuente de verdad para integracion frontend: archivos dentro de `docs/`.
+
+## Objetivo funcional (v1)
+- Auth y RBAC base.
+- CRUD de terrenos y filtros.
+- Solicitudes de alquiler y flujo de estados.
+- Contratos y auditoria basica.
+- Pagos con Stripe Checkout Session.
+- Chat interno y contacto externo.
+
+## Auth y autorizacion
+- Proveedor de identidad: Clerk.
+- Providers habilitados: Google OAuth, Microsoft OAuth y OTP por email.
+- El frontend hace sign-in/sign-up en Clerk.
+- El backend valida `Authorization: Bearer <token>` emitido por Clerk.
+- Roles iniciales de aplicacion: `user` y `admin`.
+
+Importante para frontend:
+- En fase 1 no hay endpoint propio `POST /auth/login` en backend.
+- El endpoint principal para obtener sesion de aplicacion es `GET /api/v1/auth/me`.
+
+## Pagos (fase 1)
+- Proveedor: Stripe (SDK oficial).
+- Flujo definido: Checkout Session.
+- Confirmacion de pago: webhook (`POST /api/v1/webhooks/stripe`) como fuente de verdad.
+- El frontend no debe confirmar pago solo por `success_url`; debe consultar estado de pago en API.
+
+## Documentacion para frontend
+- Rutas y endpoints: [docs/API_ENDPOINTS.md](docs/API_ENDPOINTS.md)
+- Guia de integracion (Clerk + Stripe): [docs/INTEGRATION.md](docs/INTEGRATION.md)
+
+## Variables de entorno esperadas (referencia)
+- `API_PORT`
+- `API_BASE_URL`
+- `MONGODB_URI`
+- `CLERK_SECRET_KEY`
+- `CLERK_JWKS_URL`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `WHATSAPP_CONTACT_ENABLED=true|false`
+
+## Versionado
+- Prefijo de API: `/api/v1`.
+- Cambios breaking deben crear una nueva version o una estrategia formal de compatibilidad.

--- a/apps/backend-api/docs/API_ENDPOINTS.md
+++ b/apps/backend-api/docs/API_ENDPOINTS.md
@@ -1,0 +1,231 @@
+# API endpoints - backend-api (v1)
+
+Este documento define el contrato de rutas para integracion con frontend.
+
+- Base path: `/api/v1`
+- Formato: `application/json`
+- Auth: `Authorization: Bearer <clerk_token>` en rutas protegidas
+- Estado actual: `planned` (sin implementacion productiva todavia)
+
+## Convenciones de respuesta
+
+Respuesta exitosa:
+
+```json
+{
+  "ok": true,
+  "data": {},
+  "meta": {
+    "requestId": "req_123"
+  }
+}
+```
+
+Respuesta de error:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid payload",
+    "details": [
+      {
+        "field": "price",
+        "message": "Must be greater than 0"
+      }
+    ],
+    "requestId": "req_123"
+  }
+}
+```
+
+## Roles y acceso
+
+- `public`: no requiere token.
+- `user`: requiere token valido de Clerk y usuario activo.
+- `admin`: requiere token valido + rol admin.
+- `owner`: requiere token valido + ownership del recurso (o admin).
+
+## Estados de implementacion
+
+- `planned`: contrato acordado, aun no implementado.
+- `in_progress`: en desarrollo.
+- `implemented`: disponible.
+
+## Health
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| GET | `/health` | No | public | planned | #9 |
+
+## Auth (Clerk + RBAC)
+
+Notas:
+- El login/signup vive en Clerk (Google, Microsoft, OTP email).
+- No existe `POST /auth/login` en backend para fase 1.
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| GET | `/auth/me` | Si | user, admin | planned | #23 |
+
+`GET /auth/me` response example:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "id": "usr_01",
+    "clerkUserId": "user_2x...",
+    "email": "user@example.com",
+    "role": "user",
+    "status": "active",
+    "profile": {
+      "fullName": "Chris V",
+      "phone": "+50760000000"
+    }
+  },
+  "meta": {
+    "requestId": "req_auth_me"
+  }
+}
+```
+
+## Lands
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| GET | `/lands` | No | public | planned | #24 |
+| GET | `/lands/:landId` | No | public | planned | #24 |
+| POST | `/lands` | Si | user, admin | planned | #24 |
+| PATCH | `/lands/:landId` | Si | owner, admin | planned | #24 |
+| DELETE | `/lands/:landId` | Si | owner, admin | planned | #24 |
+| PATCH | `/lands/:landId/status` | Si | owner, admin | planned | #24 |
+
+`GET /lands` query params:
+
+- `page` (default 1)
+- `pageSize` (default 20, max 100)
+- `sort` (`createdAt`, `price`, `area`)
+- `order` (`asc`, `desc`)
+- `use` (ej: `agricultura`, `ganaderia`)
+- `priceMin`, `priceMax`
+- `province`, `district`
+- `availableFrom`, `availableTo`
+
+## Rental requests
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| POST | `/rental-requests` | Si | user, admin | planned | #25 |
+| GET | `/rental-requests` | Si | user, admin | planned | #25 |
+| GET | `/rental-requests/:requestId` | Si | user, owner, admin | planned | #25 |
+| PATCH | `/rental-requests/:requestId/status` | Si | owner, admin | planned | #25 |
+
+Estados de solicitud (v1):
+
+- `draft`
+- `pending_owner`
+- `approved`
+- `rejected`
+- `cancelled`
+- `pending_payment`
+- `paid`
+
+## Contracts
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| POST | `/contracts` | Si | owner, admin | planned | #26 |
+| GET | `/contracts` | Si | user, owner, admin | planned | #26 |
+| GET | `/contracts/:contractId` | Si | user, owner, admin | planned | #26 |
+| PATCH | `/contracts/:contractId/status` | Si | owner, admin | planned | #26 |
+
+## Audit events
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| GET | `/audit-events` | Si | admin | planned | #26 |
+| GET | `/audit-events/:eventId` | Si | admin | planned | #26 |
+
+## Payments (Stripe SDK)
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| POST | `/payments/checkout-session` | Si | user, admin | planned | #27 |
+| GET | `/payments/:paymentId` | Si | user, owner, admin | planned | #27 |
+| GET | `/payments` | Si | user, owner, admin | planned | #27 |
+| POST | `/webhooks/stripe` | No (firma Stripe) | system | planned | #27 |
+
+`POST /payments/checkout-session` request example:
+
+```json
+{
+  "rentalRequestId": "rr_01",
+  "currency": "USD",
+  "successUrl": "http://localhost:5174/payments/success?paymentId={PAYMENT_ID}",
+  "cancelUrl": "http://localhost:5174/payments/cancel?paymentId={PAYMENT_ID}"
+}
+```
+
+`POST /payments/checkout-session` response example:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "paymentId": "pay_01",
+    "stripeSessionId": "cs_test_123",
+    "checkoutUrl": "https://checkout.stripe.com/c/pay/cs_test_123",
+    "status": "pending"
+  },
+  "meta": {
+    "requestId": "req_pay_01"
+  }
+}
+```
+
+## Chat y contacto externo
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| GET | `/chats` | Si | user, owner, admin | planned | #28 |
+| POST | `/chats` | Si | user, owner, admin | planned | #28 |
+| GET | `/chats/:chatId/messages` | Si | user, owner, admin | planned | #28 |
+| POST | `/chats/:chatId/messages` | Si | user, owner, admin | planned | #28 |
+| GET | `/chats/:chatId/external-contact` | Si | user, owner, admin | planned | #28 |
+
+`GET /chats/:chatId/external-contact` response example:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "whatsappEnabled": true,
+    "contact": {
+      "phone": "+50760000000",
+      "displayName": "Propietario"
+    }
+  },
+  "meta": {
+    "requestId": "req_chat_contact_01"
+  }
+}
+```
+
+## Shared contracts (packages/shared)
+
+Para mantener front/back sincronizados (issue #29), los DTOs deben exponerse en `packages/shared`:
+
+- `AuthMeResponseDto`
+- `LandDto`, `CreateLandDto`, `UpdateLandDto`, `LandFilterDto`
+- `RentalRequestDto`, `CreateRentalRequestDto`, `UpdateRentalRequestStatusDto`
+- `ContractDto`
+- `PaymentDto`, `CreateCheckoutSessionDto`
+- `ChatDto`, `ChatMessageDto`
+
+## Notas para frontend
+
+- Tratar este archivo como contrato de integracion hasta que cada endpoint pase a `implemented`.
+- Para vistas publicas usar `GET /lands` y `GET /lands/:landId` sin token.
+- Para cualquier accion transaccional usar token de Clerk.

--- a/apps/backend-api/docs/INTEGRATION.md
+++ b/apps/backend-api/docs/INTEGRATION.md
@@ -1,0 +1,119 @@
+# Integracion frontend - backend-api
+
+Guia practica para equipos frontend que integran con backend-api.
+
+## 1. Resumen rapido
+
+- Auth: Clerk (Google OAuth, Microsoft OAuth, OTP por email).
+- API auth: token JWT de Clerk via `Authorization: Bearer <token>`.
+- Pagos: Stripe SDK con Checkout Session.
+- Confirmacion de pago: webhook Stripe en backend.
+
+## 2. Flujo de autenticacion (Clerk)
+
+### Lo que hace frontend
+
+1. Mostrar opciones de acceso en UI:
+   - Continuar con Google
+   - Continuar con Microsoft
+   - Continuar con OTP por email
+2. Completar el flujo en Clerk.
+3. Obtener `session token` de Clerk.
+4. Enviar token al backend en rutas protegidas.
+
+### Lo que hace backend
+
+1. Verifica JWT con Clerk JWKS.
+2. Busca o crea usuario interno mapeado al `clerkUserId`.
+3. Responde contexto de sesion de aplicacion en `GET /api/v1/auth/me`.
+4. Aplica RBAC por `role` (`user`, `admin`) y ownership.
+
+## 3. Header de autorizacion
+
+Ejemplo de request autenticado:
+
+```http
+GET /api/v1/auth/me HTTP/1.1
+Host: api.terrashare.local
+Authorization: Bearer <clerk_jwt>
+Content-Type: application/json
+```
+
+Si falta token o es invalido, el backend responde `401`.
+
+## 4. Flujo de pagos (Stripe Checkout Session)
+
+### Step-by-step
+
+1. Front crea solicitud de alquiler (o usa una ya aprobada).
+2. Front llama `POST /api/v1/payments/checkout-session`.
+3. Backend crea session en Stripe y devuelve `checkoutUrl`.
+4. Front redirige al usuario a `checkoutUrl`.
+5. Stripe redirige a `successUrl` o `cancelUrl`.
+6. Stripe envia webhook a `POST /api/v1/webhooks/stripe`.
+7. Backend actualiza estado de pago y solicitud.
+8. Front consulta `GET /api/v1/payments/:paymentId` para estado final.
+
+### Regla clave
+
+- No usar `successUrl` como confirmacion final.
+- Estado final siempre viene del backend (actualizado por webhook).
+
+## 5. Matriz pantalla -> endpoint
+
+| Pantalla frontend | Endpoint principal | Auth |
+| --- | --- | --- |
+| Home publica / catalogo | `GET /api/v1/lands` | No |
+| Detalle terreno publico | `GET /api/v1/lands/:landId` | No |
+| Dashboard usuario | `GET /api/v1/auth/me` | Si |
+| Publicar terreno | `POST /api/v1/lands` | Si |
+| Editar terreno propio | `PATCH /api/v1/lands/:landId` | Si |
+| Crear solicitud alquiler | `POST /api/v1/rental-requests` | Si |
+| Aprobar/Rechazar solicitud | `PATCH /api/v1/rental-requests/:requestId/status` | Si |
+| Iniciar pago | `POST /api/v1/payments/checkout-session` | Si |
+| Estado de pago | `GET /api/v1/payments/:paymentId` | Si |
+| Lista de chats | `GET /api/v1/chats` | Si |
+| Mensajes de chat | `GET /api/v1/chats/:chatId/messages` | Si |
+| Contacto externo | `GET /api/v1/chats/:chatId/external-contact` | Si |
+
+## 6. Variables de entorno necesarias
+
+Backend:
+
+- `API_PORT`
+- `API_BASE_URL`
+- `MONGODB_URI`
+- `CLERK_SECRET_KEY`
+- `CLERK_JWKS_URL`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `WHATSAPP_CONTACT_ENABLED`
+
+Frontend:
+
+- `VITE_API_BASE_URL`
+- `VITE_CLERK_PUBLISHABLE_KEY`
+
+## 7. Codigos de error comunes
+
+- `400 VALIDATION_ERROR`: payload invalido.
+- `401 UNAUTHORIZED`: token ausente/invalido/expirado.
+- `403 FORBIDDEN`: rol insuficiente o recurso sin ownership.
+- `404 NOT_FOUND`: recurso inexistente.
+- `409 CONFLICT`: estado invalido o solape de alquiler.
+- `422 BUSINESS_RULE_VIOLATION`: regla de dominio no cumplida.
+- `500 INTERNAL_ERROR`: error inesperado.
+
+## 8. Checklist para frontend antes de integrar
+
+- Confirmar que token de Clerk llega correctamente en cada request protegida.
+- Implementar refresh de sesion en cliente segun SDK de Clerk.
+- Tratar todas las transiciones de pago como asincronas por webhook.
+- Manejar estados de solicitud (`pending_owner`, `approved`, `rejected`, `cancelled`, `pending_payment`, `paid`).
+- Mostrar errores por `error.code` y `error.message`.
+
+## 9. Referencias
+
+- Endpoints detallados: [API_ENDPOINTS.md](API_ENDPOINTS.md)
+- Contexto de arquitectura: [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md)
+- Reglas de negocio: [`docs/PRD.md`](../../../docs/PRD.md)


### PR DESCRIPTION
## Resumen
Este PR documenta el contrato inicial del `backend-api` para que frontend pueda integrar desde ya sin bloquearse por la implementacion pendiente. Se formalizan rutas, convenciones de respuesta/error y flujos de autenticacion/pagos.

## Issue relacionado
Related to #9, #23, #24, #25, #26, #27, #28, #29

## Tipo de cambio
- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [x] Documentacion

## Checklist
- [x] Cumple criterios de aceptacion del issue
- [x] No rompe funcionalidad existente
- [ ] Incluye/actualiza pruebas necesarias
- [ ] CI en verde
- [x] Documentacion actualizada

## Evidencia
- Se actualiza `apps/backend-api/README.md` con decisiones de Clerk (Google/Microsoft/OTP email) y Stripe Checkout Session.
- Se agrega `apps/backend-api/docs/API_ENDPOINTS.md` con catalogo de rutas v1 por modulo, auth/roles y ejemplos request/response.
- Se agrega `apps/backend-api/docs/INTEGRATION.md` con guia frontend: token Clerk -> API protegida -> Stripe checkout -> confirmacion por webhook.

## Riesgos y rollback
- Riesgo principal: desalineacion futura entre documentacion y endpoints reales durante implementacion.
- Plan de rollback: revertir este PR o ajustar los contratos en cambios incrementales por issue.