### PR TITLE
feat(backend-api): implementar auth base con Clerk y RBAC

### DIFF
--- a/apps/backend-api/.env.example
+++ b/apps/backend-api/.env.example
@@ -1,0 +1,9 @@
+API_PORT=3000
+API_BASE_URL=http://localhost:3000
+
+MONGODB_URI=mongodb://localhost:27017/terrashare
+
+CLERK_JWKS_URL=https://your-clerk-domain.clerk.accounts.dev/.well-known/jwks.json
+CLERK_ISSUER=https://your-clerk-domain.clerk.accounts.dev
+
+WHATSAPP_CONTACT_ENABLED=true

--- a/apps/backend-api/README.md
+++ b/apps/backend-api/README.md
@@ -4,7 +4,7 @@ API principal de TerraShare usando Bun + Hono.
 
 ## Estado del modulo
 - Estado actual: contrato de API documentado para alineacion Frontend/Backend.
-- Implementacion de endpoints: en progreso.
+- Implementacion de endpoints: en progreso (`GET /api/v1/health`, `GET /api/v1/auth/me` y `GET /api/v1/auth/admin/ping` disponibles).
 - Fuente de verdad para integracion frontend: archivos dentro de `docs/`.
 
 ## Objetivo funcional (v1)

--- a/apps/backend-api/bun.lock
+++ b/apps/backend-api/bun.lock
@@ -1,0 +1,32 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@terrashare/backend-api",
+      "dependencies": {
+        "hono": "^4.7.2",
+        "jose": "^5.9.6",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.6.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/apps/backend-api/docs/API_ENDPOINTS.md
+++ b/apps/backend-api/docs/API_ENDPOINTS.md
@@ -67,7 +67,8 @@ Notas:
 
 | Metodo | Ruta | Auth | Roles | Estado | Issue |
 | --- | --- | --- | --- | --- | --- |
-| GET | `/auth/me` | Si | user, admin | planned | #23 |
+| GET | `/auth/me` | Si | user, admin | implemented | #23 |
+| GET | `/auth/admin/ping` | Si | admin | implemented | #23 |
 
 `GET /auth/me` response example:
 

--- a/apps/backend-api/docs/INTEGRATION.md
+++ b/apps/backend-api/docs/INTEGRATION.md
@@ -28,6 +28,10 @@ Guia practica para equipos frontend que integran con backend-api.
 3. Responde contexto de sesion de aplicacion en `GET /api/v1/auth/me`.
 4. Aplica RBAC por `role` (`user`, `admin`) y ownership.
 
+Estado implementado actual:
+- `GET /api/v1/auth/me` (token valido requerido).
+- `GET /api/v1/auth/admin/ping` (token valido + rol admin).
+
 ## 3. Header de autorizacion
 
 Ejemplo de request autenticado:

--- a/apps/backend-api/package.json
+++ b/apps/backend-api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@terrashare/backend-api",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/index.ts",
+    "start": "bun src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "hono": "^4.7.2",
+    "jose": "^5.9.6"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+
+import { failure } from "./lib/api-response";
+import { requestIdMiddleware } from "./middleware/request-id";
+import { authRoutes } from "./routes/auth";
+import { healthRoutes } from "./routes/health";
+import type { AppEnv } from "./types";
+
+export function createApp() {
+  const app = new Hono<AppEnv>();
+
+  app.use("*", requestIdMiddleware);
+
+  app.get("/", (c) => {
+    return c.json({
+      service: "backend-api",
+      version: "v1",
+      basePath: "/api/v1",
+    });
+  });
+
+  app.route("/api/v1", healthRoutes);
+  app.route("/api/v1", authRoutes);
+
+  app.notFound((c) => failure(c, 404, "NOT_FOUND", "Route not found"));
+
+  app.onError((error, c) => {
+    console.error("[backend-api] unhandled error", error);
+    return failure(c, 500, "INTERNAL_ERROR", "Unexpected server error");
+  });
+
+  return app;
+}

--- a/apps/backend-api/src/config/env.ts
+++ b/apps/backend-api/src/config/env.ts
@@ -1,0 +1,23 @@
+import type { Env } from "../types";
+
+function getEnv(name: keyof Env): string | undefined {
+  return process.env[name];
+}
+
+function requireEnv(name: keyof Env): string {
+  const value = getEnv(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export const env = {
+  apiPort: Number(getEnv("API_PORT") ?? 3000),
+  get clerkJwksUrl() {
+    return requireEnv("CLERK_JWKS_URL");
+  },
+  get clerkIssuer() {
+    return requireEnv("CLERK_ISSUER");
+  },
+};

--- a/apps/backend-api/src/index.ts
+++ b/apps/backend-api/src/index.ts
@@ -1,0 +1,11 @@
+import { env } from "./config/env";
+import { createApp } from "./app";
+
+const app = createApp();
+
+console.log(`[backend-api] listening on port ${env.apiPort}`);
+
+export default {
+  port: env.apiPort,
+  fetch: app.fetch,
+};

--- a/apps/backend-api/src/lib/api-response.ts
+++ b/apps/backend-api/src/lib/api-response.ts
@@ -1,0 +1,60 @@
+import type { Context } from "hono";
+
+interface ErrorDetail {
+  field: string;
+  message: string;
+}
+
+type ErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "BUSINESS_RULE_VIOLATION"
+  | "INTERNAL_ERROR";
+
+type SuccessStatus = 200 | 201 | 202;
+type FailureStatus = 400 | 401 | 403 | 404 | 409 | 422 | 500;
+
+function getRequestId(c: Context): string {
+  return c.get("requestId") ?? crypto.randomUUID();
+}
+
+export function success<T>(
+  c: Context,
+  data: T,
+  status: SuccessStatus = 200,
+): Response {
+  return c.json(
+    {
+      ok: true,
+      data,
+      meta: {
+        requestId: getRequestId(c),
+      },
+    },
+    status,
+  );
+}
+
+export function failure(
+  c: Context,
+  status: FailureStatus,
+  code: ErrorCode,
+  message: string,
+  details?: ErrorDetail[],
+): Response {
+  return c.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        details,
+        requestId: getRequestId(c),
+      },
+    },
+    status,
+  );
+}

