### PR TITLE
feat(backend): analytics owner endpoint #87

### DIFF
--- a/apps/backend-api/docs/API_ENDPOINTS.md
+++ b/apps/backend-api/docs/API_ENDPOINTS.md
@@ -223,6 +223,7 @@ Estados de solicitud (v1):
 | GET | `/analytics/overview` | Si | admin | implemented | #82 |
 | GET | `/analytics/lands` | Si | admin | implemented | #82 |
 | GET | `/analytics/requests` | Si | admin | implemented | #82 |
+| GET | `/analytics/owner/:ownerId` | Si | owner, admin | implemented | #87 |
 
 `GET /analytics/overview` response example:
 
@@ -303,6 +304,30 @@ Estados de solicitud (v1):
     },
     "avgTimeToApprovalHours": 36.2,
     "approvalRate": 75.3
+  }
+}
+```
+
+`GET /analytics/owner/:ownerId` response example:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "totalLands": 2,
+    "totalRequests": 5,
+    "pendingOwner": 1,
+    "approved": 3,
+    "rejected": 1,
+    "requestsLast30Days": 4,
+    "requestsLast7Days": 1,
+    "avgTimeToDecisionHours": 36.5,
+    "requestApprovalRate": 60.0,
+    "totalRevenue": 2550,
+    "landsByCategory": {
+      "agricultura": 1,
+      "ganaderia": 1
+    }
   }
 }
 ```

--- a/apps/backend-api/src/routes/analytics.ts
+++ b/apps/backend-api/src/routes/analytics.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono";
 
 import { success } from "../lib/api-response";
+import { isOwnerOrAdmin } from "../lib/auth-helpers";
+import { requireAuth } from "../middleware/require-auth";
 import { requireAdmin } from "../middleware/require-auth";
 import { getStore } from "../store/in-memory-db";
-import type { AppEnv, AppRole } from "../types";
+import type { AppEnv } from "../types";
 
 export const analyticsRoutes = new Hono<AppEnv>();
 
@@ -176,5 +178,78 @@ analyticsRoutes.get("/analytics/requests", (c) => {
     byIntendedUse,
     avgTimeToApprovalHours: Math.round(avgDecisionTimeMs / (1000 * 60 * 60) * 10) / 10,
     approvalRate: requests.length > 0 ? Math.round((approvedLast30Days.length / recentRequests.length) * 100 * 10) / 10 : 0,
+  });
+});
+
+analyticsRoutes.get("/analytics/owner/:ownerId", requireAuth, (c) => {
+  const authUser = c.get("authUser");
+  const ownerId = c.req.param("ownerId");
+  const store = getStore();
+
+  if (!isOwnerOrAdmin(authUser, ownerId)) {
+    return c.json({ ok: false, error: { code: "FORBIDDEN", message: "Not allowed to view this owner's analytics" } }, 403);
+  }
+
+  const now = Date.now();
+  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const ownerLands = Array.from(store.lands.values()).filter((l) => l.ownerId === ownerId);
+  const activeOwnerLands = ownerLands.filter((l) => l.status === "active");
+
+  const ownerLandIds = new Set(activeOwnerLands.map((l) => l.id));
+
+  const ownerRequests = Array.from(store.rentalRequests.values()).filter((r) => {
+    return ownerLandIds.has(r.landId);
+  });
+
+  const recentRequests = ownerRequests.filter((r) => r.createdAt >= thirtyDaysAgo);
+
+  const pendingOwner = ownerRequests.filter((r) => r.status === "pending_owner").length;
+  const approved = ownerRequests.filter((r) => r.status === "approved" || r.status === "pending_payment" || r.status === "paid").length;
+  const rejected = ownerRequests.filter((r) => r.status === "rejected").length;
+  const totalRequests = ownerRequests.length;
+
+  const landsByCategory: Record<string, number> = {};
+  for (const land of activeOwnerLands) {
+    for (const use of land.allowedUses) {
+      landsByCategory[use] = (landsByCategory[use] || 0) + 1;
+    }
+  }
+
+  let avgTimeToDecisionMs = 0;
+  const decidedRequests = ownerRequests.filter(
+    (r) => r.status !== "draft" && r.status !== "pending_owner" && r.status !== "pending_payment",
+  );
+  if (decidedRequests.length > 0) {
+    let totalDecisionTime = 0;
+    for (const req of decidedRequests) {
+      const created = new Date(req.createdAt).getTime();
+      const updated = new Date(req.updatedAt).getTime();
+      totalDecisionTime += updated - created;
+    }
+    avgTimeToDecisionMs = totalDecisionTime / decidedRequests.length;
+  }
+
+  let totalRevenue = 0;
+  const approvedRequestIds = new Set(approved > 0 ? ownerRequests.filter((r) => r.status === "paid" || r.status === "approved" || r.status === "pending_payment").map((r) => r.id) : []);
+  for (const payment of Array.from(store.payments.values())) {
+    if (payment.status === "paid" && approvedRequestIds.has(payment.rentalRequestId)) {
+      totalRevenue += payment.amount;
+    }
+  }
+
+  return success(c, {
+    totalLands: activeOwnerLands.length,
+    totalRequests,
+    pendingOwner,
+    approved,
+    rejected,
+    requestsLast30Days: recentRequests.length,
+    requestsLast7Days: recentRequests.filter((r) => r.createdAt >= sevenDaysAgo).length,
+    avgTimeToDecisionHours: avgTimeToDecisionMs > 0 ? Math.round(avgTimeToDecisionMs / (1000 * 60 * 60) * 10) / 10 : 0,
+    requestApprovalRate: totalRequests > 0 ? Math.round((approved / totalRequests) * 100 * 10) / 10 : 0,
+    totalRevenue,
+    landsByCategory,
   });
 });


### PR DESCRIPTION
## Summary
- Agrega `GET /api/v1/analytics/owner/:ownerId` en `apps/backend-api/src/routes/analytics.ts`
- Owner o admin pueden consultar métricas propias: tierras activas, solicitudes, tasa de aprobación, tiempo promedio de decisión y revenue
- Documentación actualizada en `API_ENDPOINTS.md`

## Métricas incluidas
- Total de tierras activas del owner
- Total de solicitudes recibidas (y divididas por estado)
- Solicitudes últimos 30 y 7 días
- Tiempo promedio de decisión (horas)
- Tasa de aprobación (%)
- Revenue total (pagos completados)
- Tierras activas por categoría

## Condiciones de aceptación (issue #87)
- [x] Existe endpoint `/analytics/owner/:ownerId`
- [x] Incluye avg decision time, approval rate, active lands by category