### PR TITLE
feat(app-web): #14 — Catalogo con listado y filtros

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2,11 +2,14 @@ import { useState, useEffect } from "react";
 import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import LandingPage from "./pages/LandingPage";
+import CatalogPage from "./pages/CatalogPage";
+import LandDetailPage from "./pages/LandDetailPage";
 import Login from "./components/Login";
 import Register from "./components/Register";
 import AdminUsersPage from "./pages/AdminUsersPage";
 import AdminLandsPage from "./pages/AdminLandsPage";
 import { setTokenFn as setAdminTokenFn } from "./services/adminApi";
+import { setTokenFn as setApiTokenFn } from "./services/api";
 
 function ProtectedRoute({ children }) {
   const { isLoaded } = useClerk();
@@ -174,11 +177,13 @@ export default function App() {
   const { signOut } = useClerk();
   const { isSignedIn, isLoaded } = useUser();
 
-  // Inject Clerk token for admin API calls
-  const { user } = useUser();
+  // Inject Clerk token for API calls
   useEffect(() => {
     if (user) {
-      user.getToken().then((token) => setAdminTokenFn(() => token));
+      user.getToken().then((token) => {
+        setAdminTokenFn(() => token);
+        setApiTokenFn(() => token);
+      });
     }
   }, [user]);
 
@@ -199,6 +204,8 @@ export default function App() {
   return (
     <Routes>
       <Route path="/" element={<LandingPage />} />
+      <Route path="/catalog" element={<CatalogPage />} />
+      <Route path="/lands/:landId" element={<LandDetailPage />} />
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
       <Route path="/dashboard" element={

--- a/apps/web/src/pages/CatalogPage.jsx
+++ b/apps/web/src/pages/CatalogPage.jsx
@@ -1,0 +1,177 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useClerk } from "@clerk/clerk-react";
+import { listLands, adaptLand } from "../services/api";
+
+const TIPOS_USO = [
+  { value: "all", label: "Todos los tipos" },
+  { value: "agricultura", label: "Agricultura" },
+  { value: "ganaderia", label: "Ganaderia" },
+  { value: "forestal", label: "Forestal" },
+  { value: "acuicultura", label: "Acuicultura" },
+  { value: "mixto", label: "Mixto" },
+  { value: "otro", label: "Otro" },
+];
+
+const PROVINCIAS = [
+  { value: "", label: "Todas las provincias" },
+  { value: "Bocas del Toro", label: "Bocas del Toro" },
+  { value: "Cocle", label: "Cocle" },
+  { value: "Colon", label: "Colon" },
+  { value: "Chiriqui", label: "Chiriqui" },
+  { value: "Darien", label: "Darien" },
+  { value: " Herrera", label: "Herrera" },
+  { value: "Los Santos", label: "Los Santos" },
+  { value: "Panama", label: "Panama" },
+  { value: "Veraguas", label: "Veraguas" },
+];
+
+export default function CatalogPage() {
+  const { openSignUp } = useClerk();
+  const [filters, setFilters] = useState({
+    type: "all",
+    location: "",
+    maxPrice: "",
+    availableOn: "",
+  });
+  const [lands, setLands] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError("");
+
+    const load = async () => {
+      try {
+        const raw = await listLands(filters);
+        if (active) setLands(raw.map(adaptLand));
+      } catch (e) {
+        if (active) setError(e.message);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    load();
+    return () => { active = false; };
+  }, [filters]);
+
+  const handleFilterChange = (field, value) => {
+    setFilters((prev) => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <div className="page-shell">
+      <div className="ambient ambient-left" aria-hidden="true" />
+      <div className="ambient ambient-right" aria-hidden="true" />
+
+      <header className="top-nav">
+        <Link to="/" className="brand">TerraShare</Link>
+        <nav className="menu">
+          <Link to="/catalog" className="active">Explorar</Link>
+          <Link to="/login">Iniciar sesion</Link>
+        </nav>
+        <button className="btn btn-primary" onClick={() => openSignUp({})}>
+          Crear cuenta
+        </button>
+      </header>
+
+      <main>
+        <div className="section-header" style={{ marginBottom: "1.25rem" }}>
+          <h1>Catalogo de terrenos</h1>
+          <p>
+            Explora terrenos disponibles en Panama. Sin registro puedes
+            navegar y filtrar; activa tu cuenta para solicitar.
+          </p>
+        </div>
+
+        {/* ── Filtros ─────────────────────────────── */}
+        <div className="panel filters-panel">
+          <div className="filters-grid">
+            <label>
+              Tipo de uso
+              <select
+                value={filters.type}
+                onChange={(e) => handleFilterChange("type", e.target.value)}
+              >
+                {TIPOS_USO.map((t) => (
+                  <option key={t.value} value={t.value}>{t.label}</option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              Provincia
+              <select
+                value={filters.location}
+                onChange={(e) => handleFilterChange("location", e.target.value)}
+              >
+                {PROVINCIAS.map((p) => (
+                  <option key={p.value} value={p.value}>{p.label}</option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              Precio max/mes (USD)
+              <input
+                type="number"
+                placeholder="Ej: 800"
+                value={filters.maxPrice}
+                onChange={(e) => handleFilterChange("maxPrice", e.target.value)}
+                min="0"
+              />
+            </label>
+
+            <label>
+              Disponible desde
+              <input
+                type="date"
+                value={filters.availableOn}
+                onChange={(e) => handleFilterChange("availableOn", e.target.value)}
+              />
+            </label>
+          </div>
+        </div>
+
+        {/* ── Resultados ──────────────────────────── */}
+        <div className="panel results-panel">
+          {loading ? (
+            <p style={{ textAlign: "center", padding: "2rem" }}>Cargando terrenos...</p>
+          ) : error ? (
+            <div className="toast toast-error">
+              <strong>Error</strong>
+              <p>{error}</p>
+            </div>
+          ) : lands.length === 0 ? (
+            <div style={{ textAlign: "center", padding: "2rem" }}>
+              <h3>No hay terrenos con esos filtros</h3>
+              <p>Intenta ampliar los criterios de busqueda.</p>
+            </div>
+          ) : (
+            <div className="cards-grid">
+              {lands.map((land) => (
+                <article key={land.id} className="land-card">
+                  <p className="card-badge">{land.type}</p>
+                  <h3>{land.title}</h3>
+                  <p>{land.province}{land.district ? `, ${land.district}` : ""}</p>
+                  <p>
+                    {land.areaHectares} ha &middot;{" "}
+                    {land.monthlyPrice > 0 ? `$${land.monthlyPrice}/mes` : "Precio variable"}
+                  </p>
+                  <div className="card-actions">
+                    <Link to={`/lands/${land.id}`} className="btn btn-primary">
+                      Ver detalle
+                    </Link>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/pages/LandDetailPage.jsx
+++ b/apps/web/src/pages/LandDetailPage.jsx
@@ -1,0 +1,136 @@
+import { useState, useEffect } from "react";
+import { Link, useParams, useNavigate } from "react-router-dom";
+import { useClerk } from "@clerk/clerk-react";
+import { getLandById, adaptLand } from "../services/api";
+
+export default function LandDetailPage() {
+  const { landId } = useParams();
+  const navigate = useNavigate();
+  const { openSignUp, isSignedIn } = useClerk();
+
+  const [land, setLand] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!landId) return;
+    let active = true;
+    setLoading(true);
+    setError("");
+
+    const load = async () => {
+      try {
+        const raw = await getLandById(landId);
+        if (active) setLand(adaptLand(raw));
+      } catch (e) {
+        if (active) setError(e.message);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    load();
+    return () => { active = false; };
+  }, [landId]);
+
+  const handleReservar = () => {
+    if (!isSignedIn) {
+      navigate("/login", { state: { from: `/lands/${landId}` } });
+    } else {
+      navigate(`/reserve/${landId}`, { state: { land } });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="page-shell">
+        <div className="panel" style={{ textAlign: "center", padding: "3rem" }}>
+          <p>Cargando...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page-shell">
+        <div className="toast toast-error" style={{ marginTop: "1rem" }}>
+          <strong>Error</strong>
+          <p>{error}</p>
+        </div>
+        <Link to="/catalog" className="btn btn-ghost" style={{ marginTop: "1rem" }}>
+          Volver al catalogo
+        </Link>
+      </div>
+    );
+  }
+
+  if (!land) return null;
+
+  return (
+    <div className="page-shell">
+      <div className="ambient ambient-left" aria-hidden="true" />
+      <div className="ambient ambient-right" aria-hidden="true" />
+
+      <header className="top-nav">
+        <Link to="/" className="brand">TerraShare</Link>
+        <nav className="menu">
+          <Link to="/catalog">Explorar</Link>
+          <Link to="/login">Iniciar sesion</Link>
+        </nav>
+        <button className="btn btn-primary" onClick={() => openSignUp({})}>
+          Crear cuenta
+        </button>
+      </header>
+
+      <main>
+        <Link to="/catalog" className="btn btn-ghost" style={{ marginBottom: "1rem" }}>
+          &larr; Volver al catalogo
+        </Link>
+
+        <div className="panel detail-panel">
+          <div className="detail-grid">
+            <div>
+              <span className="card-badge">{land.type}</span>
+              <h1 style={{ margin: "0.5rem 0" }}>{land.title}</h1>
+              <p style={{ fontSize: "1.05rem", opacity: 0.8 }}>
+                {land.province}{land.district ? `, ${land.district}` : ""}
+                {land.location?.corregimiento ? `, ${land.location.corregimiento}` : ""}
+              </p>
+
+              {land.description && (
+                <p style={{ marginTop: "1rem", lineHeight: 1.6 }}>{land.description}</p>
+              )}
+            </div>
+
+            <div className="detail-card">
+              <h2 style={{ margin: "0 0 1rem" }}>
+                {land.monthlyPrice > 0 ? `$${land.monthlyPrice}` : "Precio variable"}
+                {land.monthlyPrice > 0 && <span style={{ fontSize: "1rem", opacity: 0.7 }}> /mes</span>}
+              </h2>
+              <dl>
+                <dt>Area</dt>
+                <dd>{land.areaHectares} ha</dd>
+                <dt>Tipo</dt>
+                <dd>{land.type}</dd>
+                <dt>Disponibilidad</dt>
+                <dd>
+                  {land.availableFrom
+                    ? `Desde ${new Date(land.availableFrom).toLocaleDateString("es-PA")}`
+                    : "Disponible"}
+                </dd>
+              </dl>
+              <button
+                className="btn btn-primary"
+                style={{ width: "100%", marginTop: "1rem" }}
+                onClick={handleReservar}
+              >
+                {isSignedIn ? "Solicitar este terreno" : "Iniciar sesion para solicitar"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/services/api.js
+++ b/apps/web/src/services/api.js
@@ -1,0 +1,87 @@
+/**
+ * API client para apps/web — conecta con backend-api.
+ *
+ * Base URL: VITE_API_BASE_URL (definida en .env)
+ * Auth: Authorization: Bearer <clerk_token>
+ */
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+
+let authTokenFn = () => null;
+export const setTokenFn = (fn) => {
+  authTokenFn = fn;
+};
+
+const buildHeaders = () => {
+  const headers = { "Content-Type": "application/json" };
+  const token = authTokenFn();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return headers;
+};
+
+const handleResponse = async (res) => {
+  if (!res.ok) {
+    let body;
+    try { body = await res.json(); } catch { body = {}; }
+    const msg = body?.error?.message || body?.message || `HTTP ${res.status}: ${res.statusText}`;
+    throw new Error(msg);
+  }
+  return res.json();
+};
+
+const request = async (method, path, body) => {
+  const opts = { method, headers: buildHeaders() };
+  if (body != null) opts.body = JSON.stringify(body);
+  const res = await fetch(`${BASE_URL}${path}`, opts);
+  return handleResponse(res);
+};
+
+// ─── Lands ───────────────────────────────────────────────────────────────────
+
+/** GET /api/v1/lands — listado con filtros (use, province, district, priceMax, availableFrom, sort, order) */
+export const listLands = async (filters = {}) => {
+  const params = new URLSearchParams();
+  if (filters.type && filters.type !== "all") params.set("use", filters.type);
+  if (filters.location) {
+    params.set("province", filters.location);
+  }
+  if (filters.maxPrice) params.set("priceMax", filters.maxPrice);
+  if (filters.availableOn) params.set("availableFrom", filters.availableOn);
+  params.set("sort", filters.sort || "createdAt");
+  params.set("order", filters.order || "desc");
+  if (filters.page) params.set("page", filters.page);
+  if (filters.pageSize) params.set("pageSize", filters.pageSize);
+
+  const qs = params.toString();
+  const res = await request("GET", `/api/v1/lands${qs ? `?${qs}` : ""}`);
+  return res?.data?.items ?? [];
+};
+
+/** GET /api/v1/lands/:landId */
+export const getLandById = async (landId) => {
+  const res = await request("GET", `/api/v1/lands/${landId}`);
+  return res?.data ?? null;
+};
+
+// ─── Field adapters ───────────────────────────────────────────────────────────────
+
+/**
+ * Traduce LandRecord del backend al formato que espera el UI.
+ * Backend: priceRule.pricePerMonth, location.{province,district}, area, allowedUses, availability
+ * UI:     monthlyPrice, province, district, areaHectares, type, availableFrom, availableTo
+ */
+export const adaptLand = (land) => {
+  if (!land) return null;
+  return {
+    ...land,
+    monthlyPrice: land.priceRule?.pricePerMonth ?? land.monthlyPrice ?? 0,
+    province: land.location?.province ?? land.province ?? "",
+    district: land.location?.district ?? land.district ?? "",
+    areaHectares: land.area ?? land.areaHectares ?? 0,
+    type: land.allowedUses?.[0] ?? land.type ?? "",
+    availableFrom: land.availability?.availableFrom ?? land.availableFrom ?? "",
+    availableTo: land.availability?.availableTo ?? land.availableTo ?? "",
+  };
+};
+
+export const api = { setTokenFn, listLands, getLandById, adaptLand };

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -212,9 +212,27 @@ textarea:focus {
   padding: 0.95rem;
 }
 
-.land-card h2 {
-  margin: 0.45rem 0;
-  font-size: 1.2rem;
+.land-card h3 {
+  margin: 0.4rem 0;
+  font-size: 1.15rem;
+}
+
+.land-card p {
+  margin: 0.3rem 0;
+  line-height: 1.45;
+}
+
+.filters-panel {
+  margin-top: 0.85rem;
+}
+
+.results-panel {
+  margin-top: 0.75rem;
+}
+
+
+.detail-panel {
+  margin-top: 0.85rem;
 }
 
 .card-badge {


### PR DESCRIPTION
## Issues
Closes #14

## Qué se hizo

### services/api.js
- listLands(filters) — GET /api/v1/lands con filtros (type, location, maxPrice, availableOn, sort, order)
- getLandById(landId) — GET /api/v1/lands/:landId
- adaptLand() — traduce campos del backend al formato del UI
- setTokenFn() — inyección de Bearer token (Clerk)

### pages/CatalogPage.jsx
- Filtros: tipo de uso, provincia, precio max/mes, fecha disponibilidad
- Listado reactivo de land-cards con datos reales del API
- Estados: loading, error, empty (sin resultados)
- Link a detalle del terreno

### pages/LandDetailPage.jsx
- Muestra: título, ubicación, descripción, precio/mes, área, tipo, disponibilidad
- Botón Solicitar — redirige a /login si no autenticado
- Link Volver al catálogo

### App.jsx
- Rutas /catalog y /lands/:landId
- Token injection para api.js (setApiTokenFn)

### styles.css
- .land-card h3, .filters-panel, .results-panel, .detail-panel

## Tests
- bun run build → 273.09 kB JS, 11.87 kB CSS, 0 errores