### PR TITLE
fix(ci): upload playwright traces on failure in e2e workflows

### DIFF
--- a/.github/workflows/app-web-e2e.yml
+++ b/.github/workflows/app-web-e2e.yml
@@ -52,3 +52,11 @@ jobs:
           name: playwright-report-web-auth
           path: apps/web/playwright-report
           if-no-files-found: ignore
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-web-auth
+          path: apps/web/playwright-report/trace.zip
+          if-no-files-found: ignore

--- a/.github/workflows/landing-e2e.yml
+++ b/.github/workflows/landing-e2e.yml
@@ -52,3 +52,11 @@ jobs:
           name: playwright-report-web-public
           path: apps/web/playwright-report
           if-no-files-found: ignore
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-web-public
+          path: apps/web/playwright-report/trace.zip
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Add Playwright trace upload step on failure in app-web-e2e workflow
- Add Playwright trace upload step on failure in landing-e2e workflow
- Improves debugging when CI tests fail by preserving trace files