### PR TITLE
feat(app-web): #18 — Chat interno visual (solo front)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -5,6 +5,7 @@ import LandingPage from "./pages/LandingPage";
 import CatalogPage from "./pages/CatalogPage";
 import LandDetailPage from "./pages/LandDetailPage";
 import ReservePage from "./pages/ReservePage";
+import ChatPage from "./pages/ChatPage";
 import Login from "./components/Login";
 import Register from "./components/Register";
 
@@ -120,6 +121,9 @@ function DashboardPage() {
       </div>
       <div className="panel" style={{ marginTop: "1.5rem" }}>
         <p>Contenido del dashboard (en desarrollo)</p>
+        <div style={{ marginTop: "1rem", display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          <Link to="/chat" className="btn btn-primary">Ir al chat</Link>
+        </div>
       </div>
     </div>
   );
@@ -204,6 +208,11 @@ export default function App() {
           <DashboardLayout onSignOut={handleSignOut}>
             <DashboardPage />
           </DashboardLayout>
+        </ProtectedRoute>
+      } />
+      <Route path="/chat" element={
+        <ProtectedRoute>
+          <ChatPage />
         </ProtectedRoute>
       } />
       <Route path="/dashboard/admin" element={

--- a/apps/web/src/pages/ChatPage.jsx
+++ b/apps/web/src/pages/ChatPage.jsx
@@ -1,0 +1,117 @@
+import { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
+import { useClerk } from "@clerk/clerk-react";
+
+const STORAGE_KEY = "terrashare_chat_messages";
+
+function loadMessages() {
+  try {
+    return JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "[]");
+  } catch {
+    return [];
+  }
+}
+
+function saveMessages(msgs) {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(msgs));
+}
+
+export default function ChatPage() {
+  const { user } = useClerk();
+  const [messages, setMessages] = useState(loadMessages);
+  const [input, setInput] = useState("");
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSend = (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+
+    const newMsg = {
+      id: `msg_${Date.now()}`,
+      text: input.trim(),
+      sender: user?.primaryEmailAddress?.emailAddress ?? "Tú",
+      timestamp: new Date().toISOString(),
+    };
+
+    const updated = [...messages, newMsg];
+    setMessages(updated);
+    saveMessages(updated);
+    setInput("");
+  };
+
+  const handleClear = () => {
+    setMessages([]);
+    sessionStorage.removeItem(STORAGE_KEY);
+  };
+
+  return (
+    <div className="page-shell">
+      <div className="ambient ambient-left" aria-hidden="true" />
+      <div className="ambient ambient-right" aria-hidden="true" />
+
+      <header className="top-nav">
+        <Link to="/" className="brand">TerraShare</Link>
+        <nav className="menu">
+          <Link to="/catalog">Explorar</Link>
+          <Link to="/dashboard">Mis solicitudes</Link>
+        </nav>
+      </header>
+
+      <main>
+        <div className="section-header" style={{ marginBottom: "1rem" }}>
+          <h1>Chat interno</h1>
+          <p>Conversacion con el arrendador/propietario. Los mensajes se borran al cerrar el navegador.</p>
+        </div>
+
+        <div className="panel chat-panel">
+          <div className="chat-messages" id="chat-messages">
+            {messages.length === 0 ? (
+              <p className="chat-empty">Sin mensajes aun. Escribe algo para comenzar.</p>
+            ) : (
+              messages.map((msg) => (
+                <div
+                  key={msg.id}
+                  className={`chat-bubble ${msg.sender === (user?.primaryEmailAddress?.emailAddress ?? "Tú") ? "chat-mine" : "chat-theirs"}`}
+                >
+                  <span className="chat-sender">{msg.sender}</span>
+                  <p className="chat-text">{msg.text}</p>
+                  <span className="chat-time">
+                    {new Date(msg.timestamp).toLocaleTimeString("es-PA", {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </span>
+                </div>
+              ))
+            )}
+            <div ref={bottomRef} />
+          </div>
+
+          <form className="chat-input-row" onSubmit={handleSend}>
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Escribe un mensaje..."
+              className="chat-input"
+              disabled={!user?.primaryEmailAddress}
+            />
+            <button type="submit" className="btn btn-primary" disabled={!input.trim()}>
+              Enviar
+            </button>
+          </form>
+
+          {messages.length > 0 && (
+            <button className="text-button" onClick={handleClear} style={{ marginTop: "0.5rem" }}>
+              Limpiar chat
+            </button>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1593,3 +1593,84 @@ select:focus {
     transform: translateY(0);
   }
 }
+/* ── Chat ──────────────────────────────────────────────────────── */
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  height: 65vh;
+  min-height: 400px;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  border: 1px solid rgba(19, 33, 24, 0.1);
+  border-radius: 12px;
+  margin-bottom: 0.75rem;
+  background: var(--paper);
+}
+
+.chat-empty {
+  text-align: center;
+  opacity: 0.5;
+  margin: auto;
+}
+
+.chat-bubble {
+  max-width: 75%;
+  padding: 0.6rem 0.85rem;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.chat-mine {
+  align-self: flex-end;
+  background: linear-gradient(135deg, var(--leaf-700), var(--leaf-900));
+  color: white;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-theirs {
+  align-self: flex-start;
+  background: rgba(19, 33, 24, 0.08);
+  color: var(--ink-900);
+  border-bottom-left-radius: 4px;
+}
+
+.chat-sender {
+  font-size: 0.75rem;
+  font-weight: 700;
+  opacity: 0.7;
+}
+
+.chat-text {
+  margin: 0;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.chat-time {
+  font-size: 0.7rem;
+  opacity: 0.6;
+  align-self: flex-end;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.chat-input {
+  flex: 1;
+}
+
+.chat-input-row .btn {
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Issues
Closes #18

## Qué se hizo

Solo front-end — sin backend. Mensajes en sessionStorage (se borran al cerrar navegador).

### pages/ChatPage.jsx
- Chat con burbujas estilo WhatsApp (mine/theirs)
- Mensajes guardados en sessionStorage
- Input + botón enviar
- Botón Limpiar chat
- Scroll automático al último mensaje
- Protegido con ProtectedRoute (requiere login)

### App.jsx
- Ruta /chat protegida
- DashboardPage ahora tiene botón "Ir al chat"

### styles.css
- .chat-panel, .chat-messages, .chat-bubble, .chat-mine, .chat-theirs
- .chat-sender, .chat-text, .chat-time
- .chat-input-row, .chat-input

## Tests
- bun run build → 270.54 kB JS, 0 errores