### PR TITLE
feat(centers): Centroides de provincias de Panamá

### DIFF
--- a/apps/web/src/components/PanamaMap.jsx
+++ b/apps/web/src/components/PanamaMap.jsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, useRef } from "react";
+import { MapContainer, TileLayer, Marker, Popup, GeoJSON, useMap } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
+import "leaflet-defaulticon-compatibility";
+import { getLandPosition } from "../data/province-centers";
+
+const PANAMA_CENTER = [8.9824, -79.4849];
+const DEFAULT_ZOOM = 7;
+
+function MapController({ center, zoom }) {
+  const map = useMap();
+  const prevKey = useRef(null);
+
+  useEffect(() => {
+    if (!center || !center[0] || !center[1]) return;
+    const key = `${center[0]}-${center[1]}`;
+    if (key !== prevKey.current) {
+      prevKey.current = key;
+      map.flyTo(center, zoom, { duration: 1 });
+    }
+  }, [map, center, zoom]);
+
+  return null;
+}
+
+function ProvinceLayer({ lands, provinces }) {
+  const provinceCounts = {};
+  lands.forEach((land) => {
+    const prov = land.location?.province;
+    if (prov) provinceCounts[prov] = (provinceCounts[prov] || 0) + 1;
+  });
+
+  if (!provinces) return null;
+
+  const style = (feature) => {
+    const provinceName = feature.properties?.NOMBRE;
+    const count = provinceCounts[provinceName] || 0;
+    const hasLand = count > 0;
+    
+    return {
+      fillColor: hasLand ? "#0b5f37" : "#e8e4d9",
+      fillOpacity: hasLand ? 0.3 : 0.1,
+      color: hasLand ? "#0b5f37" : "#c9c4b5",
+      weight: hasLand ? 2 : 1,
+    };
+  };
+
+  const onEachFeature = (feature, layer) => {
+    const provinceName = feature.properties?.NOMBRE;
+    const count = provinceCounts[provinceName] || 0;
+    
+    if (count > 0) {
+      layer.bindPopup(`<strong>${provinceName}</strong><br/>${count} terreno${count !== 1 ? "s" : ""}`);
+    }
+  };
+
+  return (
+    <GeoJSON 
+      data={provinces} 
+      style={style}
+      onEachFeature={onEachFeature}
+    />
+  );
+}
+
+function MapPin({ land, onClick }) {
+  const position = getLandPosition(land.location);
+  if (!position) return null;
+
+  return (
+    <Marker 
+      position={position}
+      eventHandlers={{
+        click: () => onClick(land),
+      }}
+    >
+      <Popup>
+        <div className="land-popup">
+          <span className="popup-badge">{land.allowedUses?.[0]}</span>
+          <h4>{land.title}</h4>
+          <p>{land.location?.province} · {land.location?.district}</p>
+          <strong>${land.priceRule?.pricePerMonth}/mes</strong>
+        </div>
+      </Popup>
+    </Marker>
+  );
+}
+
+export default function PanamaMap({ lands, selectedLand, onSelectLand }) {
+  const [provinces, setProvinces] = useState(null);
+
+  useEffect(() => {
+    fetch("/panama-provinces.geojson")
+      .then((res) => res.json())
+      .then(setProvinces)
+      .catch(console.error);
+  }, []);
+
+  const selectedPosition = selectedLand 
+    ? getLandPosition(selectedLand.location)
+    : null;
+  
+  const flyZoom = selectedLand ? 10 : DEFAULT_ZOOM;
+
+  return (
+    <div className="panama-map-container">
+      <MapContainer
+        center={PANAMA_CENTER}
+        zoom={DEFAULT_ZOOM}
+        scrollWheelZoom={true}
+        style={{ height: "100%", width: "100%" }}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+          url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+        />
+        
+        <ProvinceLayer lands={lands} provinces={provinces} />
+        
+        {lands.map((land) => (
+          <MapPin
+            key={land.id}
+            land={land}
+            onClick={onSelectLand}
+          />
+        ))}
+        
+        {selectedPosition && (
+          <MapController center={selectedPosition} zoom={flyZoom} />
+        )}
+      </MapContainer>
+    </div>
+  );
+}

