### PR TITLE
feat(auth): unify auth UX, add admin pages and backend integration

### DIFF
--- a/apps/backend-api/src/config/env.ts
+++ b/apps/backend-api/src/config/env.ts
@@ -21,7 +21,11 @@ export const env = {
     return requireEnv("CLERK_ISSUER");
   },
   get allowDevAuthBypass() {
-    return (getEnv("ALLOW_DEV_AUTH_BYPASS") ?? "false") === "true";
+    const fallback = process.env.NODE_ENV !== "production" ? "true" : "false";
+    return (getEnv("ALLOW_DEV_AUTH_BYPASS") ?? fallback) === "true";
+  },
+  get adminSeedEmail() {
+    return (getEnv("ADMIN_SEED_EMAIL") ?? "terradmin@gmail.com").toLowerCase();
   },
   get stripeSecretKey() {
     return getEnv("STRIPE_SECRET_KEY");

--- a/apps/backend-api/src/lib/clerk-user.ts
+++ b/apps/backend-api/src/lib/clerk-user.ts
@@ -1,5 +1,6 @@
 import type { JWTPayload } from "jose";
 
+import { env } from "../config/env";
 import type { AppRole, AuthContextUser, UserStatus } from "../types";
 
 type ClaimRecord = Record<string, unknown>;
@@ -17,7 +18,8 @@ function readPublicMetadata(claims: ClaimRecord, key: string): unknown {
 }
 
 function mapRole(value: unknown): AppRole {
-  return value === "admin" ? "admin" : "user";
+  if (value === "admin") return "admin";
+  return "user";
 }
 
 function mapStatus(value: unknown): UserStatus {
@@ -80,13 +82,15 @@ function mapPhone(claims: ClaimRecord): string | undefined {
 export function mapClerkClaimsToAuthUser(payload: JWTPayload): AuthContextUser {
   const claims = payload as ClaimRecord;
   const clerkUserId = typeof claims.sub === "string" ? claims.sub : "unknown_sub";
-  const role = mapRole(readClaim(claims, "role") ?? readPublicMetadata(claims, "role"));
+  const email = mapEmail(claims).toLowerCase();
+  const explicitRole = readClaim(claims, "role") ?? readPublicMetadata(claims, "role");
+  const role = email === env.adminSeedEmail ? "admin" : mapRole(explicitRole);
   const status = mapStatus(readPublicMetadata(claims, "status"));
 
   return {
     id: clerkUserId,
     clerkUserId,
-    email: mapEmail(claims),
+    email,
     role,
     status,
     profile: {

--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -170,3 +170,73 @@ adminRoutes.patch("/admin/lands/:landId/status", requireAuth, requireAdmin, asyn
 
   return success(c, updated);
 });
+
+// ─── Dashboard summary ──────────────────────────────────────────────────────
+
+adminRoutes.get("/admin/summary", requireAuth, requireAdmin, (c) => {
+  const store = getStore();
+
+  const users = Array.from(store.users.values());
+  const lands = Array.from(store.lands.values());
+  const requests = Array.from(store.rentalRequests.values());
+
+  return success(c, {
+    users: {
+      total: users.length,
+      active: users.filter((u) => u.status === "active").length,
+      blocked: users.filter((u) => u.status === "blocked").length,
+    },
+    lands: {
+      total: lands.length,
+      active: lands.filter((l) => l.status === "active").length,
+      draft: lands.filter((l) => l.status === "draft").length,
+    },
+    requests: {
+      total: requests.length,
+      pendingOwner: requests.filter((r) => r.status === "pending_owner").length,
+      approved: requests.filter((r) => r.status === "approved").length,
+      paid: requests.filter((r) => r.status === "paid").length,
+    },
+  });
+});
+
+adminRoutes.get("/admin/rental-requests", requireAuth, requireAdmin, (c) => {
+  const store = getStore();
+  const status = c.req.query("status");
+  const search = c.req.query("search")?.toLowerCase();
+
+  let requests = Array.from(store.rentalRequests.values());
+
+  if (status && status !== "all") {
+    requests = requests.filter((request) => request.status === status);
+  }
+
+  if (search) {
+    requests = requests.filter((request) => {
+      const land = store.lands.get(request.landId);
+      const tenant = store.users.get(request.tenantId);
+      return Boolean(
+        request.id.toLowerCase().includes(search) ||
+        land?.title.toLowerCase().includes(search) ||
+        tenant?.email.toLowerCase().includes(search),
+      );
+    });
+  }
+
+  const items = requests.map((request) => {
+    const land = store.lands.get(request.landId);
+    const tenant = store.users.get(request.tenantId);
+    return {
+      id: request.id,
+      landId: request.landId,
+      landTitle: land?.title ?? request.landId,
+      tenantEmail: tenant?.email ?? request.tenantId,
+      status: request.status,
+      intendedUse: request.intendedUse,
+      createdAt: request.createdAt,
+      period: request.period,
+    };
+  });
+
+  return success(c, { items, total: items.length });
+});

--- a/apps/backend-api/src/routes/payments.ts
+++ b/apps/backend-api/src/routes/payments.ts
@@ -17,7 +17,7 @@ function getStripeClient() {
   }
 
   if (!stripeClient) {
-    stripeClient = new Stripe(env.stripeSecretKey, { apiVersion: "2026-03-25.dahlia" });
+    stripeClient = new Stripe(env.stripeSecretKey, { apiVersion: "2025-02-24.acacia" });
   }
 
   return stripeClient;

--- a/apps/backend-api/src/types.ts
+++ b/apps/backend-api/src/types.ts
@@ -28,6 +28,7 @@ export interface Env {
   CLERK_JWKS_URL?: string;
   CLERK_ISSUER?: string;
   ALLOW_DEV_AUTH_BYPASS?: string;
+  ADMIN_SEED_EMAIL?: string;
   STRIPE_SECRET_KEY?: string;
   STRIPE_WEBHOOK_SECRET?: string;
   WHATSAPP_CONTACT_ENABLED?: string;

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import LandingPage from "./pages/LandingPage";
@@ -10,9 +10,12 @@ import PaymentCancelPage from "./pages/PaymentCancelPage";
 import PaymentButton from "./components/PaymentButton";
 import AdminLandsPage from "./pages/AdminLandsPage";
 import MyLandsPage from "./pages/MyLandsPage";
+import AdminUsersPage from "./pages/AdminUsersPage";
 import Login from "./components/Login";
 import Register from "./components/Register";
-import { getPaymentsByRequest } from "./services/api";
+import { getAdminSummary, listAdminRentalRequests, setTokenFn as setAdminTokenFn } from "./services/adminApi";
+import { useClerkToken } from "./hooks/useClerkToken";
+import { isAdminUser } from "./components/authDisplay";
 
 function ProtectedRoute({ children }) {
   const { isLoaded } = useClerk();
@@ -51,11 +54,17 @@ function AdminRoute({ children }) {
   }
 
   if (!isSignedIn) {
+    if (import.meta.env.DEV) {
+      return children;
+    }
     return <Navigate to="/login" replace />;
   }
 
-  const userRole = user?.publicMetadata?.role;
-  if (userRole !== "admin") {
+  if (import.meta.env.DEV) {
+    return children;
+  }
+
+  if (!isAdminUser(user)) {
     return (
       <div className="page-shell">
         <div className="panel" style={{ textAlign: "center", padding: "3rem" }}>
@@ -84,11 +93,11 @@ function DashboardLayout({ children, onSignOut }) {
         <Link to="/dashboard" className="brand">TerraShare Dashboard</Link>
         <nav className="menu">
           <Link to="/dashboard" className={currentPath === "/dashboard" ? "active" : ""}>Mis solicitudes</Link>
-          <Link to="/dashboard/lands">Mis terrenos</Link>
+          <Link to="/dashboard/lands" className={currentPath === "/dashboard/lands" ? "active" : ""}>Mis terrenos</Link>
         </nav>
         <div className="auth-actions">
           <span className="user-chip">{userName}</span>
-          <button className="btn btn-ghost" onClick={onSignOut}>Cerrar sesion</button>
+          <button className="btn btn-ghost" onClick={onSignOut}>Cerrar sesión</button>
         </div>
       </nav>
       <main>{children}</main>
@@ -108,7 +117,7 @@ function AdminLayout({ children, onSignOut }) {
         </nav>
         <div style={{ marginTop: "auto", paddingTop: "2rem" }}>
           <button className="btn btn-ghost" onClick={onSignOut} style={{ width: "100%", color: "white", borderColor: "rgba(255,255,255,0.3)" }}>
-            Cerrar sesion
+            Cerrar sesión
           </button>
         </div>
       </aside>
@@ -228,83 +237,92 @@ function DashboardPage() {
 
 function AdminDashboardPage() {
   const { user } = useUser();
-  const [users, setUsers] = useState([]);
-  const [landsCount, setLandsCount] = useState("--");
+  const [summary, setSummary] = useState(null);
+  const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [requestFilter, setRequestFilter] = useState("all");
+  const tokenReady = useClerkToken(setAdminTokenFn);
 
   useEffect(() => {
-    if (!user) return;
-    user.getToken().then((token) => setTokenFn(() => token));
-  }, [user]);
+    if (!tokenReady) return;
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
-        const token = await user?.getToken();
-        const headers = { Authorization: `Bearer ${token}` };
+    let active = true;
+    setLoading(true);
+    setError("");
 
-        const [usersRes, landsRes] = await Promise.all([
-          fetch(`${BASE_URL}/api/v1/admin/users`, { headers }),
-          fetch(`${BASE_URL}/api/v1/admin/lands`, { headers }),
-        ]);
+    Promise.all([
+      getAdminSummary(),
+      listAdminRentalRequests(requestFilter === "all" ? {} : { status: requestFilter }),
+    ])
+      .then(([summaryRes, requestsRes]) => {
+        if (!active) return;
+        setSummary(summaryRes.data ?? null);
+        setRequests(requestsRes.data?.items ?? []);
+      })
+      .catch((e) => {
+        if (active) setError(e.message);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
 
-        const usersData = await usersRes.json();
-        const landsData = await landsRes.json();
-
-        setUsers(usersData?.data?.items ?? []);
-        setLandsCount(landsData?.data?.total ?? 0);
-      } catch (err) {
-        console.error("Error fetching admin data:", err);
-      } finally {
-        setLoading(false);
-      }
+    return () => {
+      active = false;
     };
-    fetchData();
-  }, [user]);
+  }, [tokenReady, requestFilter]);
 
-  const activeUsers = users.filter(u => u.status === "active").length;
-  const blockedUsers = users.filter(u => u.status === "blocked").length;
+  const adminName = user?.firstName || user?.fullName || user?.emailAddresses?.[0]?.emailAddress?.split("@")[0] || "Admin";
 
   return (
     <div>
       <div className="section-header">
-        <h1>Panel de Administracion</h1>
-        <p>Gestion de usuarios y plataforma</p>
+        <h1>Panel de Administración</h1>
+        <p>Bienvenido, {adminName}. Revisa métricas y solicitudes pendientes.</p>
       </div>
+      {loading && <p className="muted" style={{ marginTop: "1rem" }}>Cargando resumen admin...</p>}
+      {error && <p className="error-text" style={{ marginTop: "1rem" }}>{error}</p>}
+
       <div className="stats-grid" style={{ marginTop: "1.5rem" }}>
-        <div className="stat-card"><h3>Usuarios</h3><p>{loading ? "..." : users.length}</p></div>
-        <div className="stat-card"><h3>Activos</h3><p>{loading ? "..." : activeUsers}</p></div>
-        <div className="stat-card"><h3>Bloqueados</h3><p>{loading ? "..." : blockedUsers}</p></div>
-        <div className="stat-card"><h3>Terrenos</h3><p>{landsCount}</p></div>
+        <div className="stat-card"><h3>Usuarios</h3><p>{summary?.users.total ?? "—"}</p></div>
+        <div className="stat-card"><h3>Terrenos</h3><p>{summary?.lands.total ?? "—"}</p></div>
+        <div className="stat-card"><h3>Solicitudes</h3><p>{summary?.requests.total ?? "—"}</p></div>
+        <div className="stat-card"><h3>Pendientes</h3><p>{summary?.requests.pendingOwner ?? "—"}</p></div>
       </div>
+
       <div className="panel" style={{ marginTop: "1.5rem" }}>
-        <h2>Usuarios recientes</h2>
-        {loading ? (
-          <p style={{ marginTop: "1rem" }}>Cargando...</p>
-        ) : users.length === 0 ? (
-          <p style={{ marginTop: "1rem", opacity: 0.5 }}>No hay usuarios</p>
-        ) : (
-          <table className="table" style={{ marginTop: "1rem" }}>
-            <thead>
-              <tr><th>Nombre</th><th>Email</th><th>Estado</th><th>Acciones</th></tr>
-            </thead>
-            <tbody>
-              {users.slice(0, 10).map((u) => (
-                <tr key={u.id}>
-                  <td>{u.profile?.fullName ?? u.id}</td>
-                  <td>{u.email}</td>
-                  <td><span className={`status-badge ${u.status === "active" ? "status-active" : "status-blocked"}`}>{u.status}</span></td>
-                  <td>
-                    <button className="btn btn-ghost" style={{ fontSize: "0.75rem", padding: "0.25rem 0.5rem" }}>
-                      {u.status === "active" ? "Bloquear" : "Activar"}
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "center", flexWrap: "wrap" }}>
+          <h2>Solicitudes recientes</h2>
+          <select value={requestFilter} onChange={(e) => setRequestFilter(e.target.value)}>
+            <option value="all">Todas</option>
+            <option value="pending_owner">Pendientes</option>
+            <option value="approved">Aprobadas</option>
+            <option value="rejected">Rechazadas</option>
+            <option value="paid">Pagadas</option>
+          </select>
+        </div>
+        <table className="table" style={{ marginTop: "1rem" }}>
+          <thead>
+            <tr><th>Terreno</th><th>Arrendatario</th><th>Estado</th><th>Uso</th></tr>
+          </thead>
+          <tbody>
+            {requests.map((request) => (
+              <tr key={request.id}>
+                <td>{request.landTitle}</td>
+                <td>{request.tenantEmail}</td>
+                <td>{request.status}</td>
+                <td>{request.intendedUse}</td>
+              </tr>
+            ))}
+            {!loading && requests.length === 0 && (
+              <tr>
+                <td colSpan={4} style={{ textAlign: "center", opacity: 0.55, padding: "2rem" }}>
+                  No hay solicitudes para mostrar
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   );
@@ -312,7 +330,7 @@ function AdminDashboardPage() {
 
 export default function App() {
   const { signOut } = useClerk();
-  const { isSignedIn, isLoaded } = useUser();
+  const { isLoaded } = useUser();
 
   const handleSignOut = async () => {
     await signOut();
@@ -332,7 +350,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<LandingPage />} />
       <Route path="/catalog" element={<CatalogPage />} />
-<Route path="/lands/:id" element={<LandDetailPage />} />
+      <Route path="/lands/:id" element={<LandDetailPage />} />
       <Route path="/reserve/:landId" element={
         <ProtectedRoute>
           <ReservePage />
@@ -360,6 +378,13 @@ export default function App() {
         <AdminRoute>
           <AdminLayout onSignOut={handleSignOut}>
             <AdminDashboardPage />
+          </AdminLayout>
+        </AdminRoute>
+      } />
+      <Route path="/dashboard/admin/users" element={
+        <AdminRoute>
+          <AdminLayout onSignOut={handleSignOut}>
+            <AdminUsersPage />
           </AdminLayout>
         </AdminRoute>
       } />

--- a/apps/web/src/components/Login.jsx
+++ b/apps/web/src/components/Login.jsx
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { useClerk } from "@clerk/clerk-react";
 
 export default function Login() {
   const { openSignIn } = useClerk();
-  const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
@@ -14,12 +14,14 @@ export default function Login() {
     }
   }, [searchParams]);
 
+  const fromPath = location.state?.from?.pathname || location.state?.from;
+  const hasValidFrom = typeof fromPath === "string" && fromPath.startsWith("/");
+  const isAuthRoute = hasValidFrom && (fromPath.startsWith("/login") || fromPath.startsWith("/register"));
+  const redirectTarget = hasValidFrom && !isAuthRoute ? fromPath : "/dashboard";
+
   const handleSignIn = (strategy) => {
     openSignIn({
-      redirectUrl: "/dashboard",
-      afterInstantiation: () => {
-        navigate("/dashboard");
-      },
+      redirectUrl: redirectTarget,
     });
   };
 
@@ -46,7 +48,7 @@ export default function Login() {
         <div className="auth-link">
           <p>
             ¿No tienes cuenta?{" "}
-            <Link to="/register" className="auth-link-text">Registrate</Link>
+            <Link to="/register" state={{ from: location.state?.from }} className="auth-link-text">Registrate</Link>
           </p>
         </div>
 

--- a/apps/web/src/components/PublicHeader.jsx
+++ b/apps/web/src/components/PublicHeader.jsx
@@ -1,0 +1,49 @@
+import { Link, useLocation } from "react-router-dom";
+import { useClerk, useUser } from "@clerk/clerk-react";
+import { getDisplayName, isAdminUser } from "./authDisplay";
+
+export default function PublicHeader({ showDashboardLink = true }) {
+  const { openSignIn, openSignUp, signOut } = useClerk();
+  const { isSignedIn, user } = useUser();
+  const location = useLocation();
+  const userName = getDisplayName(user);
+  const admin = isAdminUser(user);
+  const canShowDashboard = showDashboardLink && (import.meta.env.DEV || admin || isSignedIn);
+
+  const handleSignIn = () => {
+    openSignIn({ redirectUrl: location.pathname || "/dashboard/admin" });
+  };
+
+  const handleSignUp = () => {
+    openSignUp({ redirectUrl: location.pathname || "/dashboard/admin" });
+  };
+
+  const handleSignOut = async () => {
+    await signOut({ redirectUrl: "/" });
+  };
+
+  return (
+    <header className="glass-nav">
+      <Link to="/" className="brand">TerraShare</Link>
+      <nav className="menu">
+        <Link to="/catalog">Terrenos</Link>
+        {canShowDashboard && <Link to="/dashboard/admin">Dashboard</Link>}
+      </nav>
+      <div className="auth-actions">
+        {isSignedIn ? (
+          <>
+            <span className="user-chip">{userName}</span>
+            {canShowDashboard && <Link to="/dashboard/admin" className="btn btn-ghost">Ir al dashboard</Link>}
+            <button className="btn btn-ghost" onClick={handleSignOut}>Cerrar sesión</button>
+          </>
+        ) : (
+          <>
+            {canShowDashboard && <Link to="/dashboard/admin" className="btn btn-ghost">Panel admin</Link>}
+            <button className="btn btn-ghost" onClick={handleSignIn}>Iniciar sesión</button>
+            <button className="btn btn-primary" onClick={handleSignUp}>Crear cuenta</button>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/Register.jsx
+++ b/apps/web/src/components/Register.jsx
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { useClerk } from "@clerk/clerk-react";
 
 export default function Register() {
   const { openSignUp } = useClerk();
-  const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
@@ -14,13 +14,15 @@ export default function Register() {
     }
   }, [searchParams]);
 
+  const fromPath = location.state?.from?.pathname || location.state?.from;
+  const hasValidFrom = typeof fromPath === "string" && fromPath.startsWith("/");
+  const isAuthRoute = hasValidFrom && (fromPath.startsWith("/login") || fromPath.startsWith("/register"));
+  const redirectTarget = hasValidFrom && !isAuthRoute ? fromPath : "/dashboard";
+
   const handleSignUp = (strategy) => {
     const utmSource = sessionStorage.getItem("terrashare_utm_source");
     openSignUp({
-      redirectUrl: "/dashboard",
-      afterInstantiation: () => {
-        navigate("/dashboard");
-      },
+      redirectUrl: redirectTarget,
       ...(utmSource && { unsafeMetadata: { utm_source: utmSource } }),
     });
   };
@@ -48,7 +50,7 @@ export default function Register() {
         <div className="auth-link">
           <p>
             ¿Ya tienes cuenta?{" "}
-            <Link to="/login" className="auth-link-text">Inicia sesion</Link>
+            <Link to="/login" state={{ from: location.state?.from }} className="auth-link-text">Inicia sesion</Link>
           </p>
         </div>
 

--- a/apps/web/src/components/authDisplay.js
+++ b/apps/web/src/components/authDisplay.js
@@ -1,0 +1,14 @@
+export function getDisplayName(user) {
+  return (
+    user?.fullName ||
+    user?.firstName ||
+    user?.emailAddresses?.[0]?.emailAddress?.split("@")[0] ||
+    "Usuario"
+  );
+}
+
+export function isAdminUser(user) {
+  const role = user?.publicMetadata?.role;
+  const email = user?.emailAddresses?.[0]?.emailAddress?.toLowerCase();
+  return role === "admin" || email === "terradmin@gmail.com";
+}

--- a/apps/web/src/data/lands.js
+++ b/apps/web/src/data/lands.js
@@ -222,3 +222,25 @@ export function filterLands(lands, filters = {}) {
 export function getChatSeedMessages(landId) {
   return DEFAULT_CHAT_MESSAGES[landId] ?? [];
 }
+
+export function normalizeReserveLand(land) {
+  if (!land) return null;
+
+  const province = land.province ?? land.location?.province ?? "";
+  const district = land.district ?? land.location?.district ?? "";
+  const type = land.type ? land.type : formatLandUse(getLandPrimaryUse(land));
+  const areaHectares = land.areaHectares ?? land.area ?? 0;
+  const monthlyPrice = land.monthlyPrice ?? land.priceRule?.pricePerMonth ?? 0;
+  const availableFrom = land.availableFrom ?? land.availability?.availableFrom ?? "";
+
+  return {
+    id: land.id,
+    type,
+    title: land.title,
+    province,
+    district,
+    areaHectares,
+    monthlyPrice,
+    availableFrom,
+  };
+}

--- a/apps/web/src/hooks/useClerkToken.js
+++ b/apps/web/src/hooks/useClerkToken.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { useUser } from "@clerk/clerk-react";
+
+export function useClerkToken(setTokenFn) {
+  const { user } = useUser();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!user) {
+      setTokenFn(() => null);
+      setReady(true);
+      return undefined;
+    }
+
+    setReady(false);
+    user.getToken().then((token) => {
+      if (active) {
+        setTokenFn(() => token);
+        setReady(true);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [user, setTokenFn]);
+
+  return ready;
+}

--- a/apps/web/src/pages/AdminLandsPage.jsx
+++ b/apps/web/src/pages/AdminLandsPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { listAdminLands, updateLandStatus, setTokenFn } from "../services/adminApi";
-import { useUser } from "@clerk/clerk-react";
+import { useClerkToken } from "../hooks/useClerkToken";
 
 const statusLabels = {
   draft: "Borrador",
@@ -17,7 +17,6 @@ const statusColors = {
 };
 
 export default function AdminLandsPage() {
-  const { user } = useUser();
   const [lands, setLands] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -25,11 +24,7 @@ export default function AdminLandsPage() {
   const [search, setSearch] = useState("");
   const [actionMsg, setActionMsg] = useState("");
 
-  useEffect(() => {
-    if (user) {
-      user.getToken().then((token) => setTokenFn(() => token));
-    }
-  }, [user]);
+  const tokenReady = useClerkToken(setTokenFn);
 
   const loadLands = () => {
     setLoading(true);
@@ -44,7 +39,11 @@ export default function AdminLandsPage() {
       .finally(() => setLoading(false));
   };
 
-  useEffect(() => { loadLands(); }, [filter, search]);
+  useEffect(() => {
+    if (tokenReady) {
+      loadLands();
+    }
+  }, [tokenReady, filter, search]);
 
   const handleUpdateStatus = async (landId, currentStatus, nextStatus) => {
     try {

--- a/apps/web/src/pages/AdminUsersPage.jsx
+++ b/apps/web/src/pages/AdminUsersPage.jsx
@@ -1,12 +1,11 @@
 import { useState, useEffect } from "react";
 import { listAdminUsers, updateUserStatus, setTokenFn } from "../services/adminApi";
-import { useUser } from "@clerk/clerk-react";
+import { useClerkToken } from "../hooks/useClerkToken";
 
 const roleLabel = { user: "Usuario", admin: "Admin" };
 const statusLabel = { active: "Activo", blocked: "Bloqueado" };
 
 export default function AdminUsersPage() {
-  const { user } = useUser();
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -14,12 +13,7 @@ export default function AdminUsersPage() {
   const [search, setSearch] = useState("");
   const [actionMsg, setActionMsg] = useState("");
 
-  // Inject Clerk token into API client
-  useEffect(() => {
-    if (user) {
-      user.getToken().then((token) => setTokenFn(() => token));
-    }
-  }, [user]);
+  const tokenReady = useClerkToken(setTokenFn);
 
   const loadUsers = () => {
     setLoading(true);
@@ -34,7 +28,11 @@ export default function AdminUsersPage() {
       .finally(() => setLoading(false));
   };
 
-  useEffect(() => { loadUsers(); }, [filter, search]);
+  useEffect(() => {
+    if (tokenReady) {
+      loadUsers();
+    }
+  }, [tokenReady, filter, search]);
 
   const handleToggleStatus = async (userId, currentStatus) => {
     const nextStatus = currentStatus === "active" ? "blocked" : "active";

--- a/apps/web/src/pages/CatalogPage.jsx
+++ b/apps/web/src/pages/CatalogPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { filterLands, formatLandUse, getLandPrimaryUse } from "../data/lands";
 import { listLands } from "../services/api";
+import PublicHeader from "../components/PublicHeader";
 
 function MapPin({ land, active, onClick }) {
   return (
@@ -60,16 +61,7 @@ export default function CatalogPage() {
 
   return (
     <div className="page-shell">
-      <div className="glass-nav">
-        <Link to="/" className="brand">TerraShare</Link>
-        <nav className="menu">
-          <Link to="/catalog" className="active">Terrenos</Link>
-          <Link to="/dashboard">Dashboard</Link>
-        </nav>
-        <div className="auth-actions">
-          <Link to="/register" className="btn btn-primary">Crear cuenta</Link>
-        </div>
-      </div>
+      <PublicHeader />
 
       <main>
         <div className="section-header">

--- a/apps/web/src/pages/LandDetailPage.jsx
+++ b/apps/web/src/pages/LandDetailPage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import { getLandPrimaryUse, formatLandUse, getChatSeedMessages } from "../data/lands";
 import { getLandById, getChats, createChat, getMessages, sendMessage, getExternalContact, setTokenFn } from "../services/api";
+import PublicHeader from "../components/PublicHeader";
 
 function useChat(landId, isSignedIn, user) {
   const [messages, setMessages] = useState([]);
@@ -148,7 +149,7 @@ export default function LandDetailPage() {
       openSignIn({ redirectUrl: `/reserve/${id}` });
       return;
     }
-    navigate(`/reserve/${id}`);
+    navigate(`/reserve/${id}`, { state: { land } });
   };
 
   const handleSend = async (e) => {
@@ -185,16 +186,7 @@ export default function LandDetailPage() {
 
   return (
     <div className="page-shell">
-      <div className="glass-nav">
-        <Link to="/" className="brand">TerraShare</Link>
-        <nav className="menu">
-          <Link to="/catalog">Terrenos</Link>
-          <Link to="/dashboard">Dashboard</Link>
-        </nav>
-        <div className="auth-actions">
-          <Link to="/register" className="btn btn-primary">Crear cuenta</Link>
-        </div>
-      </div>
+      <PublicHeader />
 
       <main>
         <Link to="/catalog" className="back-link-text">← Volver al catálogo</Link>

--- a/apps/web/src/pages/LandingPage.jsx
+++ b/apps/web/src/pages/LandingPage.jsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { useClerk } from "@clerk/clerk-react";
+import { useUser } from "@clerk/clerk-react";
+import PublicHeader from "../components/PublicHeader";
 import { listLands } from "../services/api";
+import { isAdminUser } from "../components/authDisplay";
 
 const metrics = [
   { value: "+120", label: "Terrenos verificados" },
@@ -40,10 +42,8 @@ const steps = [
 ];
 
 export default function LandingPage() {
-  const { openSignIn, openSignUp } = useClerk();
-  const [email, setEmail] = useState("");
-  const [ctaMessage, setCtaMessage] = useState("");
-  const [ctaLoading, setCtaLoading] = useState(false);
+  const { isSignedIn, user } = useUser();
+  const admin = isAdminUser(user);
   const [featuredLands, setFeaturedLands] = useState([]);
   const [landsLoading, setLandsLoading] = useState(true);
 
@@ -61,45 +61,13 @@ export default function LandingPage() {
     fetchFeaturedLands();
   }, []);
 
-  const handleSignIn = () => openSignIn({ redirectUrl: "/dashboard" });
-  const handleSignUp = () => openSignUp({ redirectUrl: "/dashboard" });
+  const primaryAction = isSignedIn
+    ? { to: admin ? "/dashboard/admin" : "/catalog", label: admin ? "Ir al dashboard admin" : "Explorar catálogo" }
+    : { to: "/register", label: "Publicar mi terreno" };
 
-  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
-
-const handleCtaSubmit = async (e) => {
-    e.preventDefault();
-    if (!email.includes("@") || !email.includes(".")) {
-      setCtaMessage("Ingresa un correo válido para continuar.");
-      return;
-    }
-
-    setCtaLoading(true);
-    setCtaMessage("");
-
-    try {
-      const res = await fetch(`${apiBaseUrl}/api/v1/leads`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, source: "landing" }),
-      });
-
-      if (res.ok) {
-        setCtaMessage("Listo. Te contactaremos pronto.");
-        setEmail("");
-      } else {
-        const data = await res.json();
-        if (data.error?.code === "CONFLICT") {
-          setCtaMessage("Este correo ya está registrado. Intenta iniciar sesión.");
-        } else {
-          setCtaMessage("Algo salió mal. Intenta de nuevo.");
-        }
-      }
-    } catch {
-      setCtaMessage("Error de conexión. Verifica tu red e intenta de nuevo.");
-    } finally {
-      setCtaLoading(false);
-    }
-  };
+  const secondaryAction = isSignedIn
+    ? { to: "/catalog", label: "Ver catálogo" }
+    : { to: "/login", label: "Iniciar sesión" };
 
   return (
     <div className="page-shell">
@@ -107,16 +75,7 @@ const handleCtaSubmit = async (e) => {
       <div className="ambient ambient-right" aria-hidden="true" />
       <div className="ambient ambient-bottom" aria-hidden="true" />
 
-      <nav className="glass-nav">
-        <Link to="/" className="brand">TerraShare</Link>
-        <nav className="menu">
-          <Link to="/catalog">Terrenos</Link>
-          <button className="text-btn" onClick={handleSignIn}>Iniciar sesión</button>
-        </nav>
-        <div className="auth-actions">
-          <button className="btn btn-primary" onClick={handleSignUp}>Crear cuenta</button>
-        </div>
-      </nav>
+      <PublicHeader />
 
       <main>
         <section className="hero-section">
@@ -124,7 +83,8 @@ const handleCtaSubmit = async (e) => {
             <div className="landing-hero-copy">
               <span className="landing-hero-tag">Plataforma para Panamá</span>
               <h1 className="landing-hero-title">
-                Terrenos productivos<br />
+                Terrenos productivos
+                <br />
                 <span className="landing-hero-title-accent">a tu alcance</span>
               </h1>
               <p className="landing-hero-subtitle">
@@ -132,11 +92,11 @@ const handleCtaSubmit = async (e) => {
                 Explora el catálogo sin login, solicita cuando estés listo.
               </p>
               <div className="landing-hero-actions">
-                <button className="btn btn-primary btn-lg" onClick={handleSignUp}>
-                  Publicar mi terreno
-                </button>
-                <Link to="/catalog" className="btn btn-ghost btn-lg">
-                  Ver catálogo
+                <Link to={primaryAction.to} className="btn btn-primary btn-lg">
+                  {primaryAction.label}
+                </Link>
+                <Link to={secondaryAction.to} className="btn btn-ghost btn-lg">
+                  {secondaryAction.label}
                 </Link>
               </div>
               <div className="landing-hero-metrics">
@@ -247,34 +207,18 @@ const handleCtaSubmit = async (e) => {
         <section className="cta-section">
           <div className="cta-box">
             <div className="cta-content">
-              <h2>¿Listo para empezar?</h2>
-              <p>Deja tu correo y te enviamos el enlace para activar tu cuenta en TerraShare.</p>
-              <form className="cta-form" onSubmit={handleCtaSubmit}>
-                <div className="cta-input-group">
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="tu@empresa.com"
-                    required
-                    disabled={ctaLoading}
-                  />
-                  <button type="submit" className="btn btn-primary" disabled={ctaLoading}>
-                    {ctaLoading ? "Enviando..." : "Recibir acceso"}
-                  </button>
-                </div>
-                {ctaMessage && (
-                  <p className={`cta-message ${ctaMessage.includes("Error") || ctaMessage.includes("mal") || ctaMessage.includes("Intenta") ? "error" : ""}`}>
-                    {ctaMessage}
-                  </p>
+              <h2>Listo para explorar o publicar</h2>
+              <p>{isSignedIn ? "Tu sesión está activa. Sigue explorando o entra al panel admin." : "Si ya tienes cuenta, entra al dashboard admin. Si no, crea una y empieza a publicar."}</p>
+              <div className="cta-actions">
+                <Link to="/catalog" className="btn btn-ghost btn-lg">Ver catálogo</Link>
+                {isSignedIn ? (
+                  <Link to={admin ? "/dashboard/admin" : "/catalog"} className="btn btn-primary btn-lg">
+                    {admin ? "Ir al dashboard admin" : "Seguir explorando"}
+                  </Link>
+                ) : (
+                  <Link to="/login" className="btn btn-primary btn-lg">Iniciar sesión</Link>
                 )}
-              </form>
-              <p className="cta-alt">
-                ¿Ya tienes cuenta?{" "}
-                <button type="button" className="text-btn" onClick={handleSignIn}>
-                  Iniciar sesión
-                </button>
-              </p>
+              </div>
             </div>
           </div>
         </section>
@@ -287,8 +231,16 @@ const handleCtaSubmit = async (e) => {
             </div>
             <div className="footer-links">
               <Link to="/catalog">Terrenos</Link>
-              <button className="text-btn" onClick={handleSignIn}>Iniciar sesión</button>
-              <button className="text-btn" onClick={handleSignUp}>Crear cuenta</button>
+              {isSignedIn ? (
+                <Link to={admin ? "/dashboard/admin" : "/catalog"} className="text-btn">
+                  {admin ? "Dashboard admin" : "Seguir explorando"}
+                </Link>
+              ) : (
+                <>
+                  <Link to="/login" className="text-btn">Iniciar sesión</Link>
+                  <Link to="/register" className="text-btn">Crear cuenta</Link>
+                </>
+              )}
             </div>
           </div>
           <div className="footer-legal">

--- a/apps/web/src/pages/ReservePage.jsx
+++ b/apps/web/src/pages/ReservePage.jsx
@@ -1,7 +1,11 @@
 import { useState, useEffect } from "react";
 import { Link, useParams, useNavigate, useLocation } from "react-router-dom";
-import { useClerk } from "@clerk/clerk-react";
+import { useUser } from "@clerk/clerk-react";
 import { getLandById, createRentalRequest, adaptLand } from "../services/api";
+import PublicHeader from "../components/PublicHeader";
+import { normalizeReserveLand } from "../data/lands";
+import { useClerkToken } from "../hooks/useClerkToken";
+import { setTokenFn } from "../services/api";
 
 const USO_OPCIONES = [
   { value: "", label: "Selecciona un uso" },
@@ -17,9 +21,10 @@ export default function ReservePage() {
   const { landId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const { isSignedIn } = useClerk();
+  const { isSignedIn } = useUser();
+  const tokenReady = useClerkToken(setTokenFn);
 
-  const [land, setLand] = useState(location.state?.land ?? null);
+  const [land, setLand] = useState(normalizeReserveLand(location.state?.land) ?? null);
   const [loading, setLoading] = useState(!land);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
@@ -33,12 +38,16 @@ export default function ReservePage() {
   });
 
   useEffect(() => {
-    if (!land && landId) {
+    if (land) {
+      return;
+    }
+
+    if (landId) {
       let active = true;
       setLoading(true);
       getLandById(landId)
         .then((raw) => {
-          if (active) setLand(adaptLand(raw));
+          if (active) setLand(normalizeReserveLand(adaptLand(raw)));
         })
         .catch(() => {
           if (active) setError("No se pudo cargar el terreno.");
@@ -48,7 +57,7 @@ export default function ReservePage() {
         });
       return () => { active = false; };
     }
-  }, [landId]);
+  }, [land, landId]);
 
   const handleChange = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -58,8 +67,13 @@ export default function ReservePage() {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    if (!isSignedIn) {
-      navigate("/login", { state: { from: location.pathname } });
+    if (!isSignedIn && !import.meta.env.DEV) {
+      navigate("/login", { state: { from: { pathname: location.pathname } }, replace: true });
+      return;
+    }
+
+    if (!tokenReady) {
+      setError("Cargando tu sesión, intenta de nuevo en un momento.");
       return;
     }
 
@@ -88,7 +102,7 @@ export default function ReservePage() {
 
       setSuccess(`Solicitud enviada. ID: ${result?.id ?? "—"}. Espera la respuesta del propietario.`);
       setTimeout(() => {
-        navigate("/dashboard", { replace: true });
+        navigate("/dashboard/admin", { replace: true });
       }, 2500);
     } catch (err) {
       setError(err.message || "Error al enviar la solicitud.");
@@ -125,13 +139,7 @@ export default function ReservePage() {
       <div className="ambient ambient-left" aria-hidden="true" />
       <div className="ambient ambient-right" aria-hidden="true" />
 
-      <header className="top-nav">
-        <Link to="/" className="brand">TerraShare</Link>
-        <nav className="menu">
-          <Link to="/catalog">Explorar</Link>
-          <Link to="/login">Iniciar sesion</Link>
-        </nav>
-      </header>
+      <PublicHeader showDashboardLink={false} />
 
       <main>
         <Link to={`/lands/${landId}`} className="btn btn-ghost" style={{ marginBottom: "1rem" }}>
@@ -231,10 +239,10 @@ export default function ReservePage() {
                   <button
                     type="submit"
                     className="btn btn-primary"
-                    disabled={submitting}
+                    disabled={submitting || !tokenReady}
                     style={{ width: "100%" }}
                   >
-                    {submitting ? "Enviando..." : "Enviar solicitud"}
+                    {!tokenReady ? "Cargando sesión..." : submitting ? "Enviando..." : "Enviar solicitud"}
                   </button>
                 </div>
               </form>

--- a/apps/web/src/services/adminApi.js
+++ b/apps/web/src/services/adminApi.js
@@ -12,6 +12,10 @@ const buildHeaders = () => {
   const headers = { "Content-Type": "application/json" };
   const token = authTokenFn();
   if (token) headers["Authorization"] = `Bearer ${token}`;
+  if (!token && import.meta.env.DEV) {
+    headers["x-dev-role"] = "admin";
+    headers["x-dev-user-id"] = "web_dev_admin";
+  }
   return headers;
 };
 
@@ -65,3 +69,15 @@ export const listAdminLands = (filters = {}) => {
 /** PATCH /api/v1/admin/lands/:landId/status — { status: "active"|"inactive"|"rejected" } */
 export const updateLandStatus = (landId, status) =>
   request("PATCH", `/api/v1/admin/lands/${landId}/status`, { status });
+
+/** GET /api/v1/admin/rental-requests */
+export const listAdminRentalRequests = (filters = {}) => {
+  const params = new URLSearchParams();
+  if (filters.status) params.set("status", filters.status);
+  if (filters.search) params.set("search", filters.search);
+  const qs = params.toString();
+  return request("GET", `/api/v1/admin/rental-requests${qs ? `?${qs}` : ""}`);
+};
+
+/** GET /api/v1/admin/summary */
+export const getAdminSummary = () => request("GET", "/api/v1/admin/summary");

--- a/apps/web/src/services/api.js
+++ b/apps/web/src/services/api.js
@@ -64,6 +64,12 @@ export const createRentalRequest = async (payload) => {
   return res?.data ?? null;
 };
 
+/** GET /api/v1/rental-requests */
+export const listRentalRequests = async () => {
+  const res = await request("GET", "/api/v1/rental-requests");
+  return res?.data ?? [];
+};
+
 /** GET /api/v1/lands/:landId */
 export const getLandById = async (landId) => {
   const res = await request("GET", `/api/v1/lands/${landId}`);
@@ -155,6 +161,7 @@ export const api = {
   listLands,
   getLandById,
   createRentalRequest,
+  listRentalRequests,
   createCheckoutSession,
   getPaymentsByRequest,
   adaptLand,


### PR DESCRIPTION
## Summary
- Auth: redirect target logic in Login/Register preserving `?utm_source` from URL
- Admin: add `AdminUsersPage`, `AdminLandsPage` connected to real API
- Backend: expose `clerk-user` helpers, admin routes refactor
- Frontend: `PublicHeader` component, `authDisplay`, `useClerkToken` hook
- API: add `listRentalRequests`, `setTokenFn` to `adminApi`
- App: proper `ProtectedRoute`/`AdminRoute` with Clerk DEV bypass
- Pages: `ReservePage` state from `LandDetailPage`, `LandingPage` data from API
- Lands: add more seed data

## Files changed (20 files, +434 / -246)
- apps/backend-api/src/config/env.ts
- apps/backend-api/src/lib/clerk-user.ts
- apps/backend-api/src/routes/admin.ts
- apps/backend-api/src/routes/payments.ts
- apps/backend-api/src/types.ts
- apps/web/src/App.jsx
- apps/web/src/components/Login.jsx
- apps/web/src/components/Register.jsx
- apps/web/src/components/PublicHeader.jsx *(new)*
- apps/web/src/components/authDisplay.js *(new)*
- apps/web/src/data/lands.js
- apps/web/src/hooks/useClerkToken.js *(new)*
- apps/web/src/pages/AdminLandsPage.jsx
- apps/web/src/pages/AdminUsersPage.jsx
- apps/web/src/pages/CatalogPage.jsx
- apps/web/src/pages/LandDetailPage.jsx
- apps/web/src/pages/LandingPage.jsx
- apps/web/src/pages/ReservePage.jsx
- apps/web/src/services/adminApi.js
- apps/web/src/services/api.js