### PR TITLE
feat(app-web): flujo mock de reservas con aprobación/rechazo

### DIFF
--- a/.github/workflows/app-web-e2e.yml
+++ b/.github/workflows/app-web-e2e.yml
@@ -1,0 +1,54 @@
+name: App Web CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/app-web/**"
+      - ".github/workflows/app-web-e2e.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/app-web/**"
+      - ".github/workflows/app-web-e2e.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-e2e:
+    name: Build and E2E (app-web)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/app-web
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build app-web
+        run: bun run build
+
+      - name: Run E2E smoke tests
+        run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-app-web
+          path: apps/app-web/playwright-report
+          if-no-files-found: ignore

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,36 @@
+name: Require Linked Issue
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  linked-issue:
+    name: Require closing keyword
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body has closing keyword
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const closingKeywordPattern = /(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+((?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+)/i;
+
+            if (pr.draft) {
+              core.notice("Draft PR detected. Check is skipped until ready for review.");
+              return;
+            }
+
+            if (!closingKeywordPattern.test(body)) {
+              core.setFailed(
+                "PR description must include an issue-closing keyword, e.g. 'Closes #123' or 'Fixes owner/repo#123'."
+              );
+            } else {
+              core.info("Issue closing keyword found in PR description.");
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ coverage/
 # Playwright
 playwright-report/
 test-results/
+
+# Local frontend cache
+apps/**/.vite/
+
+# Temporary PR body drafts
+pr_body*.txt
+pr_body*.md

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Plataforma para alquiler de terrenos (agricultura, ganaderia y otros usos produc
 - Flujo de trabajo (issues + PR): [docs/WORKFLOW.md](docs/WORKFLOW.md)
 - Estructura de repositorio: [docs/REPOSITORY_STRUCTURE.md](docs/REPOSITORY_STRUCTURE.md)
 - Setup y comandos: [docs/SETUP_AND_COMMANDS.md](docs/SETUP_AND_COMMANDS.md)
+- Contratos entre modulos: [docs/MODULE_INTEGRATION_CONTRACTS.md](docs/MODULE_INTEGRATION_CONTRACTS.md)
 
 ## Stack tecnologico
 - Frontend: React + Vite
@@ -29,4 +30,9 @@ Plataforma para alquiler de terrenos (agricultura, ganaderia y otros usos produc
 - Login opcional para ver; obligatorio para acciones de negocio.
 
 ## Estado actual
-Solo documentacion inicial. Aun no hay implementacion de frontend/backend.
+- `apps/landing`: implementado (issue #1) con E2E y CI.
+- `apps/app-web`: implementado MVP inicial (issue #2) en modo mock:
+	catalogo, filtros, solicitud de alquiler y aprobacion/rechazo.
+- `apps/backend-api`: pendiente de implementacion, con contrato definido.
+- `apps/admin-dashboard`: pendiente de implementacion.
+- `packages/shared`: pendiente de implementacion de tipos/contratos compartidos.

--- a/apps/admin-dashboard/README.md
+++ b/apps/admin-dashboard/README.md
@@ -7,3 +7,17 @@ Responsabilidades iniciales:
 - Gestion de usuarios
 - Revision de reportes
 - Auditoria basica
+
+## Estado actual
+- Modulo en fase de planificacion.
+- Sin implementacion de UI ni conexion a backend aun.
+
+## Dependencias esperadas
+- Consumira `backend-api` para moderacion, trazabilidad y gestion de usuarios.
+- Reutilizara contratos y estados definidos en:
+	`docs/MODULE_INTEGRATION_CONTRACTS.md`
+
+## Reutilizacion recomendada
+- Mantener los mismos estados de solicitud (`draft`, `pending_owner`, `approved`,
+	`rejected`, `cancelled`) para vistas admin.
+- Reusar DTOs cuando se publiquen en `packages/shared`.

--- a/apps/app-web/.env.example
+++ b/apps/app-web/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000

--- a/apps/app-web/README.md
+++ b/apps/app-web/README.md
@@ -2,9 +2,69 @@
 
 Aplicacion principal para propietarios y arrendatarios.
 
-Responsabilidades iniciales:
-- Registro/login
-- Catalogo de terrenos (mapa + listado)
-- Solicitudes de alquiler
-- Chat interno y contacto externo
-- Flujo de pagos
+## Estado actual (issue #2)
+- Catalogo funcional con filtros por tipo, ubicacion, precio y fecha.
+- Flujo completo de solicitud de alquiler (arrendatario).
+- Bandeja de propietario con acciones de aprobar/rechazar.
+- Seguimiento de estado de solicitudes por arrendatario.
+- Implementacion en modo mock para avanzar frontend sin bloquear backend.
+
+## Alcance incluido
+- Registro e inicio de sesion mockeado.
+- Vista publica del catalogo (sin login).
+- Login obligatorio para reservar y ver solicitudes propias.
+- Reglas de negocio de aprobacion/rechazo con validacion de solapamiento.
+- Mapa pospuesto para siguiente issue.
+
+## Rutas actuales
+- `/` catalogo de terrenos.
+- `/lands/:landId` detalle de terreno.
+- `/login` inicio de sesion.
+- `/register` registro de cuenta (tenant).
+- `/reserve/:landId` crear solicitud de alquiler.
+- `/my-requests` seguimiento de solicitudes de arrendatario.
+- `/owner/requests` bandeja de propietario para aprobar/rechazar.
+
+## Cuentas semilla (modo mock)
+- Arrendatario: `tenant@terrashare.test` / `123456`
+- Propietario: `owner@terrashare.test` / `123456`
+
+## Variables de entorno
+Copiar `.env.example` a `.env`.
+
+```bash
+VITE_API_BASE_URL=http://localhost:3000
+```
+
+Nota:
+- En esta fase el frontend usa `src/services/mockApi.js`.
+- `VITE_API_BASE_URL` queda preparado para migracion a API real.
+
+## Comandos
+Desde esta carpeta:
+
+```bash
+bun install
+bun run dev
+bun run build
+bun run preview
+bun run test:e2e
+bun run test:e2e:ui
+```
+
+Antes del primer E2E local:
+
+```bash
+bunx playwright install chromium
+```
+
+## Testing y CI
+- E2E smoke: `tests/e2e/appweb.smoke.spec.js`
+- Config Playwright: `playwright.config.js`
+- Workflow CI: `.github/workflows/app-web-e2e.yml`
+
+## Integracion con otros modulos
+- Landing redirige a esta app por `VITE_APP_WEB_URL`.
+- Contrato de integracion y DTOs esperados:
+	`docs/MODULE_INTEGRATION_CONTRACTS.md`
+

--- a/apps/app-web/bun.lock
+++ b/apps/app-web/bun.lock
@@ -1,0 +1,252 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@terrashare/app-web",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1",
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "@vitejs/plugin-react": "^4.3.4",
+        "vite": "^5.4.10",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
+    "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.342", "", {}, "sha512-GTuy59SdGxYgz+HN8KwOjFAVF2gfoKEmv0PFholcvVtbI9GPDND0m6ynGX3gAKOavcHRLrcfNy0QMbHbAemYdw=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-router": ["react-router@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="],
+
+    "react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+  }
+}

--- a/apps/app-web/index.html
+++ b/apps/app-web/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="TerraShare app-web para descubrir terrenos, reservar y gestionar solicitudes de alquiler."
+    />
+    <title>TerraShare App | Catalogo y Reservas</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;700;800&family=Space+Grotesk:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/apps/app-web/package.json
+++ b/apps/app-web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@terrashare/app-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^5.4.10"
+  }
+}

--- a/apps/app-web/playwright.config.js
+++ b/apps/app-web/playwright.config.js
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:4174",
+    trace: "on-first-retry"
+  },
+  webServer: {
+    command: "bun run dev -- --host 127.0.0.1 --port 4174",
+    url: "http://127.0.0.1:4174",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/apps/app-web/src/App.jsx
+++ b/apps/app-web/src/App.jsx
@@ -1,0 +1,960 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Link,
+  NavLink,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams
+} from "react-router-dom";
+import { api, RENTAL_REQUEST_STATUS } from "./services/mockApi";
+
+const statusLabels = {
+  [RENTAL_REQUEST_STATUS.draft]: "Borrador",
+  [RENTAL_REQUEST_STATUS.pendingOwner]: "Pendiente del propietario",
+  [RENTAL_REQUEST_STATUS.approved]: "Aprobada",
+  [RENTAL_REQUEST_STATUS.rejected]: "Rechazada",
+  [RENTAL_REQUEST_STATUS.cancelled]: "Cancelada"
+};
+
+const formatDate = (value) =>
+  new Date(`${value}T00:00:00`).toLocaleDateString("es-PA", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric"
+  });
+
+const formatDateTime = (value) =>
+  new Date(value).toLocaleString("es-PA", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+
+const buildLoginRedirect = (targetPath) =>
+  `/login?next=${encodeURIComponent(targetPath)}`;
+
+function ProtectedRoute({ user, children }) {
+  const location = useLocation();
+
+  if (!user) {
+    const next = `${location.pathname}${location.search}`;
+    return <Navigate to={buildLoginRedirect(next)} replace />;
+  }
+
+  return children;
+}
+
+function OwnerRoute({ user, children }) {
+  if (!user) {
+    return <Navigate to={buildLoginRedirect("/owner/requests")} replace />;
+  }
+
+  if (user.role !== "owner") {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+}
+
+function StatusPill({ status }) {
+  return <span className={`status-pill status-${status}`}>{statusLabels[status] || status}</span>;
+}
+
+function Toast({ toast, onClose }) {
+  if (!toast) {
+    return null;
+  }
+
+  return (
+    <aside className={`toast toast-${toast.type}`} role="status" aria-live="polite">
+      <div>
+        <strong>{toast.type === "error" ? "Error" : "Listo"}</strong>
+        <p>{toast.message}</p>
+      </div>
+      <button type="button" className="text-button" onClick={onClose}>
+        Cerrar
+      </button>
+    </aside>
+  );
+}
+
+function CatalogPage({ user }) {
+  const [filters, setFilters] = useState({
+    type: "all",
+    location: "",
+    maxPrice: "",
+    availableOn: ""
+  });
+  const [lands, setLands] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await api.listLands(filters);
+        if (active) {
+          setLands(data);
+        }
+      } catch (loadError) {
+        if (active) {
+          setError(loadError.message);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      active = false;
+    };
+  }, [filters]);
+
+  return (
+    <section className="panel reveal">
+      <header className="section-header">
+        <p className="kicker">Experiencia principal</p>
+        <h1>Catalogo de terrenos</h1>
+        <p>
+          Descubre oportunidades por tipo, precio y disponibilidad. La vista de mapa
+          se planifica para siguientes issues; por ahora el enfoque es listado y
+          reserva completa.
+        </p>
+      </header>
+
+      <div className="filters-grid">
+        <label>
+          Tipo de terreno
+          <select
+            value={filters.type}
+            onChange={(event) => setFilters((prev) => ({ ...prev, type: event.target.value }))}
+          >
+            <option value="all">Todos</option>
+            <option value="Agricultura">Agricultura</option>
+            <option value="Ganaderia">Ganaderia</option>
+            <option value="Mixto">Mixto</option>
+          </select>
+        </label>
+
+        <label>
+          Ubicacion
+          <input
+            type="text"
+            placeholder="Ejemplo: Chiriqui"
+            value={filters.location}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, location: event.target.value }))
+            }
+          />
+        </label>
+
+        <label>
+          Precio maximo (USD)
+          <input
+            type="number"
+            min="1"
+            placeholder="Ejemplo: 500"
+            value={filters.maxPrice}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, maxPrice: event.target.value }))
+            }
+          />
+        </label>
+
+        <label>
+          Disponible en fecha
+          <input
+            type="date"
+            value={filters.availableOn}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, availableOn: event.target.value }))
+            }
+          />
+        </label>
+      </div>
+
+      {loading ? <p className="muted">Cargando terrenos...</p> : null}
+      {error ? <p className="error-text">{error}</p> : null}
+
+      {!loading && !error && lands.length === 0 ? (
+        <p className="muted">No hay resultados con esos filtros.</p>
+      ) : null}
+
+      <div className="cards-grid">
+        {lands.map((land) => {
+          const reserveTarget = `/reserve/${land.id}`;
+          const reserveHref = user ? reserveTarget : buildLoginRedirect(reserveTarget);
+
+          return (
+            <article className="land-card" key={land.id}>
+              <p className="card-badge">{land.type}</p>
+              <h2>{land.name}</h2>
+              <p>
+                {land.province} · {land.district}
+              </p>
+              <p>{land.summary}</p>
+              <dl>
+                <div>
+                  <dt>Precio</dt>
+                  <dd>${land.monthlyPrice}/mes</dd>
+                </div>
+                <div>
+                  <dt>Area</dt>
+                  <dd>{land.areaHectares} ha</dd>
+                </div>
+                <div>
+                  <dt>Disponibilidad</dt>
+                  <dd>
+                    {formatDate(land.availableFrom)} - {formatDate(land.availableTo)}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="card-actions">
+                <Link to={`/lands/${land.id}`} className="button ghost-button">
+                  Ver detalle
+                </Link>
+                <Link to={reserveHref} className="button primary-button">
+                  {user ? "Reservar ahora" : "Inicia sesion para reservar"}
+                </Link>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function LandDetailPage({ user }) {
+  const { landId } = useParams();
+  const [land, setLand] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const payload = await api.getLandById(landId);
+        if (active) {
+          setLand(payload);
+        }
+      } catch (loadError) {
+        if (active) {
+          setError(loadError.message);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      active = false;
+    };
+  }, [landId]);
+
+  if (loading) {
+    return (
+      <section className="panel reveal">
+        <p className="muted">Cargando detalle...</p>
+      </section>
+    );
+  }
+
+  if (error || !land) {
+    return (
+      <section className="panel reveal">
+        <p className="error-text">{error || "Terreno no disponible."}</p>
+        <Link to="/" className="button ghost-button inline-button">
+          Volver al catalogo
+        </Link>
+      </section>
+    );
+  }
+
+  const reserveTarget = `/reserve/${land.id}`;
+
+  return (
+    <section className="panel reveal">
+      <header className="section-header compact">
+        <p className="kicker">Detalle del terreno</p>
+        <h1>{land.name}</h1>
+        <p>
+          {land.province} · {land.district}
+        </p>
+      </header>
+
+      <div className="detail-grid">
+        <article className="detail-card">
+          <h2>Condiciones principales</h2>
+          <ul>
+            <li>Precio base: ${land.monthlyPrice}/mes</li>
+            <li>Area: {land.areaHectares} hectareas</li>
+            <li>Fuente de agua: {land.waterSource}</li>
+            <li>
+              Disponibilidad: {formatDate(land.availableFrom)} - {formatDate(land.availableTo)}
+            </li>
+            <li>Usos permitidos: {land.allowedUses.join(", ")}</li>
+          </ul>
+          <p>{land.summary}</p>
+        </article>
+
+        <aside className="detail-card accent-card">
+          <h2>Siguiente paso</h2>
+          <p>
+            Para reservar debes indicar periodo y uso propuesto. El propietario puede
+            aprobar o rechazar directamente en su bandeja de solicitudes.
+          </p>
+          <Link
+            to={user ? reserveTarget : buildLoginRedirect(reserveTarget)}
+            className="button primary-button"
+          >
+            {user ? "Ir a reserva" : "Inicia sesion para reservar"}
+          </Link>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function LoginPage({ user, onLogin, setToast }) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [submitting, setSubmitting] = useState(false);
+
+  const nextPath = useMemo(() => searchParams.get("next") || "/", [searchParams]);
+
+  if (user) {
+    return <Navigate to={nextPath} replace />;
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setSubmitting(true);
+
+    try {
+      await onLogin(form);
+      setToast({ type: "success", message: "Sesion iniciada correctamente." });
+      navigate(nextPath, { replace: true });
+    } catch (error) {
+      setToast({ type: "error", message: error.message });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="panel slim-panel reveal">
+      <header className="section-header compact">
+        <p className="kicker">Acceso</p>
+        <h1>Iniciar sesion</h1>
+        <p>Usa una cuenta semilla o crea una cuenta nueva desde registro.</p>
+      </header>
+
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Correo
+          <input
+            type="email"
+            value={form.email}
+            onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+            required
+          />
+        </label>
+
+        <label>
+          Contrasena
+          <input
+            type="password"
+            value={form.password}
+            onChange={(event) =>
+              setForm((prev) => ({ ...prev, password: event.target.value }))
+            }
+            required
+          />
+        </label>
+
+        <button type="submit" className="button primary-button" disabled={submitting}>
+          {submitting ? "Entrando..." : "Entrar"}
+        </button>
+      </form>
+
+      <p className="muted top-gap">
+        Cuenta arrendatario: tenant@terrashare.test / 123456
+        <br />
+        Cuenta propietario: owner@terrashare.test / 123456
+      </p>
+    </section>
+  );
+}
+
+function RegisterPage({ user, onRegister, setToast }) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    password: ""
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const nextPath = useMemo(() => searchParams.get("next") || "/", [searchParams]);
+
+  if (user) {
+    return <Navigate to={nextPath} replace />;
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setSubmitting(true);
+
+    try {
+      await onRegister(form);
+      setToast({
+        type: "success",
+        message: "Cuenta creada. Ya puedes enviar solicitudes de alquiler."
+      });
+      navigate(nextPath, { replace: true });
+    } catch (error) {
+      setToast({ type: "error", message: error.message });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="panel slim-panel reveal">
+      <header className="section-header compact">
+        <p className="kicker">Registro</p>
+        <h1>Crear cuenta de arrendatario</h1>
+        <p>El registro en este MVP mockeado crea usuarios de rol tenant.</p>
+      </header>
+
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Nombre completo
+          <input
+            type="text"
+            value={form.name}
+            onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+            required
+          />
+        </label>
+
+        <label>
+          Correo
+          <input
+            type="email"
+            value={form.email}
+            onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+            required
+          />
+        </label>
+
+        <label>
+          Contrasena
+          <input
+            type="password"
+            value={form.password}
+            onChange={(event) =>
+              setForm((prev) => ({ ...prev, password: event.target.value }))
+            }
+            required
+            minLength={6}
+          />
+        </label>
+
+        <button type="submit" className="button primary-button" disabled={submitting}>
+          {submitting ? "Creando cuenta..." : "Crear cuenta"}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function ReservePage({ user, setToast }) {
+  const navigate = useNavigate();
+  const { landId } = useParams();
+  const [land, setLand] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState({
+    startDate: "",
+    endDate: "",
+    intendedUse: "",
+    message: ""
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const payload = await api.getLandById(landId);
+        if (active) {
+          setLand(payload);
+        }
+      } catch (error) {
+        if (active) {
+          setToast({ type: "error", message: error.message });
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      active = false;
+    };
+  }, [landId, setToast]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setSubmitting(true);
+
+    try {
+      const request = await api.createRentalRequest({
+        tenantId: user.id,
+        landId,
+        ...form
+      });
+
+      setToast({
+        type: "success",
+        message: `Solicitud enviada (${request.id}). Espera la decision del propietario.`
+      });
+      navigate(`/my-requests?created=${request.id}`, { replace: true });
+    } catch (error) {
+      setToast({ type: "error", message: error.message });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="panel reveal">
+        <p className="muted">Preparando formulario de reserva...</p>
+      </section>
+    );
+  }
+
+  if (!land) {
+    return (
+      <section className="panel reveal">
+        <p className="error-text">No se encontro el terreno para reservar.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel reveal">
+      <header className="section-header compact">
+        <p className="kicker">Reserva</p>
+        <h1>Solicitar alquiler</h1>
+        <p>
+          {land.name} · {land.province}
+        </p>
+      </header>
+
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <div className="split-grid">
+          <label>
+            Fecha de inicio
+            <input
+              type="date"
+              value={form.startDate}
+              onChange={(event) =>
+                setForm((prev) => ({ ...prev, startDate: event.target.value }))
+              }
+              required
+            />
+          </label>
+
+          <label>
+            Fecha de fin
+            <input
+              type="date"
+              value={form.endDate}
+              onChange={(event) => setForm((prev) => ({ ...prev, endDate: event.target.value }))}
+              required
+            />
+          </label>
+        </div>
+
+        <label>
+          Uso propuesto
+          <input
+            type="text"
+            value={form.intendedUse}
+            onChange={(event) =>
+              setForm((prev) => ({ ...prev, intendedUse: event.target.value }))
+            }
+            placeholder="Ejemplo: cultivo de cacao"
+            required
+          />
+        </label>
+
+        <label>
+          Mensaje para el propietario
+          <textarea
+            value={form.message}
+            onChange={(event) => setForm((prev) => ({ ...prev, message: event.target.value }))}
+            placeholder="Cuenta detalles operativos o tiempos de inicio"
+            rows={4}
+          />
+        </label>
+
+        <button type="submit" className="button primary-button" disabled={submitting}>
+          {submitting ? "Enviando..." : "Enviar solicitud"}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function MyRequestsPage({ user }) {
+  const [searchParams] = useSearchParams();
+  const createdId = searchParams.get("created");
+  const [loading, setLoading] = useState(true);
+  const [requests, setRequests] = useState([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError("");
+
+      try {
+        const payload = await api.listTenantRequests(user.id);
+        if (active) {
+          setRequests(payload);
+        }
+      } catch (loadError) {
+        if (active) {
+          setError(loadError.message);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      active = false;
+    };
+  }, [user.id]);
+
+  return (
+    <section className="panel reveal">
+      <header className="section-header compact">
+        <p className="kicker">Seguimiento</p>
+        <h1>Mis solicitudes</h1>
+        <p>Revisa estados y fechas de tus solicitudes enviadas.</p>
+      </header>
+
+      {loading ? <p className="muted">Cargando solicitudes...</p> : null}
+      {error ? <p className="error-text">{error}</p> : null}
+
+      {!loading && !error && requests.length === 0 ? (
+        <p className="muted">Aun no has enviado solicitudes de alquiler.</p>
+      ) : null}
+
+      <div className="request-list">
+        {requests.map((item) => (
+          <article
+            className={`request-item ${createdId === item.id ? "request-highlight" : ""}`}
+            key={item.id}
+          >
+            <div className="request-top">
+              <h2>{item.landName}</h2>
+              <StatusPill status={item.status} />
+            </div>
+            <p className="muted">ID: {item.id}</p>
+            <p>
+              Periodo: {formatDate(item.startDate)} - {formatDate(item.endDate)}
+            </p>
+            <p>Uso: {item.intendedUse}</p>
+            <p>Actualizado: {formatDateTime(item.updatedAt)}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function OwnerRequestsPage({ user, setToast }) {
+  const [loading, setLoading] = useState(true);
+  const [requests, setRequests] = useState([]);
+  const [error, setError] = useState("");
+  const [busyRequestId, setBusyRequestId] = useState("");
+
+  const loadData = async () => {
+    setLoading(true);
+    setError("");
+
+    try {
+      const payload = await api.listOwnerRequests(user.id);
+      setRequests(payload);
+    } catch (loadError) {
+      setError(loadError.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, [user.id]);
+
+  const handleDecision = async (requestId, status) => {
+    setBusyRequestId(requestId);
+
+    try {
+      const updated = await api.updateRentalRequestStatus({
+        ownerId: user.id,
+        requestId,
+        status
+      });
+
+      setRequests((prev) =>
+        prev.map((item) => (item.id === updated.id ? updated : item))
+      );
+      setToast({
+        type: "success",
+        message: `Solicitud ${updated.id} actualizada a ${statusLabels[updated.status]}.`
+      });
+    } catch (updateError) {
+      setToast({ type: "error", message: updateError.message });
+    } finally {
+      setBusyRequestId("");
+    }
+  };
+
+  return (
+    <section className="panel reveal">
+      <header className="section-header compact">
+        <p className="kicker">Gestion propietario</p>
+        <h1>Bandeja de solicitudes</h1>
+        <p>
+          Desde aqui puedes aprobar o rechazar solicitudes pendientes de tus
+          terrenos.
+        </p>
+      </header>
+
+      {loading ? <p className="muted">Cargando bandeja...</p> : null}
+      {error ? <p className="error-text">{error}</p> : null}
+
+      {!loading && !error && requests.length === 0 ? (
+        <p className="muted">No tienes solicitudes asociadas por ahora.</p>
+      ) : null}
+
+      <div className="request-list">
+        {requests.map((item) => {
+          const isPending = item.status === RENTAL_REQUEST_STATUS.pendingOwner;
+          const isBusy = busyRequestId === item.id;
+
+          return (
+            <article className="request-item" key={item.id}>
+              <div className="request-top">
+                <h2>{item.landName}</h2>
+                <StatusPill status={item.status} />
+              </div>
+              <p className="muted">Solicitud: {item.id}</p>
+              <p>
+                Arrendatario: {item.tenantName} ({item.tenantEmail})
+              </p>
+              <p>
+                Periodo: {formatDate(item.startDate)} - {formatDate(item.endDate)}
+              </p>
+              <p>Uso propuesto: {item.intendedUse}</p>
+              <p>Actualizado: {formatDateTime(item.updatedAt)}</p>
+
+              {isPending ? (
+                <div className="inline-actions">
+                  <button
+                    type="button"
+                    className="button success-button"
+                    disabled={isBusy}
+                    onClick={() =>
+                      handleDecision(item.id, RENTAL_REQUEST_STATUS.approved)
+                    }
+                  >
+                    Aprobar
+                  </button>
+                  <button
+                    type="button"
+                    className="button danger-button"
+                    disabled={isBusy}
+                    onClick={() =>
+                      handleDecision(item.id, RENTAL_REQUEST_STATUS.rejected)
+                    }
+                  >
+                    Rechazar
+                  </button>
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function App() {
+  const [user, setUser] = useState(() => api.getSessionUser());
+  const [toast, setToast] = useState(null);
+
+  const handleLogin = async ({ email, password }) => {
+    const sessionUser = await api.login({ email, password });
+    setUser(sessionUser);
+    return sessionUser;
+  };
+
+  const handleRegister = async ({ name, email, password }) => {
+    const sessionUser = await api.register({ name, email, password });
+    setUser(sessionUser);
+    return sessionUser;
+  };
+
+  const handleLogout = () => {
+    api.logout();
+    setUser(null);
+    setToast({ type: "success", message: "Sesion cerrada." });
+  };
+
+  return (
+    <div className="page-shell">
+      <div className="ambient ambient-left" aria-hidden="true" />
+      <div className="ambient ambient-right" aria-hidden="true" />
+
+      <header className="top-nav">
+        <Link to="/" className="brand">
+          TerraShare App
+        </Link>
+
+        <nav className="menu" aria-label="Navegacion principal">
+          <NavLink to="/" end>
+            Catalogo
+          </NavLink>
+          {user ? <NavLink to="/my-requests">Mis solicitudes</NavLink> : null}
+          {user?.role === "owner" ? (
+            <NavLink to="/owner/requests">Gestion propietario</NavLink>
+          ) : null}
+        </nav>
+
+        <div className="auth-actions">
+          {user ? (
+            <>
+              <p className="session-chip">
+                {user.name} · {user.role}
+              </p>
+              <button type="button" className="button ghost-button" onClick={handleLogout}>
+                Cerrar sesion
+              </button>
+            </>
+          ) : (
+            <>
+              <Link className="button ghost-button" to="/login">
+                Iniciar sesion
+              </Link>
+              <Link className="button primary-button" to="/register">
+                Crear cuenta
+              </Link>
+            </>
+          )}
+        </div>
+      </header>
+
+      <Toast toast={toast} onClose={() => setToast(null)} />
+
+      <main>
+        <Routes>
+          <Route path="/" element={<CatalogPage user={user} />} />
+          <Route path="/lands/:landId" element={<LandDetailPage user={user} />} />
+          <Route
+            path="/login"
+            element={
+              <LoginPage
+                user={user}
+                onLogin={handleLogin}
+                setToast={setToast}
+              />
+            }
+          />
+          <Route
+            path="/register"
+            element={
+              <RegisterPage
+                user={user}
+                onRegister={handleRegister}
+                setToast={setToast}
+              />
+            }
+          />
+          <Route
+            path="/reserve/:landId"
+            element={
+              <ProtectedRoute user={user}>
+                <ReservePage user={user} setToast={setToast} />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/my-requests"
+            element={
+              <ProtectedRoute user={user}>
+                <MyRequestsPage user={user} />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/owner/requests"
+            element={
+              <OwnerRoute user={user}>
+                <OwnerRequestsPage user={user} setToast={setToast} />
+              </OwnerRoute>
+            }
+          />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/apps/app-web/src/main.jsx
+++ b/apps/app-web/src/main.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/apps/app-web/src/services/mockApi.js
+++ b/apps/app-web/src/services/mockApi.js
@@ -1,0 +1,507 @@
+const USERS_STORAGE_KEY = "terrashare.appweb.users";
+const REQUESTS_STORAGE_KEY = "terrashare.appweb.requests";
+const SESSION_STORAGE_KEY = "terrashare.appweb.session";
+const NETWORK_DELAY_MS = 180;
+
+const seedUsers = [
+  {
+    id: "usr-owner-1",
+    name: "Olga Propietaria",
+    email: "owner@terrashare.test",
+    password: "123456",
+    role: "owner"
+  },
+  {
+    id: "usr-tenant-1",
+    name: "Rafael Arrendatario",
+    email: "tenant@terrashare.test",
+    password: "123456",
+    role: "tenant"
+  },
+  {
+    id: "usr-tenant-2",
+    name: "Marta Productora",
+    email: "marta@terrashare.test",
+    password: "123456",
+    role: "tenant"
+  }
+];
+
+const seedLands = [
+  {
+    id: "land-1",
+    ownerId: "usr-owner-1",
+    name: "Finca El Tamarindo",
+    province: "Los Santos",
+    district: "Las Tablas",
+    type: "Agricultura",
+    monthlyPrice: 420,
+    areaHectares: 5,
+    availableFrom: "2026-05-01",
+    availableTo: "2026-12-31",
+    allowedUses: ["agricultura"],
+    waterSource: "Pozo y rio cercano",
+    summary:
+      "Terreno plano con acceso vehicular y punto de carga cercano para produccion continua."
+  },
+  {
+    id: "land-2",
+    ownerId: "usr-owner-1",
+    name: "Lote Vista Caisan",
+    province: "Chiriqui",
+    district: "Renacimiento",
+    type: "Ganaderia",
+    monthlyPrice: 560,
+    areaHectares: 9,
+    availableFrom: "2026-06-01",
+    availableTo: "2027-02-15",
+    allowedUses: ["ganaderia", "mixto"],
+    waterSource: "Toma de quebrada",
+    summary:
+      "Lote con pasto natural, cerramiento parcial y espacio para manejo de animales."
+  },
+  {
+    id: "land-3",
+    ownerId: "usr-owner-1",
+    name: "Parcela Rio Indio",
+    province: "Cocle",
+    district: "Penonome",
+    type: "Mixto",
+    monthlyPrice: 390,
+    areaHectares: 4,
+    availableFrom: "2026-04-25",
+    availableTo: "2026-10-30",
+    allowedUses: ["agricultura", "ganaderia", "mixto"],
+    waterSource: "Sistema de riego",
+    summary:
+      "Parcela flexible para proyectos de ciclo corto con infraestructura de riego."
+  },
+  {
+    id: "land-4",
+    ownerId: "usr-owner-1",
+    name: "Finca Alto Verde",
+    province: "Veraguas",
+    district: "Santiago",
+    type: "Agricultura",
+    monthlyPrice: 610,
+    areaHectares: 11,
+    availableFrom: "2026-07-01",
+    availableTo: "2027-06-30",
+    allowedUses: ["agricultura"],
+    waterSource: "Canal secundario",
+    summary:
+      "Espacio amplio para cultivo extensivo con acceso logistica de carga pesada."
+  }
+];
+
+const seedRequests = [
+  {
+    id: "req-100",
+    landId: "land-2",
+    tenantId: "usr-tenant-1",
+    startDate: "2026-08-01",
+    endDate: "2026-09-30",
+    intendedUse: "engorde de ganado en rotacion",
+    message: "Tengo equipo y personal para iniciar en dos semanas.",
+    status: "pending_owner",
+    createdAt: "2026-04-21T10:00:00.000Z",
+    updatedAt: "2026-04-21T10:00:00.000Z"
+  },
+  {
+    id: "req-101",
+    landId: "land-1",
+    tenantId: "usr-tenant-2",
+    startDate: "2026-05-05",
+    endDate: "2026-06-05",
+    intendedUse: "siembra de maiz",
+    message: "Busco contrato corto para ciclo de prueba.",
+    status: "approved",
+    createdAt: "2026-04-20T18:35:00.000Z",
+    updatedAt: "2026-04-20T20:00:00.000Z"
+  }
+];
+
+export const RENTAL_REQUEST_STATUS = {
+  draft: "draft",
+  pendingOwner: "pending_owner",
+  approved: "approved",
+  rejected: "rejected",
+  cancelled: "cancelled"
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const delay = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+const normalizeEmail = (email) => email.trim().toLowerCase();
+
+const sanitizeUser = (user) => {
+  if (!user) {
+    return null;
+  }
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role
+  };
+};
+
+const safeReadList = (storageKey) => {
+  const raw = localStorage.getItem(storageKey);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const getAllUsers = () => {
+  const customUsers = safeReadList(USERS_STORAGE_KEY);
+  return [...seedUsers, ...customUsers];
+};
+
+const getRequests = () => {
+  const raw = localStorage.getItem(REQUESTS_STORAGE_KEY);
+  if (!raw) {
+    localStorage.setItem(REQUESTS_STORAGE_KEY, JSON.stringify(seedRequests));
+    return clone(seedRequests);
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // If storage is corrupted, recover with seed data.
+  }
+
+  localStorage.setItem(REQUESTS_STORAGE_KEY, JSON.stringify(seedRequests));
+  return clone(seedRequests);
+};
+
+const saveRequests = (requests) => {
+  localStorage.setItem(REQUESTS_STORAGE_KEY, JSON.stringify(requests));
+};
+
+const isIsoDate = (value) => /^\d{4}-\d{2}-\d{2}$/.test(value);
+
+const isDateInRange = (date, start, end) => date >= start && date <= end;
+
+const hasOverlap = (firstStart, firstEnd, secondStart, secondEnd) =>
+  firstStart <= secondEnd && secondStart <= firstEnd;
+
+const enrichRequest = (request) => {
+  const land = seedLands.find((item) => item.id === request.landId);
+  const tenant = getAllUsers().find((user) => user.id === request.tenantId);
+
+  return {
+    ...request,
+    landName: land?.name || "Terreno no encontrado",
+    ownerId: land?.ownerId || null,
+    tenantName: tenant?.name || "Arrendatario no encontrado",
+    tenantEmail: tenant?.email || "",
+    monthlyPrice: land?.monthlyPrice || 0,
+    landType: land?.type || ""
+  };
+};
+
+const withResponse = async (payload) => {
+  await delay(NETWORK_DELAY_MS);
+  return clone(payload);
+};
+
+const withError = async (message) => {
+  await delay(NETWORK_DELAY_MS);
+  throw new Error(message);
+};
+
+const ensureSession = () => {
+  const userId = localStorage.getItem(SESSION_STORAGE_KEY);
+  if (!userId) {
+    return null;
+  }
+
+  const user = getAllUsers().find((item) => item.id === userId);
+  if (!user) {
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+    return null;
+  }
+
+  return sanitizeUser(user);
+};
+
+const listLands = async (filters = {}) => {
+  const {
+    type = "all",
+    location = "",
+    maxPrice = "",
+    availableOn = ""
+  } = filters;
+
+  const normalizedLocation = location.trim().toLowerCase();
+  const maxPriceValue = maxPrice === "" ? null : Number(maxPrice);
+
+  const rows = seedLands
+    .filter((land) => {
+      if (type !== "all" && land.type !== type) {
+        return false;
+      }
+
+      if (normalizedLocation) {
+        const locationValue = `${land.province} ${land.district} ${land.name}`.toLowerCase();
+        if (!locationValue.includes(normalizedLocation)) {
+          return false;
+        }
+      }
+
+      if (maxPriceValue !== null && !Number.isNaN(maxPriceValue)) {
+        if (land.monthlyPrice > maxPriceValue) {
+          return false;
+        }
+      }
+
+      if (availableOn) {
+        if (!isDateInRange(availableOn, land.availableFrom, land.availableTo)) {
+          return false;
+        }
+      }
+
+      return true;
+    })
+    .sort((first, second) => first.monthlyPrice - second.monthlyPrice);
+
+  return withResponse(rows);
+};
+
+const getLandById = async (landId) => {
+  const land = seedLands.find((item) => item.id === landId);
+  if (!land) {
+    return withError("No encontramos ese terreno.");
+  }
+
+  return withResponse(land);
+};
+
+const login = async ({ email, password }) => {
+  const candidate = getAllUsers().find(
+    (user) => normalizeEmail(user.email) === normalizeEmail(email)
+  );
+
+  if (!candidate || candidate.password !== password) {
+    return withError("Credenciales invalidas.");
+  }
+
+  localStorage.setItem(SESSION_STORAGE_KEY, candidate.id);
+  return withResponse(sanitizeUser(candidate));
+};
+
+const register = async ({ name, email, password }) => {
+  const cleanName = name.trim();
+  const cleanEmail = normalizeEmail(email);
+
+  if (cleanName.length < 3) {
+    return withError("El nombre debe tener al menos 3 caracteres.");
+  }
+
+  if (!cleanEmail.includes("@") || !cleanEmail.includes(".")) {
+    return withError("Ingresa un correo valido.");
+  }
+
+  if (password.length < 6) {
+    return withError("La contrasena debe tener al menos 6 caracteres.");
+  }
+
+  const exists = getAllUsers().some((user) => normalizeEmail(user.email) === cleanEmail);
+  if (exists) {
+    return withError("Ese correo ya esta registrado.");
+  }
+
+  const customUsers = safeReadList(USERS_STORAGE_KEY);
+  const newUser = {
+    id: `usr-custom-${Date.now()}`,
+    name: cleanName,
+    email: cleanEmail,
+    password,
+    role: "tenant"
+  };
+
+  customUsers.push(newUser);
+  localStorage.setItem(USERS_STORAGE_KEY, JSON.stringify(customUsers));
+  localStorage.setItem(SESSION_STORAGE_KEY, newUser.id);
+
+  return withResponse(sanitizeUser(newUser));
+};
+
+const logout = () => {
+  localStorage.removeItem(SESSION_STORAGE_KEY);
+};
+
+const getSessionUser = () => ensureSession();
+
+const createRentalRequest = async ({
+  tenantId,
+  landId,
+  startDate,
+  endDate,
+  intendedUse,
+  message
+}) => {
+  const tenant = getAllUsers().find((user) => user.id === tenantId);
+  if (!tenant) {
+    return withError("Sesion invalida. Inicia sesion nuevamente.");
+  }
+
+  if (tenant.role !== "tenant") {
+    return withError("Solo el arrendatario puede crear solicitudes.");
+  }
+
+  if (!isIsoDate(startDate) || !isIsoDate(endDate)) {
+    return withError("Debes indicar fechas validas para la solicitud.");
+  }
+
+  if (startDate > endDate) {
+    return withError("La fecha de inicio no puede ser mayor a la fecha final.");
+  }
+
+  const land = seedLands.find((item) => item.id === landId);
+  if (!land) {
+    return withError("El terreno seleccionado no existe.");
+  }
+
+  if (!isDateInRange(startDate, land.availableFrom, land.availableTo)) {
+    return withError("La fecha de inicio esta fuera del rango disponible del terreno.");
+  }
+
+  if (!isDateInRange(endDate, land.availableFrom, land.availableTo)) {
+    return withError("La fecha de fin esta fuera del rango disponible del terreno.");
+  }
+
+  if (intendedUse.trim().length < 5) {
+    return withError("Describe mejor el uso propuesto (minimo 5 caracteres).");
+  }
+
+  const now = new Date().toISOString();
+  const request = {
+    id: `req-${Date.now()}`,
+    landId,
+    tenantId,
+    startDate,
+    endDate,
+    intendedUse: intendedUse.trim(),
+    message: message.trim(),
+    status: RENTAL_REQUEST_STATUS.pendingOwner,
+    createdAt: now,
+    updatedAt: now
+  };
+
+  const requests = getRequests();
+  requests.push(request);
+  saveRequests(requests);
+
+  return withResponse(enrichRequest(request));
+};
+
+const listTenantRequests = async (tenantId) => {
+  const requests = getRequests()
+    .filter((request) => request.tenantId === tenantId)
+    .sort((first, second) => new Date(second.createdAt) - new Date(first.createdAt))
+    .map((request) => enrichRequest(request));
+
+  return withResponse(requests);
+};
+
+const listOwnerRequests = async (ownerId) => {
+  const ownedLandIds = seedLands
+    .filter((land) => land.ownerId === ownerId)
+    .map((land) => land.id);
+
+  const requests = getRequests()
+    .filter((request) => ownedLandIds.includes(request.landId))
+    .sort((first, second) => new Date(second.createdAt) - new Date(first.createdAt))
+    .map((request) => enrichRequest(request));
+
+  return withResponse(requests);
+};
+
+const updateRentalRequestStatus = async ({ ownerId, requestId, status }) => {
+  const nextStatusAllowed = [
+    RENTAL_REQUEST_STATUS.approved,
+    RENTAL_REQUEST_STATUS.rejected
+  ];
+
+  if (!nextStatusAllowed.includes(status)) {
+    return withError("Estado no permitido para esta accion.");
+  }
+
+  const requests = getRequests();
+  const currentRequest = requests.find((request) => request.id === requestId);
+  if (!currentRequest) {
+    return withError("No encontramos la solicitud que quieres actualizar.");
+  }
+
+  const land = seedLands.find((item) => item.id === currentRequest.landId);
+  if (!land || land.ownerId !== ownerId) {
+    return withError("Solo el propietario del terreno puede decidir sobre esta solicitud.");
+  }
+
+  if (currentRequest.status !== RENTAL_REQUEST_STATUS.pendingOwner) {
+    return withError("Solo las solicitudes pendientes pueden cambiar de estado.");
+  }
+
+  if (status === RENTAL_REQUEST_STATUS.approved) {
+    const overlap = requests.some((request) => {
+      if (request.id === currentRequest.id) {
+        return false;
+      }
+
+      if (request.landId !== currentRequest.landId) {
+        return false;
+      }
+
+      if (request.status !== RENTAL_REQUEST_STATUS.approved) {
+        return false;
+      }
+
+      return hasOverlap(
+        request.startDate,
+        request.endDate,
+        currentRequest.startDate,
+        currentRequest.endDate
+      );
+    });
+
+    if (overlap) {
+      return withError(
+        "No se puede aprobar porque existe un alquiler aprobado que se solapa en fechas."
+      );
+    }
+  }
+
+  currentRequest.status = status;
+  currentRequest.updatedAt = new Date().toISOString();
+  saveRequests(requests);
+
+  return withResponse(enrichRequest(currentRequest));
+};
+
+export const api = {
+  getSessionUser,
+  login,
+  register,
+  logout,
+  listLands,
+  getLandById,
+  createRentalRequest,
+  listTenantRequests,
+  listOwnerRequests,
+  updateRentalRequestStatus
+};

--- a/apps/app-web/src/styles.css
+++ b/apps/app-web/src/styles.css
@@ -1,0 +1,496 @@
+:root {
+  --leaf-700: #0b5f37;
+  --leaf-900: #063922;
+  --sun-200: #f7ecce;
+  --soil-500: #9d6a3b;
+  --river-500: #0d6f93;
+  --ink-900: #132118;
+  --paper: #fcfbf7;
+  --danger: #b3342a;
+  --success: #136b47;
+  --ring: rgba(11, 95, 55, 0.24);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: "Space Grotesk", sans-serif;
+  color: var(--ink-900);
+  background:
+    radial-gradient(circle at 15% 12%, rgba(13, 111, 147, 0.18), transparent 34%),
+    radial-gradient(circle at 90% 9%, rgba(157, 106, 59, 0.2), transparent 30%),
+    linear-gradient(145deg, #fff6df 0%, #f3fbf5 52%, #ebf7fb 100%);
+}
+
+h1,
+h2,
+.brand,
+button,
+a {
+  font-family: "Archivo", sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.page-shell {
+  width: min(1150px, 92vw);
+  margin: 0 auto;
+  padding: 1.25rem 0 2.5rem;
+  position: relative;
+}
+
+.ambient {
+  position: fixed;
+  z-index: -1;
+  width: 290px;
+  height: 290px;
+  border-radius: 999px;
+  filter: blur(58px);
+  opacity: 0.55;
+}
+
+.ambient-left {
+  top: -70px;
+  left: -85px;
+  background: rgba(11, 95, 55, 0.32);
+}
+
+.ambient-right {
+  top: 22%;
+  right: -95px;
+  background: rgba(13, 111, 147, 0.3);
+}
+
+.top-nav {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  border: 1px solid rgba(19, 33, 24, 0.1);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.75);
+  backdrop-filter: blur(8px);
+  padding: 0.75rem 1rem;
+}
+
+.brand {
+  color: var(--leaf-900);
+  text-decoration: none;
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.menu {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.menu a {
+  text-decoration: none;
+  color: var(--ink-900);
+  opacity: 0.8;
+  font-weight: 700;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+}
+
+.menu a.active {
+  opacity: 1;
+  color: var(--leaf-900);
+  background: rgba(11, 95, 55, 0.12);
+}
+
+.auth-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.session-chip {
+  margin: 0;
+  padding: 0.33rem 0.65rem;
+  border-radius: 999px;
+  font-weight: 700;
+  background: rgba(13, 111, 147, 0.14);
+  color: #084c62;
+}
+
+.panel {
+  margin-top: 1rem;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(19, 33, 24, 0.1);
+  border-radius: 22px;
+  padding: clamp(1.1rem, 2.2vw, 2rem);
+}
+
+.slim-panel {
+  max-width: 640px;
+}
+
+.section-header h1 {
+  margin: 0.35rem 0;
+  font-size: clamp(1.75rem, 4.6vw, 2.9rem);
+}
+
+.section-header p {
+  margin: 0;
+  max-width: 70ch;
+  line-height: 1.6;
+}
+
+.section-header.compact h1 {
+  font-size: clamp(1.35rem, 3.5vw, 2.2rem);
+}
+
+.kicker {
+  margin: 0;
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  background: rgba(11, 95, 55, 0.12);
+  color: var(--leaf-900);
+  font-weight: 700;
+}
+
+.filters-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 700;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid rgba(19, 33, 24, 0.22);
+  border-radius: 10px;
+  padding: 0.68rem 0.72rem;
+  font: inherit;
+  color: var(--ink-900);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--leaf-700);
+  box-shadow: 0 0 0 4px var(--ring);
+}
+
+.cards-grid {
+  margin-top: 1.1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.land-card {
+  background: var(--paper);
+  border: 1px solid rgba(19, 33, 24, 0.1);
+  border-radius: 14px;
+  padding: 0.95rem;
+}
+
+.land-card h2 {
+  margin: 0.45rem 0;
+  font-size: 1.2rem;
+}
+
+.card-badge {
+  margin: 0;
+  color: var(--river-500);
+  font-weight: 800;
+}
+
+.land-card p {
+  margin: 0.3rem 0;
+  line-height: 1.5;
+}
+
+dl {
+  margin: 0.55rem 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+dd {
+  margin: 0.15rem 0 0;
+  font-weight: 700;
+}
+
+.card-actions {
+  margin-top: 0.65rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.button {
+  border: 0;
+  cursor: pointer;
+  text-decoration: none;
+  border-radius: 10px;
+  padding: 0.63rem 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.button:disabled {
+  opacity: 0.66;
+  cursor: wait;
+  transform: none;
+}
+
+.primary-button {
+  color: white;
+  background: linear-gradient(135deg, var(--leaf-700), var(--leaf-900));
+  box-shadow: 0 9px 20px rgba(6, 57, 34, 0.22);
+}
+
+.ghost-button {
+  color: var(--ink-900);
+  background: transparent;
+  border: 1px solid rgba(19, 33, 24, 0.2);
+}
+
+.success-button {
+  color: white;
+  background: linear-gradient(135deg, #1a8f5d, var(--success));
+}
+
+.danger-button {
+  color: white;
+  background: linear-gradient(135deg, #d34c41, var(--danger));
+}
+
+.inline-button {
+  margin-top: 0.7rem;
+}
+
+.detail-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 0.75rem;
+}
+
+.detail-card {
+  background: var(--paper);
+  border: 1px solid rgba(19, 33, 24, 0.1);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.detail-card h2 {
+  margin-top: 0;
+}
+
+.detail-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  line-height: 1.6;
+}
+
+.accent-card {
+  background:
+    linear-gradient(150deg, rgba(11, 95, 55, 0.12), rgba(13, 111, 147, 0.14)),
+    var(--paper);
+}
+
+.form-grid {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.split-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.request-list {
+  margin-top: 0.9rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.request-item {
+  border: 1px solid rgba(19, 33, 24, 0.14);
+  border-radius: 12px;
+  background: var(--paper);
+  padding: 0.9rem;
+}
+
+.request-highlight {
+  border-color: rgba(11, 95, 55, 0.45);
+  box-shadow: 0 0 0 3px rgba(11, 95, 55, 0.1);
+}
+
+.request-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.request-top h2 {
+  margin: 0;
+  font-size: 1.13rem;
+}
+
+.inline-actions {
+  margin-top: 0.6rem;
+  display: flex;
+  gap: 0.45rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.83rem;
+  font-weight: 800;
+}
+
+.status-pending_owner {
+  background: rgba(13, 111, 147, 0.16);
+  color: #094f68;
+}
+
+.status-approved {
+  background: rgba(19, 107, 71, 0.16);
+  color: #0f593c;
+}
+
+.status-rejected {
+  background: rgba(179, 52, 42, 0.16);
+  color: #87281f;
+}
+
+.status-cancelled,
+.status-draft {
+  background: rgba(19, 33, 24, 0.12);
+  color: #2c4031;
+}
+
+.toast {
+  margin-top: 0.75rem;
+  border-radius: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+  border: 1px solid rgba(19, 33, 24, 0.15);
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.7rem 0.9rem;
+}
+
+.toast strong,
+.toast p {
+  margin: 0;
+}
+
+.toast-success {
+  border-color: rgba(19, 107, 71, 0.3);
+}
+
+.toast-error {
+  border-color: rgba(179, 52, 42, 0.35);
+}
+
+.text-button {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.muted {
+  color: rgba(19, 33, 24, 0.78);
+}
+
+.error-text {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.top-gap {
+  margin-top: 0.7rem;
+}
+
+.reveal {
+  animation: reveal-up 0.55s ease both;
+}
+
+@keyframes reveal-up {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 980px) {
+  .top-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .menu,
+  .auth-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .filters-grid,
+  .cards-grid,
+  .detail-grid,
+  .split-grid,
+  dl {
+    grid-template-columns: 1fr;
+  }
+
+  .session-chip {
+    width: fit-content;
+  }
+}

--- a/apps/app-web/tests/e2e/appweb.smoke.spec.js
+++ b/apps/app-web/tests/e2e/appweb.smoke.spec.js
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.clear();
+  });
+});
+
+test("arrendatario reserva y propietario aprueba", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "Catalogo de terrenos" })
+  ).toBeVisible();
+
+  await page.getByRole("link", { name: "Inicia sesion para reservar" }).first().click();
+
+  await expect(page).toHaveURL(/\/login/);
+
+  await page.getByLabel("Correo").fill("tenant@terrashare.test");
+  await page.getByLabel("Contrasena").fill("123456");
+  await page.getByRole("button", { name: "Entrar" }).click();
+
+  await expect(page).toHaveURL(/\/reserve\//);
+
+  await page.getByLabel("Fecha de inicio").fill("2026-05-10");
+  await page.getByLabel("Fecha de fin").fill("2026-06-10");
+  await page.getByLabel("Uso propuesto").fill("prueba e2e cultivo rotativo");
+  await page
+    .getByLabel("Mensaje para el propietario")
+    .fill("Tengo equipo y capital para iniciar de inmediato");
+
+  await page.getByRole("button", { name: "Enviar solicitud" }).click();
+
+  await expect(page).toHaveURL(/\/my-requests/);
+  await expect(page.getByText("Pendiente del propietario").first()).toBeVisible();
+  await expect(page.getByText("prueba e2e cultivo rotativo")).toBeVisible();
+
+  await page.getByRole("button", { name: "Cerrar sesion" }).click();
+
+  await page.getByRole("link", { name: "Iniciar sesion" }).click();
+  await page.getByLabel("Correo").fill("owner@terrashare.test");
+  await page.getByLabel("Contrasena").fill("123456");
+  await page.getByRole("button", { name: "Entrar" }).click();
+
+  await page.getByRole("link", { name: "Gestion propietario" }).click();
+
+  const requestCard = page
+    .locator(".request-item")
+    .filter({ hasText: "prueba e2e cultivo rotativo" })
+    .first();
+
+  await expect(requestCard).toBeVisible();
+  await requestCard.getByRole("button", { name: "Aprobar" }).click();
+
+  await expect(requestCard.getByText("Aprobada")).toBeVisible();
+});
+
+test("propietario puede rechazar solicitud pendiente", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.getByLabel("Correo").fill("owner@terrashare.test");
+  await page.getByLabel("Contrasena").fill("123456");
+  await page.getByRole("button", { name: "Entrar" }).click();
+
+  await page.getByRole("link", { name: "Gestion propietario" }).click();
+
+  const seedRequestCard = page
+    .locator(".request-item")
+    .filter({ hasText: "engorde de ganado en rotacion" })
+    .first();
+
+  await expect(seedRequestCard).toBeVisible();
+  await seedRequestCard.getByRole("button", { name: "Rechazar" }).click();
+
+  await expect(seedRequestCard.getByText("Rechazada")).toBeVisible();
+});

--- a/apps/app-web/vite.config.js
+++ b/apps/app-web/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/apps/backend-api/README.md
+++ b/apps/backend-api/README.md
@@ -9,3 +9,40 @@ Responsabilidades iniciales:
 - Modulo de contratos
 - Modulo de pagos
 - Modulo de chat
+
+## Estado actual
+- Aun sin implementacion de endpoints.
+- Definicion contract-first para trabajar en paralelo con `app-web`.
+
+## Contrato que debe exponer
+Referencia obligatoria:
+- `docs/MODULE_INTEGRATION_CONTRACTS.md`
+
+Rutas minimas esperadas para integrar con frontend actual:
+
+Auth:
+- `POST /auth/login`
+- `POST /auth/register`
+- `POST /auth/logout`
+- `GET /auth/session`
+
+Lands:
+- `GET /lands?type=&location=&maxPrice=&availableOn=`
+- `GET /lands/:landId`
+
+Rental requests:
+- `POST /rental-requests`
+- `GET /rental-requests/me`
+- `GET /owner/rental-requests`
+- `PATCH /owner/rental-requests/:requestId/status`
+
+## Reglas de negocio obligatorias
+1. Solo propietario del terreno puede aprobar o rechazar.
+2. Solo solicitudes `pending_owner` pueden pasar a `approved` o `rejected`.
+3. No se puede aprobar si existe solapamiento con otra solicitud ya aprobada
+	 para el mismo terreno.
+
+## Nota de interoperabilidad
+- El frontend ya implementa estas reglas en modo mock (`app-web`).
+- Al liberar endpoints reales, se debe mantener paridad de contrato para evitar
+	regresiones de UI y pruebas E2E.

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -42,3 +42,10 @@ Ejemplo:
 ```bash
 VITE_APP_WEB_URL=http://localhost:5174
 ```
+
+## Integracion entre modulos
+- La landing no consume backend directo en esta fase.
+- El contrato funcional de navegacion y datos esta documentado en:
+	`docs/MODULE_INTEGRATION_CONTRACTS.md`
+- Cuando `app-web` migre de mock a API real, la landing no requiere cambios
+	mientras se mantengan rutas de `register` y `login`.

--- a/docs/MODULE_INTEGRATION_CONTRACTS.md
+++ b/docs/MODULE_INTEGRATION_CONTRACTS.md
@@ -1,0 +1,122 @@
+# Contratos de integracion entre modulos
+
+## 1. Objetivo
+Definir un contrato comun para que frontend y backend trabajen en paralelo sin bloquearse.
+
+Estado actual:
+- `apps/app-web` usa adaptador mock local (`src/services/mockApi.js`).
+- `apps/backend-api` aun no implementa endpoints reales.
+- Este documento define el contrato que debe respetar la API real para reemplazo sin romper UI.
+
+## 2. Flujo entre modulos
+
+1. Landing (`apps/landing`) redirige al modulo principal via `VITE_APP_WEB_URL`.
+2. App web (`apps/app-web`) consume contrato de datos para:
+   - catalogo y filtros,
+   - detalle de terreno,
+   - crear solicitud,
+   - listar solicitudes de arrendatario,
+   - listar y decidir solicitudes como propietario.
+3. Backend API (`apps/backend-api`) debe implementar las rutas equivalentes.
+4. Shared (`packages/shared`) centralizara DTOs y estados cuando exista implementacion compartida.
+
+## 3. Contrato de estados de solicitud
+
+Estados validos:
+- `draft`
+- `pending_owner`
+- `approved`
+- `rejected`
+- `cancelled`
+
+Reglas de negocio ya aplicadas en mock (deben mantenerse en API real):
+1. Solo propietario del terreno puede aprobar/rechazar.
+2. Solo solicitudes `pending_owner` pueden transicionar a `approved` o `rejected`.
+3. No se puede aprobar una solicitud si solapa fechas con otra solicitud ya aprobada del mismo terreno.
+
+## 4. DTO de Land (lectura)
+
+```json
+{
+  "id": "land-1",
+  "ownerId": "usr-owner-1",
+  "name": "Finca El Tamarindo",
+  "province": "Los Santos",
+  "district": "Las Tablas",
+  "type": "Agricultura",
+  "monthlyPrice": 420,
+  "areaHectares": 5,
+  "availableFrom": "2026-05-01",
+  "availableTo": "2026-12-31",
+  "allowedUses": ["agricultura"],
+  "waterSource": "Pozo y rio cercano",
+  "summary": "Descripcion breve"
+}
+```
+
+## 5. DTO de RentalRequest
+
+```json
+{
+  "id": "req-100",
+  "landId": "land-2",
+  "tenantId": "usr-tenant-1",
+  "startDate": "2026-08-01",
+  "endDate": "2026-09-30",
+  "intendedUse": "engorde de ganado",
+  "message": "Texto libre",
+  "status": "pending_owner",
+  "createdAt": "2026-04-21T10:00:00.000Z",
+  "updatedAt": "2026-04-21T10:00:00.000Z"
+}
+```
+
+Campos enriquecidos usados por UI (respuesta de listados):
+- `landName`
+- `ownerId`
+- `tenantName`
+- `tenantEmail`
+- `monthlyPrice`
+- `landType`
+
+## 6. Endpoints esperados para backend-api
+
+Auth:
+- `POST /auth/login`
+- `POST /auth/register`
+- `POST /auth/logout`
+- `GET /auth/session`
+
+Lands:
+- `GET /lands?type=&location=&maxPrice=&availableOn=`
+- `GET /lands/:landId`
+
+Rental requests (tenant):
+- `POST /rental-requests`
+- `GET /rental-requests/me`
+
+Rental requests (owner):
+- `GET /owner/rental-requests`
+- `PATCH /owner/rental-requests/:requestId/status`
+
+Ejemplo PATCH body:
+
+```json
+{
+  "status": "approved"
+}
+```
+
+## 7. Plan de migracion mock -> API real
+
+1. Mantener la interfaz publica del servicio usada por `App.jsx`.
+2. Crear `src/services/httpApi.js` con mismas funciones que `mockApi.js`.
+3. Activar selector por variable de entorno:
+   - `VITE_DATA_SOURCE=mock` (default)
+   - `VITE_DATA_SOURCE=api`
+4. Reusar E2E existentes para validar que el comportamiento no cambia.
+
+## 8. Referencias
+- `apps/app-web/src/services/mockApi.js`
+- `apps/app-web/src/App.jsx`
+- `apps/app-web/tests/e2e/appweb.smoke.spec.js`

--- a/docs/SETUP_AND_COMMANDS.md
+++ b/docs/SETUP_AND_COMMANDS.md
@@ -31,10 +31,27 @@ bun run lint
 ```
 
 ## 4. Scripts esperados por modulo
-- landing: bun run dev
-- app-web: bun run dev
+- landing:
+	- `bun run dev`
+	- `bun run build`
+	- `bun run test:e2e`
+- app-web:
+	- `bun run dev`
+	- `bun run build`
+	- `bun run test:e2e`
 - admin-dashboard: bun run dev
 - backend-api: bun run dev
+
+## 4.1 Variables de entorno por frontend
+Landing:
+- `VITE_APP_WEB_URL=http://localhost:5174`
+
+App web:
+- `VITE_API_BASE_URL=http://localhost:3000`
+
+Nota:
+- En estado actual, `app-web` consume `mockApi` local y no backend real.
+- El contrato para backend esta en `docs/MODULE_INTEGRATION_CONTRACTS.md`.
 
 ## 5. Arranque sugerido en equipo
 1. Clonar repo con submodulos.
@@ -49,3 +66,7 @@ bun run lint
 - test
 - e2e (playwright)
 - build por modulo
+
+Workflows actuales implementados:
+- `.github/workflows/landing-e2e.yml`
+- `.github/workflows/app-web-e2e.yml`

--- a/docs/SETUP_AND_COMMANDS.md
+++ b/docs/SETUP_AND_COMMANDS.md
@@ -70,3 +70,32 @@ Nota:
 Workflows actuales implementados:
 - `.github/workflows/landing-e2e.yml`
 - `.github/workflows/app-web-e2e.yml`
+- `.github/workflows/require-linked-issue.yml`
+
+## 7. GitHub CLI para PRs (buenas practicas)
+Objetivo:
+- Evitar corrupcion de texto al editar descripciones de PR.
+- Asegurar cierre automatico de issues al merge.
+
+Reglas:
+- Incluir keyword de cierre en el body del PR: `Closes #<id>`, `Fixes #<id>` o `Resolves #<id>`.
+- Preferir `gh pr edit <numero> --body "..."` para cambios rapidos.
+- Si usas `--body-file`, guardar siempre el archivo en UTF-8.
+
+Comandos de referencia:
+```bash
+gh pr create --base main --head feature/<issue-id>-<slug> --title "feat: ..." --body "...\n\nCloses #<id>"
+gh pr edit <numero> --body "...\n\nCloses #<id>"
+```
+
+PowerShell con UTF-8 explicito:
+```powershell
+$body = @"
+## Resumen
+- Cambio principal.
+
+Closes #123
+"@
+$body | Out-File -FilePath pr_body_utf8.md -Encoding utf8
+gh pr edit 123 --body-file pr_body_utf8.md
+```

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -46,6 +46,7 @@ Minimo requerido:
 - 1 revisor obligatorio.
 - Todos los checks de GitHub Actions en verde.
 - Prohibido merge directo a main.
+- El body del PR debe incluir keyword de cierre de issue (`Closes #<id>`, `Fixes #<id>` o `Resolves #<id>`).
 
 Recomendado:
 - No hay limite fijo de lineas por PR.
@@ -73,6 +74,7 @@ Configurar para main:
 - Require approvals: 1.
 - Dismiss stale approvals when new commits are pushed.
 - Require status checks to pass before merging.
+- Marcar como requerido el check `Require closing keyword`.
 - Require conversation resolution before merging.
 - Restrict who can push directly a main.
 
@@ -83,6 +85,10 @@ Checks sugeridos:
 - test unit/integration
 - playwright e2e (smoke)
 - security scan basico (dependencias)
+
+Check implementado para gobernanza de issues:
+- `Require closing keyword` (`.github/workflows/require-linked-issue.yml`)
+- Valida que el body del PR tenga una keyword de cierre de issue.
 
 ## 8. Estrategia de repositorio
 Se adopta una estrategia de monorepo con submodulos Git para separar ownership por modulo.
@@ -151,3 +157,26 @@ Configuracion recomendada en GitHub para mantener este comportamiento:
 
 Nota:
 - Si en el futuro se habilita `CODEOWNERS` obligatorio, entonces si sera necesario que aprueben los owners definidos para las rutas afectadas.
+
+## 11. Edicion segura del body del PR (evitar texto corrupto)
+Problema conocido:
+- Si se edita el body del PR con archivos temporales en codificacion incorrecta, GitHub puede mostrar caracteres corruptos.
+
+Recomendacion:
+- Preferir `gh pr edit <numero> --body "texto"` para cambios directos.
+- Si se usa `--body-file`, guardar el archivo explicitamente en UTF-8.
+
+Ejemplo con PowerShell (UTF-8 explicito):
+```powershell
+$body = @"
+## Resumen
+- Cambio principal.
+
+Closes #123
+"@
+$body | Out-File -FilePath pr_body_utf8.md -Encoding utf8
+gh pr edit 123 --body-file pr_body_utf8.md
+```
+
+Higiene:
+- No commitear archivos temporales de cuerpo de PR (`pr_body*.txt`, `pr_body*.md`).

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -7,3 +7,20 @@ Responsabilidades iniciales:
 - Esquemas de validacion
 - Utilidades comunes
 - Constantes de dominio
+
+## Estado actual
+- Aun sin implementacion de codigo compartido.
+- Existe contrato base en documentacion para iniciar integracion entre modulos.
+
+## Fuente de verdad temporal
+- `docs/MODULE_INTEGRATION_CONTRACTS.md`
+
+## Objetivo inmediato de este paquete
+1. Publicar tipos para `Land` y `RentalRequest`.
+2. Centralizar enum de estados de solicitud.
+3. Compartir esquemas de validacion para payloads de auth, filtros y decisiones
+	 de propietario (`approved`/`rejected`).
+
+## Criterio de adopcion
+- `app-web`, `backend-api` y `admin-dashboard` deben consumir los contratos de
+	este paquete para reducir drift entre frontend y backend.


### PR DESCRIPTION
## Resumen
- Implementa app-web MVP con enfoque contract-first + mock-first.
- Agrega flujo de reservas para arrendatario.
- Agrega acciones del propietario para aprobar/rechazar solicitudes.
- Añade validaciones de dominio y persistencia local en mock API.
- Incorpora pruebas E2E de humo y workflow CI para app-web.
- Actualiza documentación transversal de módulos y contratos.

## Validación
- bun run build
- bun run test:e2e
- Ejecución local app-web en 127.0.0.1:5174.

## Nota
- El mapa se deja para una fase posterior (fuera de este alcance).

Closes #2