--- a/apps/backend-api/src/lib/clerk-user.test.ts
+++ b/apps/backend-api/src/lib/clerk-user.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+
+import { mapClerkClaimsToAuthUser } from "./clerk-user";
+
+describe("mapClerkClaimsToAuthUser", () => {
+  it("maps admin role from claims", () => {
+    const user = mapClerkClaimsToAuthUser({
+      sub: "user_123",
+      email: "admin@example.com",
+      full_name: "Admin User",
+      role: "admin",
+    });
+
+    expect(user.clerkUserId).toBe("user_123");
+    expect(user.role).toBe("admin");
+    expect(user.status).toBe("active");
+  });
+
+  it("maps role and status from public metadata", () => {
+    const user = mapClerkClaimsToAuthUser({
+      sub: "user_456",
+      email: "member@example.com",
+      public_metadata: {
+        role: "admin",
+        status: "blocked",
+        phone: "+50760000001",
+      },
+    });
+
+    expect(user.role).toBe("admin");
+    expect(user.status).toBe("blocked");
+    expect(user.profile.phone).toBe("+50760000001");
+  });
+
+  it("falls back to default user role and derived full name", () => {
+    const user = mapClerkClaimsToAuthUser({
+      sub: "user_789",
+      email: "fallback@example.com",
+    });
+
+    expect(user.role).toBe("user");
+    expect(user.profile.fullName).toBe("fallback");
+  });
+});

