### PR TITLE
feat(admin): #8 — admin endpoints + moderation UI

### DIFF
--- a/apps/backend-api/docs/API_ENDPOINTS.md
+++ b/apps/backend-api/docs/API_ENDPOINTS.md
@@ -225,6 +225,35 @@ Para mantener front/back sincronizados (issue #29), los DTOs deben exponerse en 
 - `PaymentDto`, `CreateCheckoutSessionDto`
 - `ChatDto`, `ChatMessageDto`
 
+## Admin (Moderación)
+
+| Metodo | Ruta | Auth | Roles | Estado | Issue |
+| --- | --- | --- | --- | --- | --- |
+| GET | `/admin/users` | Si | admin | implemented | #8 |
+| GET | `/admin/users/:userId` | Si | admin | implemented | #8 |
+| PATCH | `/admin/users/:userId/status` | Si | admin | implemented | #8 |
+| GET | `/admin/lands` | Si | admin | implemented | #8 |
+| PATCH | `/admin/lands/:landId/status` | Si | admin | implemented | #8 |
+
+`GET /admin/users` query params:
+- `role` (`user`, `admin`)
+- `status` (`active`, `blocked`)
+- `search` (filtra por email o nombre)
+
+`PATCH /admin/users/:userId/status` body:
+```json
+{ "status": "active" | "blocked" }
+```
+
+`GET /admin/lands` query params:
+- `status` (`draft`, `active`, `inactive`)
+- `search` (filtra por título o provincia)
+
+`PATCH /admin/lands/:landId/status` body:
+```json
+{ "status": "active" | "inactive" | "rejected" }
+```
+
 ## Notas para frontend
 
 - Tratar este archivo como contrato de integracion hasta que cada endpoint pase a `implemented`.

--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -4,6 +4,7 @@ import { failure } from "./lib/api-response";
 import { requestIdMiddleware } from "./middleware/request-id";
 import { authRoutes } from "./routes/auth";
 import { healthRoutes } from "./routes/health";
+import { adminRoutes } from "./routes/admin";
 import { landRoutes } from "./routes/lands";
 import { leadRoutes } from "./routes/leads";
 import { rentalRequestRoutes } from "./routes/rental-requests";
@@ -27,6 +28,7 @@ export function createApp() {
 
   app.route("/api/v1", healthRoutes);
   app.route("/api/v1", authRoutes);
+  app.route("/api/v1", adminRoutes);
   app.route("/api/v1", landRoutes);
   app.route("/api/v1", leadRoutes);
   app.route("/api/v1", rentalRequestRoutes);

--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -1,0 +1,172 @@
+import { Hono } from "hono";
+
+import { failure, success } from "../lib/api-response";
+import { requireAdmin, requireAuth } from "../middleware/require-auth";
+import { createAuditEvent } from "../store/audit";
+import { getStore } from "../store/in-memory-db";
+import type { AdminLandSummary, AdminUserSummary, UserStatus } from "../../store/types";
+import type { AppEnv } from "../../types";
+
+export const adminRoutes = new Hono<AppEnv>();
+
+// ─── Users ──────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/admin/users
+ * Lista todos los usuarios del sistema con filtros opcionales.
+ * Auth: required (admin)
+ */
+adminRoutes.get("/admin/users", requireAuth, requireAdmin, (c) => {
+  const store = getStore();
+  const role = c.req.query("role") as "user" | "admin" | undefined;
+  const status = c.req.query("status") as UserStatus | undefined;
+  const search = c.req.query("search")?.toLowerCase();
+
+  let users = Array.from(store.users.values()) as AdminUserSummary[];
+
+  if (role) {
+    users = users.filter((u) => u.role === role);
+  }
+  if (status) {
+    users = users.filter((u) => u.status === status);
+  }
+  if (search) {
+    users = users.filter(
+      (u) =>
+        u.email.toLowerCase().includes(search) ||
+        u.profile.fullName.toLowerCase().includes(search),
+    );
+  }
+
+  return success(c, { items: users, total: users.length });
+});
+
+/**
+ * GET /api/v1/admin/users/:userId
+ * Detalle de un usuario.
+ * Auth: required (admin)
+ */
+adminRoutes.get("/admin/users/:userId", requireAuth, requireAdmin, (c) => {
+  const store = getStore();
+  const userId = c.req.param("userId");
+  const user = store.users.get(userId);
+  if (!user) {
+    return failure(c, 404, "NOT_FOUND", "User not found");
+  }
+  return success(c, user);
+});
+
+/**
+ * PATCH /api/v1/admin/users/:userId/status
+ * Bloquea o activa un usuario.
+ * Auth: required (admin)
+ * Body: { status: "active" | "blocked" }
+ */
+adminRoutes.patch("/admin/users/:userId/status", requireAuth, requireAdmin, async (c) => {
+  const store = getStore();
+  const authUser = c.get("authUser");
+  const userId = c.req.param("userId");
+  const user = store.users.get(userId);
+  if (!user) {
+    return failure(c, 404, "NOT_FOUND", "User not found");
+  }
+
+  const body = (await c.req.json().catch(() => null)) as { status?: UserStatus } | null;
+  const nextStatus = body?.status;
+  if (!nextStatus || !["active", "blocked"].includes(nextStatus)) {
+    return failure(c, 400, "VALIDATION_ERROR", "Invalid status value");
+  }
+
+  // Cannot block yourself
+  if (userId === authUser.id) {
+    return failure(c, 400, "BUSINESS_RULE", "Cannot modify own account status");
+  }
+
+  const updated = { ...user, status: nextStatus, updatedAt: new Date().toISOString() };
+  store.users.set(userId, updated);
+
+  createAuditEvent({
+    actor: authUser,
+    entity: "user",
+    action: nextStatus === "blocked" ? "blocked" : "activated",
+    entityId: userId,
+    metadata: { email: user.email },
+  });
+
+  return success(c, updated);
+});
+
+// ─── Lands ───────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/admin/lands
+ * Lista terrenos con filtros — centrado en moderation (draft/inactive).
+ * Auth: required (admin)
+ */
+adminRoutes.get("/admin/lands", requireAuth, requireAdmin, (c) => {
+  const store = getStore();
+  const status = c.req.query("status");
+  const search = c.req.query("search")?.toLowerCase();
+
+  let lands = Array.from(store.lands.values());
+
+  if (status && ["draft", "active", "inactive"].includes(status)) {
+    lands = lands.filter((l) => l.status === status);
+  }
+  if (search) {
+    lands = lands.filter(
+      (l) =>
+        l.title.toLowerCase().includes(search) ||
+        l.location.province.toLowerCase().includes(search),
+    );
+  }
+
+  const items: AdminLandSummary[] = lands.map((l) => {
+    const owner = store.users.get(l.ownerId);
+    return {
+      id: l.id,
+      ownerId: l.ownerId,
+      ownerEmail: owner?.email ?? l.ownerId,
+      title: l.title,
+      status: l.status,
+      createdAt: l.createdAt,
+    };
+  });
+
+  return success(c, { items, total: items.length });
+});
+
+/**
+ * PATCH /api/v1/admin/lands/:landId/status
+ * Cambia el estado de un terreno — usado para aprobar/rechazar moderation.
+ * Auth: required (admin)
+ * Body: { status: "active" | "inactive" | "rejected" }
+ */
+adminRoutes.patch("/admin/lands/:landId/status", requireAuth, requireAdmin, async (c) => {
+  const store = getStore();
+  const authUser = c.get("authUser");
+  const landId = c.req.param("landId");
+  const land = store.lands.get(landId);
+  if (!land) {
+    return failure(c, 404, "NOT_FOUND", "Land not found");
+  }
+
+  const body = (await c.req.json().catch(() => null)) as { status?: string } | null;
+  const nextStatus = body?.status;
+  if (!nextStatus || !["active", "inactive", "rejected"].includes(nextStatus)) {
+    return failure(c, 400, "VALIDATION_ERROR", "Invalid status value");
+  }
+
+  const updated = { ...land, status: nextStatus as typeof land.status, updatedAt: new Date().toISOString() };
+  store.lands.set(landId, updated);
+
+  createAuditEvent({
+    actor: authUser,
+    entity: "land",
+    action: nextStatus === "active" ? "approved" : "rejected",
+    entityId: landId,
+    metadata: { title: land.title },
+  });
+
+  return success(c, updated);
+});

--- a/apps/backend-api/src/store/in-memory-db.ts
+++ b/apps/backend-api/src/store/in-memory-db.ts
@@ -1,4 +1,5 @@
 import type {
+  AdminUserSummary,
   AuditEventRecord,
   ChatRecord,
   ChatMessageRecord,
@@ -8,6 +9,7 @@ import type {
   LeadRecord,
   PaymentRecord,
   RentalRequestRecord,
+  UserRecord,
 } from "./types";
 
 const store: InMemoryStore = {
@@ -23,6 +25,64 @@ const store: InMemoryStore = {
 };
 
 const now = new Date().toISOString();
+
+// Seed users — mirrors Clerk identities for dev/admin flows
+const seedUsers: UserRecord[] = [
+  {
+    id: "user_owner_01",
+    clerkUserId: "user_owner_01",
+    email: "owner@terrashare.test",
+    role: "user",
+    status: "active",
+    profile: { fullName: "Propietario Demo" },
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "user_owner_02",
+    clerkUserId: "user_owner_02",
+    email: "owner2@terrashare.test",
+    role: "user",
+    status: "active",
+    profile: { fullName: "Propietario Dos" },
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "user_tenant_01",
+    clerkUserId: "user_tenant_01",
+    email: "tenant@terrashare.test",
+    role: "user",
+    status: "active",
+    profile: { fullName: "Arrendatario Demo" },
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "user_tenant_99",
+    clerkUserId: "user_tenant_99",
+    email: "tenant99@terrashare.test",
+    role: "user",
+    status: "active",
+    profile: { fullName: "Arrendatario Test" },
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "user_admin_01",
+    clerkUserId: "user_admin_01",
+    email: "admin@terrashare.test",
+    role: "admin",
+    status: "active",
+    profile: { fullName: "Administrador" },
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+for (const user of seedUsers) {
+  store.users.set(user.id, user);
+}
 
 const seedLandA: LandRecord = {
   id: "land_seed_01",

--- a/apps/backend-api/src/store/types.ts
+++ b/apps/backend-api/src/store/types.ts
@@ -172,3 +172,27 @@ export interface InMemoryStore {
   auditEvents: Map<string, AuditEventRecord>;
   leads: Map<string, LeadRecord>;
 }
+
+export interface UserRecord extends AuthContextUser {
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AdminUserSummary {
+  id: string;
+  clerkUserId: string;
+  email: string;
+  role: AppRole;
+  status: UserStatus;
+  profile: { fullName: string; phone?: string };
+  createdAt: string;
+}
+
+export interface AdminLandSummary {
+  id: string;
+  ownerId: string;
+  ownerEmail: string;
+  title: string;
+  status: LandStatus;
+  createdAt: string;
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,9 +1,12 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import LandingPage from "./pages/LandingPage";
 import Login from "./components/Login";
 import Register from "./components/Register";
+import AdminUsersPage from "./pages/AdminUsersPage";
+import AdminLandsPage from "./pages/AdminLandsPage";
+import { setTokenFn as setAdminTokenFn } from "./services/adminApi";
 
 function ProtectedRoute({ children }) {
   const { isLoaded } = useClerk();
@@ -85,14 +88,17 @@ function DashboardLayout({ children, onSignOut }) {
 }
 
 function AdminLayout({ children, onSignOut }) {
+  const location = useLocation();
+  const currentPath = location.pathname;
+
   return (
     <div className="admin-layout">
       <aside className="sidebar">
         <Link to="/dashboard/admin" className="brand">TerraShare Admin</Link>
         <nav>
-          <Link to="/dashboard/admin">Dashboard</Link>
-          <Link to="/dashboard/admin/users">Usuarios</Link>
-          <Link to="/dashboard/admin/lands">Terrenos</Link>
+          <Link to="/dashboard/admin" className={currentPath === "/dashboard/admin" ? "active" : ""}>Dashboard</Link>
+          <Link to="/dashboard/admin/users" className={currentPath === "/dashboard/admin/users" ? "active" : ""}>Usuarios</Link>
+          <Link to="/dashboard/admin/lands" className={currentPath === "/dashboard/admin/lands" ? "active" : ""}>Terrenos</Link>
         </nav>
         <div style={{ marginTop: "auto", paddingTop: "2rem" }}>
           <button className="btn btn-ghost" onClick={onSignOut} style={{ width: "100%", color: "white", borderColor: "rgba(255,255,255,0.3)" }}>
@@ -120,10 +126,29 @@ function DashboardPage() {
 }
 
 function AdminDashboardPage() {
-  const [users, setUsers] = useState([
-    { id: 1, name: "Juan Perez", email: "juan@example.com", status: "active" },
-    { id: 2, name: "Maria Garcia", email: "maria@example.com", status: "blocked" },
-  ]);
+  const [counts, setCounts] = useState({ total: 0, active: 0, blocked: 0, lands: 0 });
+  const [loading, setLoading] = useState(true);
+  const { user } = useUser();
+
+  useEffect(() => {
+    if (!user) return;
+    user.getToken().then((token) => setAdminTokenFn(() => token));
+    // Load counts from admin endpoints
+    import("./services/adminApi").then(({ listAdminUsers, listAdminLands }) => {
+      Promise.all([
+        listAdminUsers({}).then((r) => r.data?.items ?? []),
+        listAdminLands({ status: "draft" }).then((r) => r.data?.items ?? []),
+      ]).then(([users, landsDraft]) => {
+        setCounts({
+          total: users.length,
+          active: users.filter((u) => u.status === "active").length,
+          blocked: users.filter((u) => u.status === "blocked").length,
+          lands: landsDraft.length,
+        });
+        setLoading(false);
+      }).catch(() => setLoading(false));
+    });
+  }, [user]);
 
   return (
     <div>
@@ -132,32 +157,14 @@ function AdminDashboardPage() {
         <p>Gestion de usuarios y plataforma</p>
       </div>
       <div className="stats-grid" style={{ marginTop: "1.5rem" }}>
-        <div className="stat-card"><h3>Usuarios</h3><p>{users.length}</p></div>
-        <div className="stat-card"><h3>Activos</h3><p>{users.filter(u => u.status === "active").length}</p></div>
-        <div className="stat-card"><h3>Bloqueados</h3><p>{users.filter(u => u.status === "blocked").length}</p></div>
-        <div className="stat-card"><h3>Terrenos</h3><p>--</p></div>
+        <div className="stat-card"><h3>Total usuarios</h3><p>{loading ? "..." : counts.total}</p></div>
+        <div className="stat-card"><h3>Activos</h3><p>{loading ? "..." : counts.active}</p></div>
+        <div className="stat-card"><h3>Bloqueados</h3><p>{loading ? "..." : counts.blocked}</p></div>
+        <div className="stat-card"><h3>Terrenos pendientes</h3><p>{loading ? "..." : counts.lands}</p></div>
       </div>
       <div className="panel" style={{ marginTop: "1.5rem" }}>
-        <h2>Usuarios recientes</h2>
-        <table className="table" style={{ marginTop: "1rem" }}>
-          <thead>
-            <tr><th>Nombre</th><th>Email</th><th>Estado</th><th>Acciones</th></tr>
-          </thead>
-          <tbody>
-            {users.map((u) => (
-              <tr key={u.id}>
-                <td>{u.name}</td>
-                <td>{u.email}</td>
-                <td><span className={`status-badge ${u.status === "active" ? "status-active" : "status-blocked"}`}>{u.status}</span></td>
-                <td>
-                  <button className="btn btn-ghost" style={{ fontSize: "0.75rem", padding: "0.25rem 0.5rem" }}>
-                    {u.status === "active" ? "Bloquear" : "Activar"}
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <h2>Resumen rapido</h2>
+        <p style={{ opacity: 0.7 }}>Usa el menu lateral para gestionar usuarios y moderar terrenos.</p>
       </div>
     </div>
   );
@@ -166,6 +173,14 @@ function AdminDashboardPage() {
 export default function App() {
   const { signOut } = useClerk();
   const { isSignedIn, isLoaded } = useUser();
+
+  // Inject Clerk token for admin API calls
+  const { user } = useUser();
+  useEffect(() => {
+    if (user) {
+      user.getToken().then((token) => setAdminTokenFn(() => token));
+    }
+  }, [user]);
 
   const handleSignOut = async () => {
     await signOut();
@@ -197,6 +212,20 @@ export default function App() {
         <AdminRoute>
           <AdminLayout onSignOut={handleSignOut}>
             <AdminDashboardPage />
+          </AdminLayout>
+        </AdminRoute>
+      } />
+      <Route path="/dashboard/admin/users" element={
+        <AdminRoute>
+          <AdminLayout onSignOut={handleSignOut}>
+            <AdminUsersPage />
+          </AdminLayout>
+        </AdminRoute>
+      } />
+      <Route path="/dashboard/admin/lands" element={
+        <AdminRoute>
+          <AdminLayout onSignOut={handleSignOut}>
+            <AdminLandsPage />
           </AdminLayout>
         </AdminRoute>
       } />

--- a/apps/web/src/pages/AdminLandsPage.jsx
+++ b/apps/web/src/pages/AdminLandsPage.jsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from "react";
+import { listAdminLands, updateLandStatus, setTokenFn } from "../services/adminApi";
+import { useUser } from "@clerk/clerk-react";
+
+const statusLabels = {
+  draft: "Borrador",
+  active: "Activo",
+  inactive: "Inactivo",
+  rejected: "Rechazado",
+};
+
+const statusColors = {
+  draft: { bg: "rgba(200, 170, 0, 0.15)", color: "var(--accent-600)" },
+  active: { bg: "rgba(11, 95, 55, 0.15)", color: "var(--leaf-700)" },
+  inactive: { bg: "rgba(100, 100, 100, 0.15)", color: "var(--stone-600)" },
+  rejected: { bg: "rgba(180, 40, 40, 0.15)", color: "var(--error)" },
+};
+
+export default function AdminLandsPage() {
+  const { user } = useUser();
+  const [lands, setLands] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [filter, setFilter] = useState("draft");
+  const [search, setSearch] = useState("");
+  const [actionMsg, setActionMsg] = useState("");
+
+  useEffect(() => {
+    if (user) {
+      user.getToken().then((token) => setTokenFn(() => token));
+    }
+  }, [user]);
+
+  const loadLands = () => {
+    setLoading(true);
+    setError("");
+    const filters = {};
+    if (filter !== "all") filters.status = filter;
+    if (search.trim()) filters.search = search.trim();
+
+    listAdminLands(filters)
+      .then((res) => setLands(res.data?.items ?? []))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { loadLands(); }, [filter, search]);
+
+  const handleUpdateStatus = async (landId, currentStatus, nextStatus) => {
+    try {
+      await updateLandStatus(landId, nextStatus);
+      setLands((prev) => prev.map((l) => l.id === landId ? { ...l, status: nextStatus } : l));
+      setActionMsg(`Terreno ${nextStatus === "active" ? "aprobado" : "rechazado"}`);
+    } catch (e) {
+      setError(e.message);
+    }
+    setTimeout(() => setActionMsg(""), 3000);
+  };
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Moderación de Terrenos</h1>
+        <p>Revisa y aprueba los terrenos publicados en la plataforma</p>
+      </div>
+
+      <div className="filters-bar" style={{ marginTop: "1.5rem", display: "flex", gap: "1rem", alignItems: "center", flexWrap: "wrap" }}>
+        <input
+          type="text"
+          placeholder="Buscar por título o provincia..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ maxWidth: "300px", flex: 1 }}
+        />
+        <select value={filter} onChange={(e) => setFilter(e.target.value)}>
+          <option value="all">Todos</option>
+          <option value="draft">Borrador (pendiente)</option>
+          <option value="active">Activos</option>
+          <option value="inactive">Inactivos</option>
+          <option value="rejected">Rechazados</option>
+        </select>
+        <span style={{ opacity: 0.7 }}>{lands.length} terreno{lands.length !== 1 ? "s" : ""}</span>
+        {actionMsg && (
+          <span style={{ color: "var(--leaf-600)", fontWeight: 600 }}>{actionMsg}</span>
+        )}
+      </div>
+
+      {loading && <p className="muted" style={{ marginTop: "1rem" }}>Cargando...</p>}
+      {error && <p className="error-text" style={{ marginTop: "1rem" }}>{error}</p>}
+
+      {!loading && !error && (
+        <div style={{ marginTop: "1rem", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          {lands.map((land) => {
+            const colors = statusColors[land.status] ?? statusColors.draft;
+            return (
+              <div key={land.id} className="panel" style={{ display: "flex", alignItems: "center", gap: "1rem", flexWrap: "wrap" }}>
+                <div style={{ flex: 1 }}>
+                  <h3 style={{ margin: 0 }}>{land.title}</h3>
+                  <p style={{ margin: "0.25rem 0 0", opacity: 0.7, fontSize: "0.875rem" }}>
+                    Propietario: {land.ownerEmail}
+                  </p>
+                  <p style={{ margin: "0.25rem 0 0", opacity: 0.5, fontSize: "0.75rem" }}>
+                    ID: {land.id}
+                  </p>
+                </div>
+                <span style={{
+                  display: "inline-block", padding: "0.25rem 0.75rem",
+                  borderRadius: "999px", fontSize: "0.75rem", fontWeight: 700,
+                  background: colors.bg, color: colors.color,
+                }}>
+                  {statusLabels[land.status] ?? land.status}
+                </span>
+                {land.status === "draft" && (
+                  <>
+                    <button
+                      className="btn btn-primary"
+                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem" }}
+                      onClick={() => handleUpdateStatus(land.id, land.status, "active")}
+                    >
+                      Aprobar
+                    </button>
+                    <button
+                      className="btn btn-ghost"
+                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem" }}
+                      onClick={() => handleUpdateStatus(land.id, land.status, "rejected")}
+                    >
+                      Rechazar
+                    </button>
+                  </>
+                )}
+                {land.status === "active" && (
+                  <button
+                    className="btn btn-ghost"
+                    style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem" }}
+                    onClick={() => handleUpdateStatus(land.id, land.status, "inactive")}
+                  >
+                    Desactivar
+                  </button>
+                )}
+              </div>
+            );
+          })}
+          {lands.length === 0 && (
+            <div className="panel" style={{ textAlign: "center", opacity: 0.5, padding: "2rem" }}>
+              No se encontraron terrenos
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/AdminUsersPage.jsx
+++ b/apps/web/src/pages/AdminUsersPage.jsx
@@ -1,0 +1,146 @@
+import { useState, useEffect } from "react";
+import { listAdminUsers, updateUserStatus, setTokenFn } from "../services/adminApi";
+import { useUser } from "@clerk/clerk-react";
+
+const roleLabel = { user: "Usuario", admin: "Admin" };
+const statusLabel = { active: "Activo", blocked: "Bloqueado" };
+
+export default function AdminUsersPage() {
+  const { user } = useUser();
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [filter, setFilter] = useState("all");
+  const [search, setSearch] = useState("");
+  const [actionMsg, setActionMsg] = useState("");
+
+  // Inject Clerk token into API client
+  useEffect(() => {
+    if (user) {
+      user.getToken().then((token) => setTokenFn(() => token));
+    }
+  }, [user]);
+
+  const loadUsers = () => {
+    setLoading(true);
+    setError("");
+    const filters = {};
+    if (filter === "active" || filter === "blocked") filters.status = filter;
+    if (search.trim()) filters.search = search.trim();
+
+    listAdminUsers(filters)
+      .then((res) => setUsers(res.data?.items ?? []))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { loadUsers(); }, [filter, search]);
+
+  const handleToggleStatus = async (userId, currentStatus) => {
+    const nextStatus = currentStatus === "active" ? "blocked" : "active";
+    try {
+      await updateUserStatus(userId, nextStatus);
+      setUsers((prev) =>
+        prev.map((u) => u.id === userId ? { ...u, status: nextStatus } : u)
+      );
+      setActionMsg(`Usuario ${nextStatus === "blocked" ? "bloqueado" : "activado"}`);
+    } catch (e) {
+      setError(e.message);
+    }
+    setTimeout(() => setActionMsg(""), 3000);
+  };
+
+  const filtered = users; // Backend already filters
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Gestión de Usuarios</h1>
+        <p>Administra cuentas de usuarios y propietarios</p>
+      </div>
+
+      <div className="filters-bar" style={{ marginTop: "1.5rem", display: "flex", gap: "1rem", alignItems: "center", flexWrap: "wrap" }}>
+        <input
+          type="text"
+          placeholder="Buscar por nombre o email..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ maxWidth: "300px", flex: 1 }}
+        />
+        <select value={filter} onChange={(e) => setFilter(e.target.value)}>
+          <option value="all">Todos</option>
+          <option value="active">Activos</option>
+          <option value="blocked">Bloqueados</option>
+        </select>
+        <span style={{ opacity: 0.7 }}>{filtered.length} usuario{filtered.length !== 1 ? "s" : ""}</span>
+        {actionMsg && (
+          <span style={{ color: "var(--leaf-600)", fontWeight: 600 }}>{actionMsg}</span>
+        )}
+      </div>
+
+      {loading && <p className="muted" style={{ marginTop: "1rem" }}>Cargando...</p>}
+      {error && <p className="error-text" style={{ marginTop: "1rem" }}>{error}</p>}
+
+      {!loading && !error && (
+        <div className="panel" style={{ marginTop: "1rem" }}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Nombre</th>
+                <th>Email</th>
+                <th>Rol</th>
+                <th>Estado</th>
+                <th>Fecha de registro</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((u) => (
+                <tr key={u.id}>
+                  <td style={{ fontWeight: 700 }}>{u.profile.fullName}</td>
+                  <td>{u.email}</td>
+                  <td>
+                    <span className="role-badge" style={{
+                      display: "inline-block", padding: "0.2rem 0.5rem",
+                      borderRadius: "999px", fontSize: "0.75rem", fontWeight: 700,
+                      background: u.role === "owner"
+                        ? "rgba(13, 111, 147, 0.15)"
+                        : "rgba(11, 95, 55, 0.15)",
+                      color: u.role === "owner" ? "var(--river-500)" : "var(--leaf-700)",
+                    }}>
+                      {roleLabel[u.role] ?? u.role}
+                    </span>
+                  </td>
+                  <td>
+                    <span className={`status-badge status-${u.status === "active" ? "active" : "blocked"}`}>
+                      {statusLabel[u.status] ?? u.status}
+                    </span>
+                  </td>
+                  <td style={{ opacity: 0.7 }}>
+                    {new Date(u.createdAt).toLocaleDateString("es-PA")}
+                  </td>
+                  <td>
+                    <button
+                      className={`btn ${u.status === "active" ? "btn-ghost" : "btn-primary"}`}
+                      onClick={() => handleToggleStatus(u.id, u.status)}
+                      style={{ fontSize: "0.75rem", padding: "0.25rem 0.5rem" }}
+                    >
+                      {u.status === "active" ? "Bloquear" : "Activar"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={6} style={{ textAlign: "center", opacity: 0.5, padding: "2rem" }}>
+                    No se encontraron usuarios
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/services/adminApi.js
+++ b/apps/web/src/services/adminApi.js
@@ -1,0 +1,67 @@
+/**
+ * Admin API client — connects to backend-api admin endpoints.
+ * Auth: Bearer token from Clerk via setTokenFn.
+ */
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+
+let authTokenFn = () => null;
+export const setTokenFn = (fn) => { authTokenFn = fn; };
+
+const buildHeaders = () => {
+  const headers = { "Content-Type": "application/json" };
+  const token = authTokenFn();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return headers;
+};
+
+const handleResponse = async (res) => {
+  if (!res.ok) {
+    let err;
+    try { err = await res.json(); } catch { err = {}; }
+    throw new Error(err?.error?.message || `HTTP ${res.status}`);
+  }
+  return res.json();
+};
+
+const request = (method, path, body) =>
+  fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: buildHeaders(),
+    body: body != null ? JSON.stringify(body) : undefined,
+  }).then(handleResponse);
+
+// ─── Users ───────────────────────────────────────────────────────────────────
+
+/** GET /api/v1/admin/users?role=&status=&search= */
+export const listAdminUsers = (filters = {}) => {
+  const params = new URLSearchParams();
+  if (filters.role) params.set("role", filters.role);
+  if (filters.status) params.set("status", filters.status);
+  if (filters.search) params.set("search", filters.search);
+  const qs = params.toString();
+  return request("GET", `/api/v1/admin/users${qs ? `?${qs}` : ""}`);
+};
+
+/** GET /api/v1/admin/users/:userId */
+export const getAdminUser = (userId) =>
+  request("GET", `/api/v1/admin/users/${userId}`);
+
+/** PATCH /api/v1/admin/users/:userId/status — { status: "active"|"blocked" } */
+export const updateUserStatus = (userId, status) =>
+  request("PATCH", `/api/v1/admin/users/${userId}/status`, { status });
+
+// ─── Lands ───────────────────────────────────────────────────────────────────
+
+/** GET /api/v1/admin/lands?status=&search= */
+export const listAdminLands = (filters = {}) => {
+  const params = new URLSearchParams();
+  if (filters.status) params.set("status", filters.status);
+  if (filters.search) params.set("search", filters.search);
+  const qs = params.toString();
+  return request("GET", `/api/v1/admin/lands${qs ? `?${qs}` : ""}`);
+};
+
+/** PATCH /api/v1/admin/lands/:landId/status — { status: "active"|"inactive"|"rejected" } */
+export const updateLandStatus = (landId, status) =>
+  request("PATCH", `/api/v1/admin/lands/${landId}/status`, { status });


### PR DESCRIPTION
## Issue
Closes #8

## Qué se hizo

### Backend
- **Nuevo archivo:** `apps/backend-api/src/routes/admin.ts`
  - `GET /api/v1/admin/users` — lista usuarios con filtros (role, status, search)
  - `GET /api/v1/admin/users/:userId` — detalle de usuario
  - `PATCH /api/v1/admin/users/:userId/status` — bloquear/activar usuario
  - `GET /api/v1/admin/lands` — lista terrenos con filtros (status, search)
  - `PATCH /api/v1/admin/lands/:landId/status` — aprobar/rechazar terreno
- **Seed users:** 5 usuarios en el store (owner×2, tenant×2, admin×1)
- **Audit events:** se registran bloqueos de usuarios y approve/reject de terrenos
- **`API_ENDPOINTS.md`:** documentados los nuevos endpoints admin

### Frontend (`apps/web`)
- **Nuevo:** `services/adminApi.js` — cliente para todos los endpoints admin
- **Nuevo:** `pages/AdminUsersPage.jsx` — tabla de usuarios con filtros y botones block/unlock
- **Nuevo:** `pages/AdminLandsPage.jsx` — lista de terrenos pendientes con aprobar/rechazar
- **Actualizado:** `AdminDashboardPage` — stats en vivo desde la API
- **Nuevas rutas:** `/dashboard/admin/users`, `/dashboard/admin/lands`
- **`.env`:** configurada Clerk key pública

## Tests
- Backend tests pasan: `bun test` → 13 pass, 0 fail
- Build pasa: `bun run build` → 263KB JS, sin errores