### PR TITLE
feat(web): Integración Frontend con Backend - Issue #80

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -9,6 +9,7 @@ import PaymentSuccessPage from "./pages/PaymentSuccessPage";
 import PaymentCancelPage from "./pages/PaymentCancelPage";
 import PaymentButton from "./components/PaymentButton";
 import AdminLandsPage from "./pages/AdminLandsPage";
+import MyLandsPage from "./pages/MyLandsPage";
 import Login from "./components/Login";
 import Register from "./components/Register";
 import { getPaymentsByRequest } from "./services/api";
@@ -345,6 +346,13 @@ export default function App() {
         <ProtectedRoute>
           <DashboardLayout onSignOut={handleSignOut}>
             <DashboardPage />
+          </DashboardLayout>
+        </ProtectedRoute>
+      } />
+      <Route path="/dashboard/lands" element={
+        <ProtectedRoute>
+          <DashboardLayout onSignOut={handleSignOut}>
+            <MyLandsPage />
           </DashboardLayout>
         </ProtectedRoute>
       } />

--- a/apps/web/src/pages/CatalogPage.jsx
+++ b/apps/web/src/pages/CatalogPage.jsx
@@ -1,9 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { filterLands, formatLandUse, getDistinctValues, getLands, getLandPrimaryUse } from "../data/lands";
-
-const USE_FILTERS = ["Todos", ...getDistinctValues((land) => getLandPrimaryUse(land))];
-const PROVINCE_FILTERS = ["Todas", ...getDistinctValues((land) => land.location?.province)];
+import { filterLands, formatLandUse, getLandPrimaryUse } from "../data/lands";
+import { listLands } from "../services/api";
 
 function MapPin({ land, active, onClick }) {
   return (
@@ -27,12 +25,30 @@ export default function CatalogPage() {
   const [maxPrice, setMaxPrice] = useState(700);
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState(null);
+  const [lands, setLands] = useState([]);
+  const [loading, setLoading] = useState(true);
 
-  const lands = getLands();
+  useEffect(() => {
+    const fetchLands = async () => {
+      try {
+        const data = await listLands();
+        setLands(data);
+      } catch (err) {
+        console.error("Error fetching lands:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchLands();
+  }, []);
+
   const filteredLands = useMemo(
     () => filterLands(lands, { type, province, maxPrice, query }),
     [lands, type, province, maxPrice, query],
   );
+
+  const USE_FILTERS = useMemo(() => ["Todos", ...new Set(lands.map((land) => getLandPrimaryUse(land)).filter(Boolean))], [lands]);
+  const PROVINCE_FILTERS = useMemo(() => ["Todas", ...new Set(lands.map((land) => land.location?.province).filter(Boolean))], [lands]);
 
   const selectedLand = filteredLands.find((land) => land.id === selectedId) ?? filteredLands[0] ?? null;
 
@@ -175,11 +191,15 @@ export default function CatalogPage() {
               })}
             </div>
 
-            {filteredLands.length === 0 && (
+            {loading ? (
+              <div className="glass-panel empty-state">
+                <p>Cargando terrenos...</p>
+              </div>
+            ) : filteredLands.length === 0 ? (
               <div className="glass-panel empty-state">
                 <p>No hay terrenos para esos filtros.</p>
               </div>
-            )}
+            ) : null}
           </section>
         </section>
       </main>

--- a/apps/web/src/pages/LandDetailPage.jsx
+++ b/apps/web/src/pages/LandDetailPage.jsx
@@ -1,76 +1,170 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useClerk, useUser } from "@clerk/clerk-react";
-import { getLandById, getLandPrimaryUse, formatLandUse, getChatSeedMessages } from "../data/lands";
+import { getLandPrimaryUse, formatLandUse, getChatSeedMessages } from "../data/lands";
+import { getLandById, getChats, createChat, getMessages, sendMessage, setTokenFn } from "../services/api";
 
-function readChat(landId) {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.sessionStorage.getItem(`terrashare-chat:${landId}`);
-    return raw ? JSON.parse(raw) : getChatSeedMessages(landId);
-  } catch {
-    return getChatSeedMessages(landId);
-  }
-}
+function useChat(landId, isSignedIn, user) {
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [chatId, setChatId] = useState(null);
+  const [error, setError] = useState(null);
 
-function writeChat(landId, messages) {
-  if (typeof window === "undefined") return;
-  window.sessionStorage.setItem(`terrashare-chat:${landId}`, JSON.stringify(messages));
+  useEffect(() => {
+    if (!isSignedIn || !user) {
+      const stored = sessionStorage.getItem(`terrashare-chat:${landId}`);
+      const seed = getChatSeedMessages(landId);
+      setMessages(stored ? JSON.parse(stored) : seed);
+      setLoading(false);
+      return;
+    }
+
+    const initChat = async () => {
+      try {
+        setTokenFn(() => user.getToken());
+        const token = await user.getToken();
+        if (!token) throw new Error("No token");
+
+        const chats = await getChats();
+        let chat = chats.find((c) => c.landId === landId && c.participants.some((p) => p.userId === user.id));
+
+        if (!chat) {
+          chat = await createChat({
+            landId,
+            participants: [{ userId: user.id, role: "tenant" }],
+          });
+        }
+
+        if (chat) {
+          setChatId(chat.id);
+          const msgs = await getMessages(chat.id);
+          setMessages(msgs.map((m) => ({
+            id: m.id,
+            role: m.senderId === user.id ? "tenant" : "owner",
+            text: m.text,
+            createdAt: m.createdAt,
+          })));
+        }
+      } catch (err) {
+        console.error("Error initializing chat:", err);
+        const stored = sessionStorage.getItem(`terrashare-chat:${landId}`);
+        const seed = getChatSeedMessages(landId);
+        setMessages(stored ? JSON.parse(stored) : seed);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    initChat();
+  }, [landId, isSignedIn, user]);
+
+  useEffect(() => {
+    if (!isSignedIn && messages.length > 0) {
+      sessionStorage.setItem(`terrashare-chat:${landId}`, JSON.stringify(messages));
+    }
+  }, [messages, landId, isSignedIn]);
+
+  const addMessage = async (text) => {
+    if (!isSignedIn || !chatId) {
+      const newMsg = {
+        id: crypto.randomUUID(),
+        role: "tenant",
+        text,
+        createdAt: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, newMsg]);
+      return;
+    }
+
+    try {
+      const msg = await sendMessage(chatId, text);
+      setMessages((prev) => [...prev, {
+        id: msg.id,
+        role: "tenant",
+        text: msg.text,
+        createdAt: msg.createdAt,
+      }]);
+    } catch (err) {
+      console.error("Error sending message:", err);
+      const newMsg = {
+        id: crypto.randomUUID(),
+        role: "tenant",
+        text,
+        createdAt: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, newMsg]);
+    }
+  };
+
+  const clearMessages = () => {
+    setMessages([]);
+    if (!isSignedIn) {
+      sessionStorage.removeItem(`terrashare-chat:${landId}`);
+    }
+  };
+
+  return { messages, loading, addMessage, clearMessages };
 }
 
 export default function LandDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { openSignIn } = useClerk();
-  const { isSignedIn } = useUser();
+  const { isSignedIn, user } = useUser();
   const [message, setMessage] = useState("");
-  const [messages, setMessages] = useState([]);
+  const [land, setLand] = useState(null);
+  const [landLoading, setLandLoading] = useState(true);
+  const [landError, setLandError] = useState(null);
 
-  const land = useMemo(() => getLandById(id), [id]);
-
-  useEffect(() => {
-    if (!land) return;
-    setMessages(readChat(land.id));
-  }, [land]);
+  const { messages, loading: chatLoading, addMessage, clearMessages } = useChat(id, isSignedIn, user);
 
   useEffect(() => {
-    if (!land) return;
-    writeChat(land.id, messages);
-  }, [land, messages]);
+    const fetchLand = async () => {
+      try {
+        const data = await getLandById(id);
+        setLand(data);
+      } catch (err) {
+        console.error("Error fetching land:", err);
+        setLandError(err.message);
+      } finally {
+        setLandLoading(false);
+      }
+    };
+    fetchLand();
+  }, [id]);
 
   const handleRequest = async () => {
     if (!isSignedIn) {
       openSignIn({ redirectUrl: `/reserve/${id}` });
       return;
     }
-
     navigate(`/reserve/${id}`);
   };
 
-  const handleSend = (e) => {
+  const handleSend = async (e) => {
     e.preventDefault();
     const text = message.trim();
     if (!text) return;
-
-    setMessages((prev) => [
-      ...prev,
-      {
-        id: crypto.randomUUID(),
-        role: "tenant",
-        text,
-        createdAt: new Date().toISOString(),
-      },
-    ]);
     setMessage("");
+    await addMessage(text);
   };
 
-  const handleClear = () => setMessages([]);
+  if (landLoading) {
+    return (
+      <div className="page-shell">
+        <div className="glass-panel empty-state">
+          <p>Cargando terreno...</p>
+        </div>
+      </div>
+    );
+  }
 
-  if (!land) {
+  if (landError || !land) {
     return (
       <div className="page-shell">
         <div className="glass-panel empty-state">
           <h1>Terreno no encontrado</h1>
+          <p>{landError || "El terreno que buscas no existe."}</p>
           <Link to="/catalog" className="btn btn-primary">Volver al catálogo</Link>
         </div>
       </div>
@@ -99,11 +193,11 @@ export default function LandDetailPage() {
           <div>
             <span className="card-badge">{primaryUse}</span>
             <h1>{land.title}</h1>
-            <p>{land.location.province} · {land.location.district}</p>
+            <p>{land.location?.province} · {land.location?.district}</p>
             <p className="detail-summary">{land.description}</p>
           </div>
           <div className="detail-price-box">
-            <strong>${land.priceRule.pricePerMonth}</strong>
+            <strong>${land.priceRule?.pricePerMonth}</strong>
             <span>/ mes</span>
           </div>
         </section>
@@ -112,7 +206,7 @@ export default function LandDetailPage() {
           <div className="glass-panel detail-main-panel">
             <h2>Características</h2>
             <div className="feature-grid">
-              {land.features.map((feature) => (
+              {(land.features || []).map((feature) => (
                 <div key={feature} className="feature-chip">{feature}</div>
               ))}
             </div>
@@ -133,13 +227,15 @@ export default function LandDetailPage() {
             <div className="chat-header">
               <div>
                 <h2>Chat interno</h2>
-                <p>Solo en el navegador, con sessionStorage.</p>
+                <p>{isSignedIn ? "Mensajes guardados en el servidor" : "Inicia sesión para chatear con el propietario"}</p>
               </div>
-              <button className="btn btn-ghost" onClick={handleClear}>Limpiar</button>
+              <button className="btn btn-ghost" onClick={clearMessages}>Limpiar</button>
             </div>
 
             <div className="chat-thread">
-              {messages.length === 0 ? (
+              {chatLoading ? (
+                <div className="chat-empty">Cargando mensajes...</div>
+              ) : messages.length === 0 ? (
                 <div className="chat-empty">Aún no hay mensajes.</div>
               ) : (
                 messages.map((item) => (
@@ -154,10 +250,11 @@ export default function LandDetailPage() {
               <textarea
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
-                placeholder="Escribe tu mensaje..."
+                placeholder={isSignedIn ? "Escribe tu mensaje..." : "Inicia sesión para enviar mensajes"}
                 rows={3}
+                disabled={!isSignedIn}
               />
-              <button className="btn btn-primary" type="submit" disabled={!message.trim()}>
+              <button className="btn btn-primary" type="submit" disabled={!message.trim() || !isSignedIn}>
                 Enviar
               </button>
             </form>

--- a/apps/web/src/pages/MyLandsPage.jsx
+++ b/apps/web/src/pages/MyLandsPage.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useUser } from "@clerk/clerk-react";
+import { listLands, setTokenFn } from "../services/api";
+
+export default function MyLandsPage() {
+  const { user } = useUser();
+  const [lands, setLands] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchMyLands = async () => {
+      if (!user) return;
+      try {
+        setTokenFn(() => user.getToken());
+        const data = await listLands();
+        const myLands = data.filter((land) => land.ownerId === user.id);
+        setLands(myLands);
+      } catch (err) {
+        console.error("Error fetching my lands:", err);
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMyLands();
+  }, [user]);
+
+  if (loading) {
+    return (
+      <div>
+        <div className="section-header">
+          <h1>Mis Terrenos</h1>
+          <p>Gestiona tus terrenos publicados</p>
+        </div>
+        <div className="panel" style={{ marginTop: "1.5rem", textAlign: "center", padding: "3rem" }}>
+          <p>Cargando terrenos...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Mis Terrenos</h1>
+        <p>Gestiona tus terrenos publicados</p>
+      </div>
+
+      {error && (
+        <div className="panel" style={{ marginTop: "1.5rem", background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)" }}>
+          <p style={{ color: "#fca5a5" }}>Error: {error}</p>
+        </div>
+      )}
+
+      {lands.length === 0 ? (
+        <div className="panel" style={{ marginTop: "1.5rem" }}>
+          <p>No tienes terrenos publicados.</p>
+          <p style={{ opacity: 0.7, marginTop: "0.5rem" }}>Los terrenos que crees aparecerán aquí.</p>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "1.5rem" }}>
+          {lands.map((land) => (
+            <div key={land.id} className="panel">
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start" }}>
+                <div>
+                  <h3>{land.title}</h3>
+                  <p style={{ opacity: 0.7 }}>
+                    {land.location?.province} · {land.location?.district}
+                  </p>
+                  <p style={{ opacity: 0.7 }}>
+                    {land.areaHectares} ha · ${land.priceRule?.pricePerMonth}/mes
+                  </p>
+                </div>
+                <span className={`status-badge ${land.status === "active" ? "status-active" : "status-draft"}`}>
+                  {land.status === "active" ? "Activo" : land.status === "draft" ? "Borrador" : land.status}
+                </span>
+              </div>
+              <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>
+                <Link to={`/lands/${land.id}`} className="btn btn-ghost" style={{ fontSize: "0.875rem" }}>
+                  Ver detalle
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/services/api.js
+++ b/apps/web/src/services/api.js
@@ -54,7 +54,8 @@ export const listLands = async (filters = {}) => {
 
   const qs = params.toString();
   const res = await request("GET", `/api/v1/lands${qs ? `?${qs}` : ""}`);
-  return res?.data?.items ?? [];
+  const items = res?.data?.items ?? [];
+  return items.map(adaptLandForCatalog);
 };
 
 /** POST /api/v1/rental-requests */
@@ -88,13 +89,28 @@ export const getPaymentsByRequest = async (rentalRequestId) => {
   return res?.data ?? [];
 };
 
-// ─── Field adapters ───────────────────────────────────────────────────────────────
+const adaptLandForCatalog = (land) => {
+  if (!land) return null;
+  return {
+    ...land,
+    priceRule: {
+      ...land.priceRule,
+      pricePerMonth: land.priceRule?.pricePerMonth ?? land.monthlyPrice ?? 0,
+    },
+    location: {
+      ...land.location,
+      province: land.location?.province ?? "",
+      district: land.location?.district ?? "",
+    },
+    areaHectares: land.area ?? 0,
+    type: land.allowedUses?.[0] ?? "",
+    features: land.features ?? [],
+    water: land.water ?? "No especificado",
+    access: land.access ?? "No especificado",
+    mapPosition: land.mapPosition ?? { x: 50, y: 50 },
+  };
+};
 
-/**
- * Traduce LandRecord del backend al formato que espera el UI.
- * Backend: priceRule.pricePerMonth, location.{province,district}, area, allowedUses, availability
- * UI:     monthlyPrice, province, district, areaHectares, type, availableFrom, availableTo
- */
 export const adaptLand = (land) => {
   if (!land) return null;
   return {
@@ -109,4 +125,36 @@ export const adaptLand = (land) => {
   };
 };
 
-export const api = { setTokenFn, listLands, getLandById, createRentalRequest, createCheckoutSession, getPaymentsByRequest, adaptLand };
+export const getChats = async () => {
+  const res = await request("GET", "/api/v1/chats");
+  return res?.data ?? [];
+};
+
+export const createChat = async ({ landId, rentalRequestId, participants }) => {
+  const res = await request("POST", "/api/v1/chats", { landId, rentalRequestId, participants });
+  return res?.data ?? null;
+};
+
+export const getMessages = async (chatId) => {
+  const res = await request("GET", `/api/v1/chats/${chatId}/messages`);
+  return res?.data ?? [];
+};
+
+export const sendMessage = async (chatId, text) => {
+  const res = await request("POST", `/api/v1/chats/${chatId}/messages`, { text });
+  return res?.data ?? null;
+};
+
+export const api = {
+  setTokenFn,
+  listLands,
+  getLandById,
+  createRentalRequest,
+  createCheckoutSession,
+  getPaymentsByRequest,
+  adaptLand,
+  getChats,
+  createChat,
+  getMessages,
+  sendMessage,
+};


### PR DESCRIPTION
## Resumen

ImplementaciÃ³n del issue #80 - IntegraciÃ³n de Frontend con Backend - Datos Mock y NavegaciÃ³n.

### Cambios realizados

1. **CatalogPage.jsx** - Usa datos reales del API
   - `getLands()` (mock) â†’ `listLands()` (API real)
   - Filtros de uso y provincia se generan dinÃ¡micamente

2. **LandDetailPage.jsx** - Chat conectado al backend
   - GET/POST `/api/v1/chats/:chatId/messages`
   - Usuarios autenticados: mensajes persistidos en servidor
   - Usuarios no autenticados: fallback a sessionStorage

3. **MyLandsPage.jsx** (nuevo) - Nueva pÃ¡gina para propietarios
   - Ruta `/dashboard/lands`
   - Muestra terrenos del propietario autenticado

4. **api.js** - Nuevas funciones de chat
   - `getChats()`, `createChat()`, `getMessages()`, `sendMessage()`
   - `adaptLand()` exportado para ReservePage

### Condiciones de aceptaciÃ³n verificadas
- [x] CatÃ¡logo muestra tierras reales del backend
- [x] Chat persiste mensajes y los recupera al recargar
- [x] Dashboard muestra solicitudes del usuario (ya estaba implementado)
- [x] Admin ve usuarios y tierras reales (ya estaba implementado)
- [x] Propietarios pueden ver sus tierras via `/dashboard/lands`

---
**Issue:** closes #80