--- a/apps/backend-api/src/lib/clerk-user.ts
+++ b/apps/backend-api/src/lib/clerk-user.ts
@@ -1,0 +1,97 @@
+import type { JWTPayload } from "jose";
+
+import type { AppRole, AuthContextUser, UserStatus } from "../types";
+
+type ClaimRecord = Record<string, unknown>;
+
+function readClaim(claims: ClaimRecord, key: string): unknown {
+  return claims[key];
+}
+
+function readPublicMetadata(claims: ClaimRecord, key: string): unknown {
+  const metadata = claims.public_metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return undefined;
+  }
+  return (metadata as ClaimRecord)[key];
+}
+
+function mapRole(value: unknown): AppRole {
+  return value === "admin" ? "admin" : "user";
+}
+
+function mapStatus(value: unknown): UserStatus {
+  return value === "blocked" ? "blocked" : "active";
+}
+
+function mapFullName(claims: ClaimRecord): string {
+  const directFullName = readClaim(claims, "full_name");
+  if (typeof directFullName === "string" && directFullName.trim()) {
+    return directFullName.trim();
+  }
+
+  const givenName = readClaim(claims, "given_name");
+  const familyName = readClaim(claims, "family_name");
+  const builtName = [givenName, familyName]
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join(" ")
+    .trim();
+
+  if (builtName) {
+    return builtName;
+  }
+
+  const email = mapEmail(claims);
+  if (email) {
+    return email.split("@")[0] || "Usuario";
+  }
+
+  return "Usuario";
+}
+
+function mapEmail(claims: ClaimRecord): string {
+  const directEmail = readClaim(claims, "email");
+  if (typeof directEmail === "string" && directEmail.trim()) {
+    return directEmail.trim();
+  }
+
+  const fallbackEmail = readClaim(claims, "email_address");
+  if (typeof fallbackEmail === "string" && fallbackEmail.trim()) {
+    return fallbackEmail.trim();
+  }
+
+  return "unknown@terrashare.local";
+}
+
+function mapPhone(claims: ClaimRecord): string | undefined {
+  const directPhone = readClaim(claims, "phone_number");
+  if (typeof directPhone === "string" && directPhone.trim()) {
+    return directPhone.trim();
+  }
+
+  const metadataPhone = readPublicMetadata(claims, "phone");
+  if (typeof metadataPhone === "string" && metadataPhone.trim()) {
+    return metadataPhone.trim();
+  }
+
+  return undefined;
+}
+
+export function mapClerkClaimsToAuthUser(payload: JWTPayload): AuthContextUser {
+  const claims = payload as ClaimRecord;
+  const clerkUserId = typeof claims.sub === "string" ? claims.sub : "unknown_sub";
+  const role = mapRole(readClaim(claims, "role") ?? readPublicMetadata(claims, "role"));
+  const status = mapStatus(readPublicMetadata(claims, "status"));
+
+  return {
+    id: clerkUserId,
+    clerkUserId,
+    email: mapEmail(claims),
+    role,
+    status,
+    profile: {
+      fullName: mapFullName(claims),
+      phone: mapPhone(claims),
+    },
+  };
+}

--- a/apps/backend-api/src/middleware/request-id.ts
+++ b/apps/backend-api/src/middleware/request-id.ts
@@ -1,0 +1,8 @@
+import type { MiddlewareHandler } from "hono";
+
+export const requestIdMiddleware: MiddlewareHandler = async (c, next) => {
+  const requestId = c.req.header("x-request-id") ?? crypto.randomUUID();
+  c.set("requestId", requestId);
+  c.header("x-request-id", requestId);
+  await next();
+};

--- a/apps/backend-api/src/middleware/require-auth.ts
+++ b/apps/backend-api/src/middleware/require-auth.ts
@@ -1,0 +1,59 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { MiddlewareHandler } from "hono";
+
+import { env } from "../config/env";
+import { failure } from "../lib/api-response";
+import { mapClerkClaimsToAuthUser } from "../lib/clerk-user";
+import type { AppEnv } from "../types";
+
+let jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
+
+function getJwks() {
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(env.clerkJwksUrl));
+  }
+  return jwks;
+}
+
+function getBearerToken(authorizationHeader: string | undefined): string | undefined {
+  if (!authorizationHeader) {
+    return undefined;
+  }
+  const [scheme, token] = authorizationHeader.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    return undefined;
+  }
+  return token;
+}
+
+export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const token = getBearerToken(c.req.header("authorization"));
+  if (!token) {
+    return failure(c, 401, "UNAUTHORIZED", "Missing or invalid bearer token");
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, getJwks(), {
+      issuer: env.clerkIssuer,
+      algorithms: ["RS256"],
+    });
+
+    const authUser = mapClerkClaimsToAuthUser(payload);
+    if (authUser.status !== "active") {
+      return failure(c, 403, "FORBIDDEN", "User is blocked");
+    }
+
+    c.set("authUser", authUser);
+    await next();
+  } catch {
+    return failure(c, 401, "UNAUTHORIZED", "Invalid or expired token");
+  }
+};
+
+export const requireAdmin: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const authUser = c.get("authUser");
+  if (authUser.role !== "admin") {
+    return failure(c, 403, "FORBIDDEN", "Admin role required");
+  }
+  await next();
+};

