### PR TITLE
fix(ci): workflows + require-auth + e2e tests

### DIFF
--- a/.github/workflows/app-web-e2e.yml
+++ b/.github/workflows/app-web-e2e.yml
@@ -1,57 +1,28 @@
-name: App Web CI
+name: Web Auth CI
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - "apps/app-web/**"
-      - "packages/shared/**"
+      - "apps/web/**"
       - ".github/workflows/app-web-e2e.yml"
   push:
     branches: [main]
     paths:
-      - "apps/app-web/**"
-      - "packages/shared/**"
+      - "apps/web/**"
       - ".github/workflows/app-web-e2e.yml"
 
 permissions:
   contents: read
 
 jobs:
-  shared-typecheck:
-    name: TypeScript check (shared)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: contains(github.event.head_commit.modified, 'packages/shared')
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-        working-directory: packages/shared
-
-      - name: Build shared
-        run: bun run build
-        working-directory: packages/shared
-
-      - name: TypeScript check
-        run: bun run typecheck
-        working-directory: packages/shared
-
   build-and-e2e:
-    name: Build and E2E (app-web)
+    name: Build and E2E (auth flow)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
       run:
-        working-directory: apps/app-web
-    needs: shared-typecheck
+        working-directory: apps/web
 
     steps:
       - name: Checkout repository
@@ -68,16 +39,16 @@ jobs:
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium
 
-      - name: Build app-web
+      - name: Build web app
         run: bun run build
 
-      - name: Run E2E smoke tests
-        run: bun run test:e2e
+      - name: Run auth smoke tests
+        run: bun run test:e2e -- tests/e2e/auth-protected.smoke.spec.js
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-app-web
-          path: apps/app-web/playwright-report
+          name: playwright-report-web-auth
+          path: apps/web/playwright-report
           if-no-files-found: ignore

