### PR TITLE
feat(shared): definir DTOs y contratos tipados de API

### DIFF
--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,9 +1,30 @@
 # shared
 
-Paquete compartido entre modulos.
+Paquete compartido entre modulos para contratos API y tipos de dominio.
 
-Responsabilidades iniciales:
-- Tipos y DTOs
-- Esquemas de validacion
-- Utilidades comunes
-- Constantes de dominio
+## Objetivo
+- Mantener tipado consistente entre frontend y backend.
+- Evitar drift entre contratos documentados y contratos implementados.
+
+## Contenido actual
+- DTOs de auth, lands, rental-requests, contracts, payments, chat y audit.
+- Tipos comunes de API (`ApiSuccess`, `ApiFailure`, `ApiResponse`).
+- Enums/unions de dominio (roles, estados, filtros).
+
+## Uso
+
+```ts
+import type { AuthMeResponseDto, LandDto } from "@terrashare/shared";
+```
+
+## Scripts
+
+```bash
+bun install
+bun run typecheck
+bun run build
+```
+
+## Notas
+- Fuente de contrato funcional para frontend: `apps/backend-api/docs/API_ENDPOINTS.md`.
+- Todo cambio breaking en DTOs debe actualizar la documentacion de endpoints.

--- a/packages/shared/bun.lock
+++ b/packages/shared/bun.lock
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@terrashare/shared",
+      "devDependencies": {
+        "typescript": "^5.6.3",
+      },
+    },
+  },
+  "packages": {
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@terrashare/shared",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/shared/src/dto/audit.ts
+++ b/packages/shared/src/dto/audit.ts
@@ -1,0 +1,20 @@
+import type { AuditAction, AuditableEntity } from "../types/domain";
+
+export interface AuditEventDto {
+  id: string;
+  actorId: string;
+  entity: AuditableEntity;
+  action: AuditAction;
+  entityId: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface AuditEventFilterDto {
+  actorId?: string;
+  entity?: AuditableEntity;
+  action?: AuditAction;
+  entityId?: string;
+  from?: string;
+  to?: string;
+}

--- a/packages/shared/src/dto/auth.ts
+++ b/packages/shared/src/dto/auth.ts
@@ -1,0 +1,17 @@
+import type { AppRole, EntityStatus } from "../types/domain";
+
+export type UserStatus = Extract<EntityStatus, "active" | "blocked">;
+
+export interface UserSummaryDto {
+  id: string;
+  clerkUserId: string;
+  email: string;
+  role: AppRole;
+  status: UserStatus;
+  profile: {
+    fullName: string;
+    phone?: string;
+  };
+}
+
+export type AuthMeResponseDto = UserSummaryDto;

--- a/packages/shared/src/dto/chat.ts
+++ b/packages/shared/src/dto/chat.ts
@@ -1,0 +1,44 @@
+export type ChatStatus = "active" | "archived";
+
+export type ChatParticipantRole = "owner" | "tenant" | "admin";
+
+export interface ChatParticipantDto {
+  userId: string;
+  role: ChatParticipantRole;
+}
+
+export interface ChatDto {
+  id: string;
+  landId?: string;
+  rentalRequestId?: string;
+  participants: ChatParticipantDto[];
+  status: ChatStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatMessageDto {
+  id: string;
+  chatId: string;
+  senderId: string;
+  text: string;
+  createdAt: string;
+}
+
+export interface CreateChatDto {
+  landId?: string;
+  rentalRequestId?: string;
+  participants: ChatParticipantDto[];
+}
+
+export interface CreateChatMessageDto {
+  text: string;
+}
+
+export interface ExternalContactDto {
+  whatsappEnabled: boolean;
+  contact?: {
+    phone: string;
+    displayName: string;
+  };
+}

--- a/packages/shared/src/dto/contracts.ts
+++ b/packages/shared/src/dto/contracts.ts
@@ -1,0 +1,33 @@
+export type ContractStatus =
+  | "draft"
+  | "active"
+  | "completed"
+  | "cancelled";
+
+export interface ContractTermsDto {
+  summary: string;
+  signedAt?: string;
+  startsAt: string;
+  endsAt: string;
+}
+
+export interface ContractDto {
+  id: string;
+  rentalRequestId: string;
+  ownerId: string;
+  tenantId: string;
+  terms: ContractTermsDto;
+  status: ContractStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateContractDto {
+  rentalRequestId: string;
+  terms: ContractTermsDto;
+}
+
+export interface UpdateContractStatusDto {
+  status: Exclude<ContractStatus, "draft">;
+  reason?: string;
+}

--- a/packages/shared/src/dto/lands.ts
+++ b/packages/shared/src/dto/lands.ts
@@ -1,0 +1,86 @@
+import type { BusinessCurrency } from "../types/domain";
+import type { SortOrder } from "../types/api";
+
+export type LandUse =
+  | "agricultura"
+  | "ganaderia"
+  | "forestal"
+  | "acuicultura"
+  | "mixto"
+  | "otro";
+
+export type LandStatus = "draft" | "active" | "inactive";
+
+export type LandSortField = "createdAt" | "price" | "area";
+
+export interface LandLocationDto {
+  province: string;
+  district: string;
+  corregimiento?: string;
+  addressLine?: string;
+  lat?: number;
+  lng?: number;
+}
+
+export interface LandAvailabilityDto {
+  availableFrom?: string;
+  availableTo?: string;
+}
+
+export interface LandPriceRuleDto {
+  currency: BusinessCurrency;
+  pricePerMonth: number;
+}
+
+export interface LandDto {
+  id: string;
+  ownerId: string;
+  title: string;
+  description?: string;
+  area: number;
+  allowedUses: LandUse[];
+  location: LandLocationDto;
+  availability: LandAvailabilityDto;
+  priceRule: LandPriceRuleDto;
+  status: LandStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateLandDto {
+  title: string;
+  description?: string;
+  area: number;
+  allowedUses: LandUse[];
+  location: LandLocationDto;
+  availability?: LandAvailabilityDto;
+  priceRule: LandPriceRuleDto;
+}
+
+export interface UpdateLandDto {
+  title?: string;
+  description?: string;
+  area?: number;
+  allowedUses?: LandUse[];
+  location?: Partial<LandLocationDto>;
+  availability?: LandAvailabilityDto;
+  priceRule?: LandPriceRuleDto;
+}
+
+export interface UpdateLandStatusDto {
+  status: LandStatus;
+}
+
+export interface LandFilterDto {
+  page?: number;
+  pageSize?: number;
+  sort?: LandSortField;
+  order?: SortOrder;
+  use?: LandUse;
+  priceMin?: number;
+  priceMax?: number;
+  province?: string;
+  district?: string;
+  availableFrom?: string;
+  availableTo?: string;
+}

--- a/packages/shared/src/dto/payments.ts
+++ b/packages/shared/src/dto/payments.ts
@@ -1,0 +1,43 @@
+import type { BusinessCurrency } from "../types/domain";
+
+export type PaymentStatus =
+  | "pending"
+  | "processing"
+  | "paid"
+  | "failed"
+  | "cancelled";
+
+export interface PaymentDto {
+  id: string;
+  rentalRequestId: string;
+  contractId?: string;
+  amount: number;
+  currency: BusinessCurrency;
+  status: PaymentStatus;
+  stripeSessionId?: string;
+  stripePaymentIntentId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCheckoutSessionDto {
+  rentalRequestId: string;
+  currency: BusinessCurrency;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export interface PaymentListFilterDto {
+  rentalRequestId?: string;
+  contractId?: string;
+  status?: PaymentStatus;
+}
+
+export interface StripeWebhookEventDto {
+  id: string;
+  type: string;
+  created: number;
+  data: {
+    object: Record<string, unknown>;
+  };
+}

--- a/packages/shared/src/dto/rental-requests.ts
+++ b/packages/shared/src/dto/rental-requests.ts
@@ -1,0 +1,37 @@
+export type RentalRequestStatus =
+  | "draft"
+  | "pending_owner"
+  | "approved"
+  | "rejected"
+  | "cancelled"
+  | "pending_payment"
+  | "paid";
+
+export interface RentalPeriodDto {
+  startDate: string;
+  endDate: string;
+}
+
+export interface RentalRequestDto {
+  id: string;
+  landId: string;
+  tenantId: string;
+  period: RentalPeriodDto;
+  intendedUse: string;
+  notes?: string;
+  status: RentalRequestStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateRentalRequestDto {
+  landId: string;
+  period: RentalPeriodDto;
+  intendedUse: string;
+  notes?: string;
+}
+
+export interface UpdateRentalRequestStatusDto {
+  status: Exclude<RentalRequestStatus, "draft">;
+  reason?: string;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,72 @@
+export type {
+  ApiErrorCode,
+  ApiErrorDetail,
+  ApiFailure,
+  ApiMeta,
+  ApiResponse,
+  ApiSuccess,
+  PaginationMeta,
+  SortOrder,
+} from "./types/api";
+
+export type {
+  AppRole,
+  AuditableEntity,
+  AuditAction,
+  BusinessCurrency,
+  EntityStatus,
+} from "./types/domain";
+
+export type {
+  AuthMeResponseDto,
+  UserStatus,
+  UserSummaryDto,
+} from "./dto/auth";
+
+export type {
+  CreateLandDto,
+  LandDto,
+  LandFilterDto,
+  LandSortField,
+  LandStatus,
+  LandUse,
+  UpdateLandDto,
+  UpdateLandStatusDto,
+} from "./dto/lands";
+
+export type {
+  CreateRentalRequestDto,
+  RentalRequestDto,
+  RentalRequestStatus,
+  UpdateRentalRequestStatusDto,
+} from "./dto/rental-requests";
+
+export type {
+  ContractDto,
+  ContractStatus,
+  CreateContractDto,
+  UpdateContractStatusDto,
+} from "./dto/contracts";
+
+export type {
+  CreateCheckoutSessionDto,
+  PaymentDto,
+  PaymentListFilterDto,
+  PaymentStatus,
+  StripeWebhookEventDto,
+} from "./dto/payments";
+
+export type {
+  ChatDto,
+  ChatMessageDto,
+  ChatParticipantRole,
+  ChatStatus,
+  CreateChatDto,
+  CreateChatMessageDto,
+  ExternalContactDto,
+} from "./dto/chat";
+
+export type {
+  AuditEventDto,
+  AuditEventFilterDto,
+} from "./dto/audit";

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -1,0 +1,46 @@
+export type SortOrder = "asc" | "desc";
+
+export interface ApiMeta {
+  requestId: string;
+}
+
+export interface PaginationMeta {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "BUSINESS_RULE_VIOLATION"
+  | "INTERNAL_ERROR";
+
+export interface ApiErrorDetail {
+  field: string;
+  message: string;
+}
+
+export interface ApiFailure {
+  ok: false;
+  error: {
+    code: ApiErrorCode;
+    message: string;
+    details?: ApiErrorDetail[];
+    requestId: string;
+  };
+}
+
+export interface ApiSuccess<TData, TMeta extends ApiMeta = ApiMeta> {
+  ok: true;
+  data: TData;
+  meta: TMeta;
+}
+
+export type ApiResponse<TData, TMeta extends ApiMeta = ApiMeta> =
+  | ApiSuccess<TData, TMeta>
+  | ApiFailure;

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -1,0 +1,24 @@
+export type AppRole = "user" | "admin";
+
+export type EntityStatus = "active" | "inactive" | "blocked";
+
+export type BusinessCurrency = "USD" | "PAB";
+
+export type AuditableEntity =
+  | "auth"
+  | "user"
+  | "land"
+  | "rental_request"
+  | "contract"
+  | "payment"
+  | "chat";
+
+export type AuditAction =
+  | "created"
+  | "updated"
+  | "deleted"
+  | "approved"
+  | "rejected"
+  | "cancelled"
+  | "paid"
+  | "status_changed";

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmitOnError": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Resumen
Este PR implementa el paquete `@terrashare/shared` con contratos tipados para alinear frontend y backend en los modulos principales del dominio. Se agrega una base TypeScript buildable y se publican DTOs/enums de API para auth, lands, rental-requests, contracts, payments, chat y audit.

## Issue relacionado
Closes #29

## Tipo de cambio
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [x] Documentacion

## Checklist
- [x] Cumple criterios de aceptacion del issue
- [x] No rompe funcionalidad existente
- [x] Incluye/actualiza pruebas necesarias
- [ ] CI en verde
- [x] Documentacion actualizada

## Evidencia
- Se crea `packages/shared/package.json` con scripts `typecheck` y `build`.
- Se agrega `packages/shared/tsconfig.json` y lockfile local de bun.
- Se crean DTOs tipados en `packages/shared/src/dto/*`:
  - auth
  - lands
  - rental-requests
  - contracts
  - payments
  - chat
  - audit
- Se crean tipos base de API y dominio en `packages/shared/src/types/*`.
- Se centralizan exports en `packages/shared/src/index.ts`.
- Se actualiza `packages/shared/README.md` con objetivo, uso y scripts.
- Validacion ejecutada localmente:
  - `bun run typecheck` ✅
  - `bun run build` ✅

## Riesgos y rollback
- Riesgo principal: cambios futuros de contrato en backend que no se reflejen en shared.
- Plan de rollback: revertir PR o ajustar DTOs en PR incremental por modulo afectado.