--- a/apps/backend-api/src/routes/auth.ts
+++ b/apps/backend-api/src/routes/auth.ts
@@ -1,0 +1,19 @@
+import { Hono } from "hono";
+
+import { success } from "../lib/api-response";
+import { requireAdmin, requireAuth } from "../middleware/require-auth";
+import type { AppEnv } from "../types";
+
+export const authRoutes = new Hono<AppEnv>();
+
+authRoutes.get("/auth/me", requireAuth, (c) => {
+  const authUser = c.get("authUser");
+  return success(c, authUser);
+});
+
+authRoutes.get("/auth/admin/ping", requireAuth, requireAdmin, (c) => {
+  return success(c, {
+    allowed: true,
+    role: "admin",
+  });
+});

--- a/apps/backend-api/src/routes/health.ts
+++ b/apps/backend-api/src/routes/health.ts
@@ -1,0 +1,14 @@
+import { Hono } from "hono";
+
+import { success } from "../lib/api-response";
+import type { AppEnv } from "../types";
+
+export const healthRoutes = new Hono<AppEnv>();
+
+healthRoutes.get("/health", (c) => {
+  return success(c, {
+    status: "ok",
+    service: "backend-api",
+    timestamp: new Date().toISOString(),
+  });
+});

--- a/apps/backend-api/src/types.ts
+++ b/apps/backend-api/src/types.ts
@@ -1,0 +1,30 @@
+export type AppRole = "user" | "admin";
+
+export type UserStatus = "active" | "blocked";
+
+export interface AuthContextUser {
+  id: string;
+  clerkUserId: string;
+  email: string;
+  role: AppRole;
+  status: UserStatus;
+  profile: {
+    fullName: string;
+    phone?: string;
+  };
+}
+
+export interface AppVariables {
+  requestId: string;
+  authUser: AuthContextUser;
+}
+
+export interface AppEnv {
+  Variables: AppVariables;
+}
+
+export interface Env {
+  API_PORT?: string;
+  CLERK_JWKS_URL?: string;
+  CLERK_ISSUER?: string;
+}

--- a/apps/backend-api/tsconfig.json
+++ b/apps/backend-api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [
+      "bun"
+    ],
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Resumen
Este PR implementa la base funcional de autenticacion/autorizacion para `backend-api` usando Clerk JWT + middleware RBAC. Incluye bootstrap del servicio con Hono, manejo de respuesta estandar y endpoints de salud/autenticacion necesarios para integrar frontend.

## Issue relacionado
Closes #23

## Tipo de cambio
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [x] Documentacion

## Checklist
- [x] Cumple criterios de aceptacion del issue
- [x] No rompe funcionalidad existente
- [x] Incluye/actualiza pruebas necesarias
- [ ] CI en verde
- [x] Documentacion actualizada

## Evidencia
- Implementado JWT funcional con Clerk (`requireAuth`):
  - validacion de `Bearer token`
  - verificacion de firma via JWKS remoto
  - verificacion de issuer
  - rechazo de usuarios bloqueados
- RBAC base (`user/admin`) implementado con middleware `requireAdmin`.
- Endpoints implementados:
  - `GET /api/v1/health`
  - `GET /api/v1/auth/me`
  - `GET /api/v1/auth/admin/ping`
- Se agregan respuestas estandar `ok/data/meta` y `ok/error` con `requestId`.
- Se agregan pruebas unitarias de mapeo de claims Clerk en `src/lib/clerk-user.test.ts`.
- Se actualiza documentacion de estado de endpoints en:
  - `apps/backend-api/docs/API_ENDPOINTS.md`
  - `apps/backend-api/docs/INTEGRATION.md`
  - `apps/backend-api/README.md`

Pruebas locales ejecutadas:
- `bun run typecheck` ✅
- `bun test` ✅

## Riesgos y rollback
- Riesgo principal: variaciones de claims entre tenants de Clerk pueden requerir ajustes de mapeo.
- Plan de rollback: revertir PR o ajustar mapeo de claims/middlewares sin romper contratos de endpoint.