--- a/.github/workflows/backend-api-ci.yml
+++ b/.github/workflows/backend-api-ci.yml
@@ -1,0 +1,45 @@
+name: Backend API CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/backend-api/**"
+      - "packages/shared/**"
+      - ".github/workflows/backend-api-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/backend-api/**"
+      - "packages/shared/**"
+      - ".github/workflows/backend-api-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-typecheck:
+    name: Test and TypeScript check (backend-api)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/backend-api
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run backend tests
+        run: bun test
+
+      - name: TypeScript check
+        run: bun run typecheck

--- a/.github/workflows/landing-e2e.yml
+++ b/.github/workflows/landing-e2e.yml
@@ -1,15 +1,15 @@
-name: Landing CI
+name: Web Public CI
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - "apps/landing/**"
+      - "apps/web/**"
       - ".github/workflows/landing-e2e.yml"
   push:
     branches: [main]
     paths:
-      - "apps/landing/**"
+      - "apps/web/**"
       - ".github/workflows/landing-e2e.yml"
 
 permissions:
@@ -17,12 +17,12 @@ permissions:
 
 jobs:
   build-and-e2e:
-    name: Build and E2E (landing)
+    name: Build and E2E (public landing/catalog)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
       run:
-        working-directory: apps/landing
+        working-directory: apps/web
 
     steps:
       - name: Checkout repository
@@ -39,16 +39,16 @@ jobs:
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium
 
-      - name: Build landing
+      - name: Build web app
         run: bun run build
 
-      - name: Run E2E smoke tests
-        run: bun run test:e2e
+      - name: Run public smoke tests
+        run: bun run test:e2e -- tests/e2e/landing.smoke.spec.js
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-landing
-          path: apps/landing/playwright-report
+          name: playwright-report-web-public
+          path: apps/web/playwright-report
           if-no-files-found: ignore

--- a/.github/workflows/landing-e2e.yml
+++ b/.github/workflows/landing-e2e.yml
@@ -43,7 +43,7 @@ jobs:
         run: bun run build
 
       - name: Run public smoke tests
-        run: bun run test:e2e -- tests/e2e/landing.smoke.spec.js
+        run: bun run test:e2e -- tests/e2e/public.smoke.spec.js
 
       - name: Upload Playwright report
         if: always()

--- a/apps/backend-api/src/middleware/require-auth.ts
+++ b/apps/backend-api/src/middleware/require-auth.ts
@@ -5,6 +5,7 @@ import { env } from "../config/env";
 import { failure } from "../lib/api-response";
 import type { AuthContextUser } from "../types";
 import { mapClerkClaimsToAuthUser } from "../lib/clerk-user";
+import { getStore } from "../store/in-memory-db";
 import type { AppEnv } from "../types";
 
 let jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
@@ -27,10 +28,34 @@ function getBearerToken(authorizationHeader: string | undefined): string | undef
   return token;
 }
 
+function upsertAuthUser(authUser: AuthContextUser) {
+  const store = getStore();
+  const existing = store.users.get(authUser.id);
+
+  if (!existing) {
+    store.users.set(authUser.id, authUser);
+    return authUser;
+  }
+
+  const merged: AuthContextUser = {
+    ...existing,
+    ...authUser,
+    profile: {
+      ...existing.profile,
+      ...authUser.profile,
+    },
+    role: authUser.role === "admin" ? "admin" : existing.role,
+    status: existing.status,
+  };
+
+  store.users.set(authUser.id, merged);
+  return merged;
+}
+
 export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   const roleHeader = c.req.header("x-dev-role");
   const userIdHeader = c.req.header("x-dev-user-id");
-  if (roleHeader || userIdHeader) {
+  if ((roleHeader || userIdHeader) && env.allowDevAuthBypass) {
     const devUser: AuthContextUser = {
       id: userIdHeader ?? "dev_user",
       clerkUserId: userIdHeader ?? "dev_user",
@@ -39,7 +64,13 @@ export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
       status: "active",
       profile: { fullName: "Developer" },
     };
-    c.set("authUser", devUser);
+
+    const persistedDevUser = upsertAuthUser(devUser);
+    if (persistedDevUser.status !== "active") {
+      return failure(c, 403, "FORBIDDEN", "User is blocked");
+    }
+
+    c.set("authUser", persistedDevUser);
     await next();
     return;
   }
@@ -56,11 +87,13 @@ export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     });
 
     const authUser = mapClerkClaimsToAuthUser(payload);
-    if (authUser.status !== "active") {
+    const persistedUser = upsertAuthUser(authUser);
+
+    if (persistedUser.status !== "active") {
       return failure(c, 403, "FORBIDDEN", "User is blocked");
     }
 
-    c.set("authUser", authUser);
+    c.set("authUser", persistedUser);
     await next();
   } catch {
     return failure(c, 401, "UNAUTHORIZED", "Invalid or expired token");

--- a/apps/web/playwright.config.js
+++ b/apps/web/playwright.config.js
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ["list"],
+    ["html", { open: "never" }]
+  ],
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry"
+  },
+  webServer: {
+    command: "bun run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/apps/web/tests/e2e/public.smoke.spec.js
+++ b/apps/web/tests/e2e/public.smoke.spec.js
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Smoke E2E navegacion publica", () => {
+  test("landing: carga correcta de hero y elementos principales", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: /Terrenos productivos/ })).toBeVisible();
+
+    await expect(page.getByRole("link", { name: /Ver catalogo/ })).toBeVisible();
+
+    await expect(page.getByRole("button", { name: /Publicar mi terreno/ })).toBeVisible();
+  });
+
+  test("catalogo: acceso sin login y filtros basicos", async ({ page }) => {
+    await page.goto("/catalog");
+
+    await expect(page.getByRole("heading", { name: /Catalogo de Terrenos/ })).toBeVisible();
+
+    await expect(page.getByText("Finca El Tamarindo")).toBeVisible();
+    await expect(page.getByText("Lote Vista Caisan")).toBeVisible();
+    await expect(page.getByText("Parcela Rio Indio")).toBeVisible();
+
+    await page.getByRole("button", { name: "Ganaderia" }).click();
+
+    await expect(page.getByText("Lote Vista Caisan")).toBeVisible();
+    await expect(page.getByText("Finca El Tamarindo")).toHaveCount(0);
+    await expect(page.getByText("Parcela Rio Indio")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Agricultura" }).click();
+
+    await expect(page.getByText("Finca El Tamarindo")).toBeVisible();
+    await expect(page.getByText("Parcela Rio Indio")).toBeVisible();
+    await expect(page.getByText("Lote Vista Caisan")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Todos" }).click();
+
+    await expect(page.getByText("Finca El Tamarindo")).toBeVisible();
+    await expect(page.getByText("Lote Vista Caisan")).toBeVisible();
+    await expect(page.getByText("Parcela Rio Indio")).toBeVisible();
+  });
+
+  test("landing: navegacion hacia catalogo funciona", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "Ver catalogo" }).click();
+
+    await expect(page).toHaveURL(/.*\/catalog/);
+    await expect(page.getByRole("heading", { name: /Catalogo de Terrenos/ })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Update app-web-e2e.yml and landing-e2e.yml workflows for apps/web rename
- Add new backend-api-ci.yml workflow for backend API tests
- Fix require-auth.ts middleware to persist auth users to in-memory store
- Add Playwright config and e2e smoke tests for web app

## Changes
- `.github/workflows/app-web-e2e.yml` - workflow actualizado
- `.github/workflows/backend-api-ci.yml` - nuevo workflow
- `.github/workflows/landing-e2e.yml` - workflow actualizado
- `apps/backend-api/src/middleware/require-auth.ts` - fix de auth
- `apps/web/playwright.config.js` - config de Playwright
- `apps/web/tests/e2e/public.smoke.spec.js` - test e2e de smoke