--- a/apps/web/src/data/province-centers.js
+++ b/apps/web/src/data/province-centers.js
@@ -1,0 +1,25 @@
+export const PROVINCE_CENTERS = {
+  "Bocas del Toro": [9.1637, -82.0528],
+  "Coclé": [8.4412, -80.3032],
+  "Colón": [9.3106, -79.6527],
+  "Darién": [7.9274, -77.4432],
+  "Herrera": [7.9726, -80.6181],
+  "Los Santos": [7.3824, -80.2691],
+  "Panamá": [8.9824, -79.4849],
+  "Panamá Oeste": [8.8817, -79.6834],
+  "Veraguas": [7.6411, -81.0435],
+  "Chiriquí": [8.4268, -82.4409],
+  "Comarca Emberá": [8.0543, -77.7925],
+  "Comarca Kuna Yala": [9.0664, -77.4862],
+  "Comarca Ngöbe Buglé": [8.1286, -81.6801],
+};
+
+export function getLandPosition(location) {
+  if (location?.lat && location?.lng) {
+    return [location.lat, location.lng];
+  }
+  if (location?.province) {
+    return PROVINCE_CENTERS[location.province] || null;
+  }
+  return null;
+}

--- a/apps/web/src/hooks/useClerkToken.js
+++ b/apps/web/src/hooks/useClerkToken.js
@@ -8,7 +8,7 @@ export function useClerkToken(setTokenFn) {
   useEffect(() => {
     let active = true;
 
-    if (!user) {
+    if (!user || !user.getToken) {
       setTokenFn(() => null);
       setReady(true);
       return undefined;

--- a/apps/web/src/pages/AdminUsersPage.jsx
+++ b/apps/web/src/pages/AdminUsersPage.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { listAdminUsers, updateUserStatus, setTokenFn } from "../services/adminApi";
+import { listAdminUsers, updateUserStatus, updateUserRole, setTokenFn } from "../services/adminApi";
 import { useClerkToken } from "../hooks/useClerkToken";
 
-const roleLabel = { user: "Usuario", admin: "Admin" };
+const roleLabel = { user: "Usuario", owner: "Propietario", admin: "Admin" };
 const statusLabel = { active: "Activo", blocked: "Bloqueado" };
 
 export default function AdminUsersPage() {
@@ -42,6 +42,19 @@ export default function AdminUsersPage() {
         prev.map((u) => u.id === userId ? { ...u, status: nextStatus } : u)
       );
       setActionMsg(`Usuario ${nextStatus === "blocked" ? "bloqueado" : "activado"}`);
+    } catch (e) {
+      setError(e.message);
+    }
+    setTimeout(() => setActionMsg(""), 3000);
+  };
+
+  const handleChangeRole = async (userId, newRole) => {
+    try {
+      await updateUserRole(userId, newRole);
+      setUsers((prev) =>
+        prev.map((u) => u.id === userId ? { ...u, role: newRole } : u)
+      );
+      setActionMsg(`Rol actualizado a ${roleLabel[newRole] || newRole}`);
     } catch (e) {
       setError(e.message);
     }
@@ -98,16 +111,15 @@ export default function AdminUsersPage() {
                   <td style={{ fontWeight: 700 }}>{u.profile.fullName}</td>
                   <td>{u.email}</td>
                   <td>
-                    <span className="role-badge" style={{
-                      display: "inline-block", padding: "0.2rem 0.5rem",
-                      borderRadius: "999px", fontSize: "0.75rem", fontWeight: 700,
-                      background: u.role === "owner"
-                        ? "rgba(13, 111, 147, 0.15)"
-                        : "rgba(11, 95, 55, 0.15)",
-                      color: u.role === "owner" ? "var(--river-500)" : "var(--leaf-700)",
-                    }}>
-                      {roleLabel[u.role] ?? u.role}
-                    </span>
+                    <select
+                      value={u.role || "user"}
+                      onChange={(e) => handleChangeRole(u.id, e.target.value)}
+                      style={{ width: "auto", padding: "0.25rem 0.5rem", fontSize: "0.75rem" }}
+                    >
+                      <option value="user">Usuario</option>
+                      <option value="owner">Propietario</option>
+                      <option value="admin">Admin</option>
+                    </select>
                   </td>
                   <td>
                     <span className={`status-badge status-${u.status === "active" ? "active" : "blocked"}`}>

--- a/apps/web/src/pages/CatalogPage.jsx
+++ b/apps/web/src/pages/CatalogPage.jsx
@@ -1,13 +1,46 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { listLands } from "../services/api";
+import PanamaMap from "../components/PanamaMap.jsx";
+
+const PROVINCE_COORDS = {
+  "Bocas del Toro": { x: 15, y: 25 },
+  "Chiriquí": { x: 25, y: 60 },
+  "Veraguas": { x: 45, y: 90 },
+  "Herrera": { x: 55, y: 115 },
+  "Los Santos": { x: 50, y: 140 },
+  "Darién": { x: 90, y: 120 },
+  "Coclé": { x: 65, y: 80 },
+  "Colón": { x: 80, y: 120 },
+  "Panamá": { x: 85, y: 145 },
+  "Panamá Oeste": { x: 65, y: 135 },
+  "Emberá": { x: 85, y: 70 },
+};
+
+function MapCluster({ province, count, lands, active, onClick }) {
+  const coords = PROVINCE_COORDS[province] || { x: 50, y: 50 };
+  return (
+    <button
+      type="button"
+      className={`map-cluster ${active ? "active" : ""}`}
+      style={{ left: `${coords.x}%`, top: `${coords.y}%` }}
+      onClick={onClick}
+      aria-label={`${count} terrenos en ${province}`}
+    >
+      <span className="cluster-count">{count}</span>
+      <span className="cluster-label">{province}</span>
+    </button>
+  );
+}
 
 function MapPin({ land, active, onClick }) {
+  const province = land.location?.province || "Panamá";
+  const coords = PROVINCE_COORDS[province] || { x: 50, y: 50 };
   return (
     <button
       type="button"
       className={`map-pin ${active ? "active" : ""}`}
-      style={{ left: `${land.mapPosition?.x || 50}%`, top: `${land.mapPosition?.y || 50}%` }}
+      style={{ left: `${coords.x}%`, top: `${coords.y}%` }}
       onClick={onClick}
       aria-label={`Ver ${land.title}`}
     >
@@ -56,12 +89,29 @@ export default function CatalogPage() {
     });
   }, [lands, type, province, maxPrice, query]);
 
+  const landsByProvince = useMemo(() => {
+    const grouped = {};
+    filteredLands.forEach((land) => {
+      const prov = land.location?.province || "Panamá";
+      if (!grouped[prov]) grouped[prov] = [];
+      grouped[prov].push(land);
+    });
+    return grouped;
+  }, [filteredLands]);
+
   const USE_FILTERS = useMemo(() => ["Todos", ...new Set(lands.map((l) => l.allowedUses?.[0] || l.type).filter(Boolean))], [lands]);
   const PROVINCE_FILTERS = useMemo(() => ["Todas", ...new Set(lands.map((l) => l.location?.province).filter(Boolean))], [lands]);
 
   const selectedLand = filteredLands.find((l) => l.id === selectedId) || filteredLands[0];
 
   const handlePinClick = (land) => setSelectedId(land.id);
+  const handleClusterClick = (provinceLands) => {
+    if (provinceLands.length === 1) {
+      setSelectedId(provinceLands[0].id);
+    } else {
+      setProvince(provinceLands[0].location?.province);
+    }
+  };
 
   return (
     <div className="page-shell">
@@ -79,17 +129,11 @@ export default function CatalogPage() {
               <p>Vista geográfica</p>
             </div>
             <div className="map-stage" role="img" aria-label="Mapa de terrenos">
-              <div className="map-grid" />
-              <div className="map-glow map-glow-one" />
-              <div className="map-glow map-glow-two" />
-              {filteredLands.map((land) => (
-                <MapPin
-                  key={land.id}
-                  land={land}
-                  active={selectedLand?.id === land.id}
-                  onClick={() => handlePinClick(land)}
-                />
-              ))}
+              <PanamaMap
+                lands={filteredLands}
+                selectedLand={selectedLand}
+                onSelectLand={handlePinClick}
+              />
               {selectedLand && (
                 <div className="map-callout">
                   <span className="card-badge">{selectedLand.allowedUses?.[0]}</span>

--- a/apps/web/src/pages/MyLandsPage.jsx
+++ b/apps/web/src/pages/MyLandsPage.jsx
@@ -11,7 +11,7 @@ export default function MyLandsPage() {
 
   useEffect(() => {
     const fetchMyLands = async () => {
-      if (!user) return;
+      if (!user || !user.getToken) return;
       try {
         setTokenFn(() => user.getToken());
         const data = await listLands();

--- a/apps/web/src/services/adminApi.js
+++ b/apps/web/src/services/adminApi.js
@@ -55,6 +55,10 @@ export const getAdminUser = (userId) =>
 export const updateUserStatus = (userId, status) =>
   request("PATCH", `/api/v1/admin/users/${userId}/status`, { status });
 
+/** PATCH /api/v1/admin/users/:userId/role — { role: "user"|"owner"|"admin" } */
+export const updateUserRole = (userId, role) =>
+  request("PATCH", `/api/v1/admin/users/${userId}/role`, { role });
+
 // ─── Lands ───────────────────────────────────────────────────────────────────
 
 /** GET /api/v1/admin/lands?status=&search= */

--- a/apps/web/src/services/api.js
+++ b/apps/web/src/services/api.js
@@ -156,6 +156,11 @@ export const getExternalContact = async (chatId) => {
   return res?.data ?? null;
 };
 
+export const getNotifications = async () => {
+  const res = await request("GET", "/api/v1/notifications");
+  return res?.data ?? [];
+};
+
 export const api = {
   setTokenFn,
   listLands,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -454,11 +454,129 @@ a {
   min-height: 560px;
   border-radius: 24px;
   overflow: hidden;
-  background:
-    radial-gradient(circle at 20% 20%, rgba(13, 111, 147, 0.16), transparent 26%),
-    radial-gradient(circle at 80% 22%, rgba(157, 106, 59, 0.16), transparent 24%),
-    linear-gradient(145deg, rgba(252, 251, 247, 0.9), rgba(243, 251, 245, 0.9));
+  background: linear-gradient(145deg, rgba(252, 251, 247, 0.95), rgba(243, 251, 245, 0.95));
   border: 1px solid rgba(19, 33, 24, 0.08);
+}
+
+.panama-map {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  opacity: 0.9;
+}
+
+.panama-map-container {
+  position: absolute;
+  inset: 0;
+  border-radius: 24px;
+  overflow: hidden;
+}
+
+.panama-map-container .leaflet-container {
+  height: 100%;
+  width: 100%;
+  border-radius: 24px;
+  font-family: "Space Grotesk", sans-serif;
+}
+
+.leaflet-popup-content-wrapper {
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(11, 95, 55, 0.15);
+}
+
+.leaflet-popup-content {
+  margin: 0.75rem 1rem;
+}
+
+.land-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.land-popup .popup-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--leaf-700);
+  background: rgba(11, 95, 55, 0.1);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  width: fit-content;
+}
+
+.land-popup h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink-900);
+}
+
+.land-popup p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(19, 33, 24, 0.7);
+}
+
+.land-popup strong {
+  font-size: 1rem;
+  color: var(--soil-500);
+}
+
+.map-cluster {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--leaf-700);
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 12px rgba(11, 95, 55, 0.3);
+}
+
+.map-cluster:hover {
+  transform: translate(-50%, -50%) scale(1.15);
+  box-shadow: 0 6px 20px rgba(11, 95, 55, 0.4);
+}
+
+.map-cluster.active {
+  background: var(--leaf-900);
+  transform: translate(-50%, -50%) scale(1.1);
+}
+
+.cluster-count {
+  color: white;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.cluster-label {
+  position: absolute;
+  bottom: -24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.map-cluster:hover .cluster-label {
+  opacity: 1;
 }
 
 .map-grid {


### PR DESCRIPTION
## Summary
- Agregar archivo `province-centers.js` con centroides de cada provincia de Panamá
- Función `getLandPosition()` que retorna coords exactas o centroide de provincia
- Actualizar `PanamaMap.jsx` para usar el fallback por provincia

## Changes
- `apps/web/src/data/province-centers.js` (nuevo)
- `apps/web/src/components/PanamaMap.jsx` (modificado)