### PR TITLE
feat: migrate backend routes to MongoDB and fix frontend pages

### DIFF
--- a/CLERK_TOKENS_REMOVAL.md
+++ b/CLERK_TOKENS_REMOVAL.md
@@ -1,0 +1,93 @@
+# Clerk Tokens Removal - Roadmap
+
+> **Estado:** Completado en frontend
+> **Fecha:** 2026-04-26
+
+## Resumen
+
+Este documento detalla el roadmap para eliminar el uso de tokens JWT de Clerk del sistema, manteniendo solo Clerk para autenticación de login (información del usuario).
+
+---
+
+## ✅ Completado
+
+### Fase 1: Admin Dashboard Fix
+- [x] Remover `useClerkToken` de App.jsx (AdminDashboardPage)
+- [x] Simplificar efecto sin dependencia de tokenReady
+- [x] Remover imports de useClerkToken y setAdminTokenFn
+
+### Fase 2: Simplificar API Services
+- [x] **adminApi.js**: Eliminar `setTokenFn`, siempre usar dev bypass headers en DEV
+- [x] **api.js**: Eliminar `setTokenFn`, siempre usar dev bypass headers en DEV
+
+### Fase 3: Limpiar Páginas
+- [x] **MyLandsPage.jsx**: Remover `setTokenFn`, usar `getMyLands()`
+- [x] **PaymentsPage.jsx**: Remover `setTokenFn`, usar `getMyPayments()`
+- [x] **ChatsPage.jsx**: Remover `setTokenFn`, usar `getChats()`
+- [x] **LandDetailPage.jsx**: Remover `setTokenFn`, usar functions de api
+- [x] **ReservePage.jsx**: Remover `useClerkToken` y `setTokenFn`
+- [x] **AdminUsersPage.jsx**: Remover `useClerkToken` y `setTokenFn`
+- [x] **AdminLandsPage.jsx**: Remover `useClerkToken` y `setTokenFn`
+
+---
+
+## Pendiente (Backlog)
+
+### Backend - Simplificar Middleware (Opcional)
+Cuando el frontend esté funcionando sin tokens, el backend aún espera los headers `x-dev-role` y `x-dev-user-id` en desarrollo. Esto ya funciona correctamente.
+
+**Opcional:** Revisar si se quiere:
+- [ ] Usar autenticación real en producción (requiere integración con Clerk JWT)
+- [ ] Simplificar middleware require-auth.ts para producción real
+
+### Hook useClerkToken
+El archivo `apps/web/src/hooks/useClerkToken.js` ya no se usa en ninguna página. 
+
+**Opcional:** 
+- [ ] Eliminar archivo si no se necesita más
+- [ ] Mantener para futuro uso potencial
+
+---
+
+## Arquitectura Final
+
+### Desarrollo (DEV)
+```
+Frontend → headers x-dev-role/x-dev-user-id → Backend
+```
+
+### Produccion (PROD)
+```
+Frontend → (sin headers) → 401 Unauthorized
+```
+
+Si se necesita auth real en producción, se debe integrar con Clerk JWT verification.
+
+---
+
+## Archivos Modificados
+
+| Archivo | Acción |
+|---------|--------|
+| `App.jsx` | Remover imports de token |
+| `adminApi.js` | Simplificar headers |
+| `api.js` | Simplificar headers |
+| `useClerkToken.js` | No usado (pendiente eliminar) |
+| `MyLandsPage.jsx` | Limpiar imports |
+| `PaymentsPage.jsx` | Limpiar imports |
+| `ChatsPage.jsx` | Limpiar imports |
+| `LandDetailPage.jsx` | Limpiar imports |
+| `ReservePage.jsx` | Limpiar imports |
+| `AdminUsersPage.jsx` | Limpiar imports |
+| `AdminLandsPage.jsx` | Limpiar imports |
+
+---
+
+## Notas
+
+- Clerk SIGUE siendo usado para:
+  - `useUser()` - obtener información del usuario (user.id, user.email, etc.)
+  - `<ClerkProvider>` en main.jsx
+  - Componentes de Login/Register
+
+- Tokens de Clerk YA NO son necesarios para las llamadas API

--- a/ENDPOINTS_RUTAS.md
+++ b/ENDPOINTS_RUTAS.md
@@ -1,0 +1,252 @@
+# ENDPOINTS_RUTAS.md
+
+> Documentación completa de endpoints del backend, rutas del frontend y guía de contribución.
+
+---
+
+## 1. Endpoints del Backend API
+
+### lands.ts
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| GET | `/api/v1/lands` | Lista tierras con filtros | Público |
+| GET | `/api/v1/lands/:landId` | Obtener tierra por ID | Público |
+| POST | `/api/v1/lands` | Crear nueva tierra | Required |
+| PATCH | `/api/v1/lands/:landId` | Actualizar tierra | Owner/Admin |
+| PATCH | `/api/v1/lands/:landId/status` | Cambiar estado | Owner/Admin |
+| DELETE | `/api/v1/lands/:landId` | Eliminar tierra | Owner/Admin |
+
+**Filtros:** `use`, `province`, `district`, `priceMin`, `priceMax`, `availableFrom`, `availableTo`, `sort`, `order`, `page`, `pageSize`
+
+### rental-requests.ts
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| GET | `/api/v1/rental-requests` | Lista solicitudes | User |
+| GET | `/api/v1/rental-requests/:requestId` | Obtener solicitud | User |
+| POST | `/api/v1/rental-requests` | Crear solicitud | User |
+| PATCH | `/api/v1/rental-requests/:requestId/status` | Cambiar estado | Owner/Admin |
+
+### contracts.ts
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| GET | `/api/v1/contracts` | Lista contratos | User |
+| GET | `/api/v1/contracts/:contractId` | Obtener contrato | User |
+| POST | `/api/v1/contracts` | Crear contrato | User |
+| PATCH | `/api/v1/contracts/:contractId/status` | Cambiar estado | Owner/Admin |
+| POST | `/api/v1/contracts/:contractId/sign` | Firmar contrato | User |
+| POST | `/api/v1/contracts/:contractId/complete` | Completar contrato | User |
+| GET | `/api/v1/audit-events` | Lista eventos auditoría | Admin |
+| GET | `/api/v1/audit-events/:eventId` | Detalle evento | Admin |
+
+### payments.ts
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| POST | `/api/v1/payments/checkout-session` | Crear sesión Stripe | User |
+| GET | `/api/v1/payments` | Lista pagos | User |
+| GET | `/api/v1/payments/:paymentId` | Obtener pago | User |
+| POST | `/api/v1/webhooks/stripe` | Webhook Stripe | Webhook |
+
+### chat.ts
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| GET | `/api/v1/chats` | Lista chats | User |
+| POST | `/api/v1/chats` | Crear chat | User |
+| GET | `/api/v1/chats/:chatId/messages` | Obtener mensajes | User |
+| POST | `/api/v1/chats/:chatId/messages` | Enviar mensaje | User |
+| GET | `/api/v1/chats/:chatId/external-contact` | Contacto WhatsApp | User |
+
+### admin.ts
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| GET | `/api/v1/admin/users` | Lista usuarios | Admin |
+| GET | `/api/v1/admin/users/:userId` | Detalle usuario | Admin |
+| PATCH | `/api/v1/admin/users/:userId/status` | Cambiar estado | Admin |
+| GET | `/api/v1/admin/lands` | Lands para moderación | Admin |
+| PATCH | `/api/v1/admin/lands/:landId/status` | Aprobar/rechazar | Admin |
+| GET | `/api/v1/admin/summary` | Dashboard summary | Admin |
+| GET | `/api/v1/admin/rental-requests` | Solicitudes (admin) | Admin |
+
+### analytics.ts
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| GET | `/api/v1/analytics/overview` | Dashboard overview | Admin |
+| GET | `/api/v1/analytics/lands` | Lands por provincia | Admin |
+| GET | `/api/v1/analytics/requests` | Requests analytics | Admin |
+| GET | `/api/v1/analytics/owner/:ownerId` | Owner analytics | Admin |
+
+### Otros endpoints
+| Método | Ruta | Descripción | Auth |
+|-------|------|-------------|------|
+| GET | `/api/v1/health` | Health check | Público |
+| GET | `/api/v1/auth/me` | Current user | Required |
+| GET | `/api/v1/auth/admin/ping` | Admin check | Admin |
+| POST | `/api/v1/leads` | Crear lead | Público |
+| GET | `/api/v1/leads` | Lista leads | Admin |
+| GET | `/api/v1/notifications` | Lista notificaciones | User |
+| PATCH | `/api/v1/notifications/:notificationId/read` | Marcar leída | User |
+
+---
+
+## 2. Frontend API Service
+
+**Archivo:** `apps/web/src/services/api.js`
+
+### Funciones exportadas
+
+| Función | Endpoint | Descripción |
+|---------|----------|-------------|
+| `listLands(filters)` | GET `/api/v1/lands` | Lista tierras con filtros |
+| `getLandById(landId)` | GET `/api/v1/lands/:landId` | Obtener tierra |
+| `createRentalRequest(payload)` | POST `/api/v1/rental-requests` | Crear solicitud |
+| `listRentalRequests()` | GET `/api/v1/rental-requests` | Lista solicitudes |
+| `createCheckoutSession(payload)` | POST `/api/v1/payments/checkout-session` | Crear sesión pago |
+| `getPaymentsByRequest(rentalRequestId)` | GET `/api/v1/payments` | Lista pagos |
+| `getChats()` | GET `/api/v1/chats` | Lista chats |
+| `createChat(payload)` | POST `/api/v1/chats` | Crear chat |
+| `getMessages(chatId)` | GET `/api/v1/chats/:chatId/messages` | Obtener mensajes |
+| `sendMessage(chatId, text)` | POST `/api/v1/chats/:chatId/messages` | Enviar mensaje |
+| `getExternalContact(chatId)` | GET `/api/v1/chats/:chatId/external-contact` | Contacto WhatsApp |
+| `adaptLand(land)` | - | Adapta tierra para detail |
+| `adaptLandForCatalog(land)` | - | Adapta tierra para catálogo |
+
+### Adaptadores
+
+```javascript
+// Adapta землю para detail page
+const adapted = adaptLand(land);
+// Para catálogo
+const catalog = adaptLandForCatalog(land);
+```
+
+---
+
+## 3. Rutas del Frontend
+
+**Archivo:** `apps/web/src/App.jsx`
+
+| Ruta | Página | Auth | Componente |
+|------|-------|------|-----------|
+| `/` | LandingPage | Público | LandingPage.jsx |
+| `/catalog` | CatalogPage | User | CatalogPage.jsx |
+| `/lands/:id` | LandDetailPage | Público | LandDetailPage.jsx |
+| `/reserve/:landId` | ReservePage | User | ReservePage.jsx |
+| `/login` | Login | Público | Login.jsx |
+| `/register` | Register | Público | Register.jsx |
+| `/checkout/success` | PaymentSuccess | User | PaymentSuccessPage.jsx |
+| `/checkout/cancel` | PaymentCancel | User | PaymentCancelPage.jsx |
+| `/dashboard` | Dashboard | User | DashboardPage.jsx |
+| `/dashboard/lands` | MyLands | User | MyLandsPage.jsx |
+| `/dashboard/chats` | Chats | User | ChatsPage.jsx |
+| `/dashboard/notifications` | Notifications | User | NotificationsPage.jsx |
+| `/dashboard/payments` | Payments | User | PaymentsPage.jsx |
+| `/dashboard/profile` | Profile | User | ProfilePage.jsx |
+| `/dashboard/admin` | AdminDashboard | Admin | AdminDashboardPage.jsx |
+| `/dashboard/admin/users` | AdminUsers | Admin | AdminUsersPage.jsx |
+| `/dashboard/admin/lands` | AdminLands | Admin | AdminLandsPage.jsx |
+
+### Layouts
+
+- **Público:** `PublicHeader` (solo nav pública)
+- **User:** `UserDashboardLayout` (nav + sidebar)
+- **Admin:** `AdminLayout` (nav + sidebar admin)
+
+---
+
+## 4. Guía de Contribución
+
+### Estructura de Ramas
+
+```
+feature/web/<issue-id>-<slug>        # Frontend
+feature/backend-api/<issue-id>-<slug>  # Backend
+fix/<issue-id>-<slug>             # Fix
+chore/<slug>                     # Chore
+```
+
+### Commits
+
+```bash
+# Features
+git commit -m "feat(backend-api): add new endpoint"
+git commit -m "feat(web): add new page"
+
+# Fixes
+git commit -m "fix: resolve issue"
+
+# Chores
+git commit -m "chore: update dependencies"
+```
+
+### Flujo de Trabajo
+
+1. **Crear rama desde main:**
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b feature/web/123-description
+   ```
+
+2. **Hacer cambios:**
+   ```bash
+   git add .
+   git commit -m "feat: description"
+   ```
+
+3. **Push y PR:**
+   ```bash
+   git push -u origin feature/web/123-description
+   gh pr create --title "feat(web): ..." --body "Closes #123"
+   ```
+
+### Requisitos de PR
+
+- 1 revisor obligatorio
+- Todos los checks en verde
+- Body debe incluir keyword: `Closes #`, `Fixes #`, `Resolves #`
+- No merge directo a main
+
+### Comandos de Desarrollo
+
+```bash
+# Frontend
+cd apps/web && bun run dev          # Puerto 5173
+
+# Backend
+cd apps/backend-api && bun run dev   # Puerto 3000
+
+# E2E Tests
+cd apps/web && bun run test:e2e
+```
+
+---
+
+## 5. Migración Pendiente
+
+### Routes que necesitan migración a MongoDB
+
+- [ ] routes/rental-requests.ts
+- [ ] routes/contracts.ts
+- [ ] routes/payments.ts
+- [ ] routes/chat.ts
+- [ ] routes/admin.ts
+- [ ] routes/leads.ts
+- [ ] routes/analytics.ts
+- [ ] routes/notifications.ts
+
+### Pages que necesitan revisión
+
+- [ ] CatalogPage.jsx - listLands
+- [ ] LandDetailPage.jsx - getLandById
+- [ ] ReservePage.jsx - createRentalRequest
+- [ ] MyLandsPage.jsx - lands del usuario
+- [ ] ChatsPage.jsx - getChats, getMessages
+- [ ] PaymentsPage.jsx - getPayments
+- [ ] AdminDashboardPage.jsx - analytics
+
+---
+
+## Notas
+
+- El backend usa MongoDB con fallback in-memory
+- El frontend consume todos los endpoints listados
+- La autenticación es via Clerk (Bearer token)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,223 @@
+# MIGRATION.md
+
+> Plan de migración y mejoras para TerraShare. Ejecutar en orden de prioridad.
+
+---
+
+## TAREA 1: MongoDB - Migración Completa
+
+### Estado Actual
+- Backend usa `in-memory-db.ts` (almacenamiento en memoria RAM)
+- No hay persistencia - datos se pierden al reiniciar servidor
+- 9 colecciones: users, lands, rentalRequests, contracts, payments, chats, chatMessages, auditEvents, leads
+
+### Objetivo
+- Migrar a MongoDB local: `mongodb://127.0.0.1:27017/terrashare`
+- Datos persistentes entre reinicios
+- Mantener API compatible con in-memory como fallback
+
+### 1.1 Instalar dependencias
+
+```bash
+cd apps/backend-api
+bun add mongodb mongoose
+```
+
+### 1.2 Actualizar `.env.local`
+
+Agregar al final de `apps/backend-api/.env.local`:
+
+```
+MONGODB_URI=mongodb://127.0.0.1:27017/terrashare
+```
+
+### 1.3 Crear `apps/backend-api/src/config/database.ts`
+
+```typescript
+import { MongoClient, Db } from "mongodb";
+
+let client: MongoClient | null = null;
+let db: Db | null = null;
+
+const DEFAULT_URI = "mongodb://127.0.0.1:27017";
+const DEFAULT_DB = "terrashare";
+
+export async function connectDatabase(): Promise<Db> {
+  if (db) return db;
+
+  const uri = process.env.MONGODB_URI || DEFAULT_URI;
+  const dbName = process.env.MONGODB_URI?.split("/").pop() || DEFAULT_DB;
+
+  try {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(dbName);
+    console.log(`[database] Connected to MongoDB: ${dbName}`);
+    return db;
+  } catch (error) {
+    console.error("[database] Connection failed:", error);
+    throw error;
+  }
+}
+
+export function getDatabase(): Db | null {
+  return db;
+}
+
+export async function closeDatabase(): Promise<void> {
+  if (client) {
+    await client.close();
+    client = null;
+    db = null;
+    console.log("[database] Connection closed");
+  }
+}
+```
+
+### 1.4 Verificar que MongoDB esté corriendo
+
+```bash
+# En otra terminal
+mongod
+# O verificar estado
+pgrep -x mongod
+```
+
+### 1.5 Prueba de conexión
+
+```bash
+cd apps/backend-api
+bun run dev
+
+# En otra terminal, probar endpoint
+curl http://localhost:3000/api/v1/lands
+```
+
+---
+
+## TAREA 2: Navbar LandDetailPage
+
+### Estado Actual
+- `LandDetailPage.jsx` ya usa `PublicHeader`
+- Verificar que concuede con el diseño del catálogo
+
+### Pasos de Verificación
+
+1. Revisar que el navbar se vea igual que en CatalogPage
+2. Si hay diferencias, ajustar en `styles.css`
+
+---
+
+## TAREA 3: Diseño Mejorado - LandDetailPage
+
+### Análisis con SKILL.md (docs/SKILL.md)
+
+El SKILL.md indica:
+- **Evitar**: generic "AI slop", fonts genéricos, layouts predecibles
+- **Enfoque**: Diseño intentional con dirección clara
+
+### Propuesta: Estilo Natural/Orgánico
+
+#### Características
+- Colores tierra, verde hoja, tonos suaves
+- Formas orgánicas, gradientes sutiles, texturas
+- Tipografía distintiva
+- Espaciado generoso
+
+### Pasos de Implementación
+
+1. Agregar estilos CSS en `styles.css`
+2. Mejorar componentes JSX
+3. Agregar animaciones
+
+---
+
+## Guía de Contribución al Repositorio Remoto
+
+### 1. Configuración Inicial
+
+```bash
+# Clonar repo
+git clone https://github.com/1ZH13/TerraShare.git
+cd TerraShare
+
+# Instalar dependencias
+bun install
+
+# Configurar variables de entorno
+cp apps/web/.env.example apps/web/.env.local
+cp apps/backend-api/.env.example apps/backend-api/.env.local
+```
+
+### 2. Flujo de Trabajo por Issue
+
+1. **Crear issue** con alcance y criterios de aceptación
+2. **Crear rama** desde main:
+   ```bash
+   git checkout -b feature/web/<issue-id>-<slug>
+   ```
+3. **Implementar** cambios átomicos
+4. **Abrir PR** referenciando el issue:
+   ```bash
+   gh pr create --title "feat(web): ..." --body "..."
+   # Body debe incluir: Closes #<id>
+   ```
+5. **Pasar CI** (checks automáticos)
+6. **Recibir aprobación** (1 revisor mínimo)
+7. **Squash merge** a main
+
+### 3. Sincronizar con Main
+
+```bash
+# Actualizar main
+git checkout main
+git fetch origin
+git pull origin main
+
+# Traer cambios a tu rama
+git checkout feature/<tu-rama>
+git merge origin/main
+```
+
+### 4. Reglas de PR
+
+- 1 revisor obligatorio
+- Todos los checks en verde
+- Body debe incluir keyword de cierre: `Closes #`, `Fixes #`, `Resolves #`
+- Prohibido merge directo a main
+
+### 5. Comandos Útiles
+
+```bash
+# Servidores
+cd apps/web && bun run dev      # Puerto 5173
+cd apps/backend-api && bun run dev  # Puerto 3000
+
+# Testing
+cd apps/web && bun run test:e2e
+
+# Git
+git status
+git add .
+git commit -m "feat: ..."
+git push -u origin feature/<rama>
+gh pr create
+```
+
+### 6. Estructura de Ramas
+
+```
+feature/web/<issue-id>-<slug>        # Frontend
+feature/backend-api/<issue-id>-<slug>  # Backend
+fix/<issue-id>-<slug>             # Fix
+chore/<slug>                     # Chore
+```
+
+---
+
+## Notas
+
+- MongoDB requiere estar instalado y corriendo localmente
+- El backend usa Bun como runtime
+- Frontend usa Vite + React 18
+- Autenticación via Clerk

--- a/apps/backend-api/bun.lock
+++ b/apps/backend-api/bun.lock
@@ -7,6 +7,8 @@
       "dependencies": {
         "hono": "^4.7.2",
         "jose": "^5.9.6",
+        "mongodb": "^7.2.0",
+        "mongoose": "^9.5.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -18,11 +20,19 @@
     },
   },
   "packages": {
+    "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.9", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA=="],
+
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/stripe": ["@types/stripe@8.0.417", "", { "dependencies": { "stripe": "*" } }, "sha512-PTuqskh9YKNENnOHGVJBm4sM0zE8B1jZw1JIskuGAPkMB+OH236QeN8scclhYGPA4nG6zTtPXgwpXdp+HPDTVw=="],
+
+    "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
+
+    "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
+
+    "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
@@ -30,10 +40,40 @@
 
     "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
+    "kareem": ["kareem@3.3.0", "", {}, "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw=="],
+
+    "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
+
+    "mongodb": ["mongodb@7.2.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.2.0", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw=="],
+
+    "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.1", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ=="],
+
+    "mongoose": ["mongoose@9.5.0", "", { "dependencies": { "kareem": "3.3.0", "mongodb": "~7.1", "mpath": "0.9.0", "mquery": "6.0.0", "ms": "2.1.3", "sift": "17.1.3" } }, "sha512-B4blGFkFL1s0G24URuMvx0qTlx+gRVLmfO7WcSz8NcmW/XHEJ3G69capdyW1iRsGKiycp1tkwKHnxHbnwjwmPw=="],
+
+    "mpath": ["mpath@0.9.0", "", {}, "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="],
+
+    "mquery": ["mquery@6.0.0", "", {}, "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "sift": ["sift@17.1.3", "", {}, "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="],
+
+    "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
+
     "stripe": ["stripe@22.0.2", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-2/BLrQ3oB1zlNfeL/LfHFjTGx6EQn0j+ztrrTJHuDjV5VVIpk92oSDaxyKLUr3pG3dnee2LZqhFUv2Bf0G1/3g=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "mongoose/mongodb": ["mongodb@7.1.1", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w=="],
   }
 }

--- a/apps/backend-api/package.json
+++ b/apps/backend-api/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "hono": "^4.7.2",
-    "jose": "^5.9.6"
+    "jose": "^5.9.6",
+    "mongodb": "^7.2.0",
+    "mongoose": "^9.5.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/apps/backend-api/src/config/database.ts
+++ b/apps/backend-api/src/config/database.ts
@@ -1,0 +1,77 @@
+import { MongoClient, Db } from "mongodb";
+
+let client: MongoClient | null = null;
+let db: Db | null = null;
+
+const DEFAULT_URI = "mongodb://127.0.0.1:27017";
+const DEFAULT_DB = "terrashare";
+
+export async function connectDatabase(): Promise<Db> {
+  if (db) return db;
+
+  const uri = process.env.MONGODB_URI || DEFAULT_URI;
+  const dbName = process.env.MONGODB_URI?.split("/").pop() || DEFAULT_DB;
+
+  try {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(dbName);
+    console.log(`[database] Connected to MongoDB: ${dbName}`);
+    
+    await createIndexes(db);
+    return db;
+  } catch (error) {
+    console.error("[database] Connection failed:", error);
+    throw error;
+  }
+}
+
+async function createIndexes(db: Db) {
+  console.log("[database] Creating indexes...");
+  
+  await db.collection("lands").createIndex({ id: 1 }, { unique: true });
+  await db.collection("lands").createIndex({ ownerId: 1 });
+  await db.collection("lands").createIndex({ status: 1 });
+  
+  await db.collection("users").createIndex({ clerkUserId: 1 }, { unique: true });
+  await db.collection("users").createIndex({ id: 1 }, { unique: true });
+  
+  await db.collection("rentalRequests").createIndex({ id: 1 }, { unique: true });
+  await db.collection("rentalRequests").createIndex({ landId: 1 });
+  await db.collection("rentalRequests").createIndex({ tenantId: 1 });
+  await db.collection("rentalRequests").createIndex({ status: 1 });
+  
+  await db.collection("contracts").createIndex({ id: 1 }, { unique: true });
+  await db.collection("contracts").createIndex({ ownerId: 1 });
+  await db.collection("contracts").createIndex({ tenantId: 1 });
+  
+  await db.collection("payments").createIndex({ id: 1 }, { unique: true });
+  await db.collection("payments").createIndex({ rentalRequestId: 1 });
+  
+  await db.collection("chats").createIndex({ id: 1 }, { unique: true });
+  await db.collection("chats").createIndex({ landId: 1 });
+  
+  await db.collection("chatMessages").createIndex({ id: 1 }, { unique: true });
+  await db.collection("chatMessages").createIndex({ chatId: 1, createdAt: 1 });
+  
+  await db.collection("auditEvents").createIndex({ id: 1 }, { unique: true });
+  await db.collection("auditEvents").createIndex({ entity: 1, entityId: 1 });
+  
+  await db.collection("leads").createIndex({ id: 1 }, { unique: true });
+  await db.collection("leads").createIndex({ email: 1 });
+  
+  console.log("[database] Indexes created");
+}
+
+export function getDatabase(): Db | null {
+  return db;
+}
+
+export async function closeDatabase(): Promise<void> {
+  if (client) {
+    await client.close();
+    client = null;
+    db = null;
+    console.log("[database] Connection closed");
+  }
+}

--- a/apps/backend-api/src/db/collections.ts
+++ b/apps/backend-api/src/db/collections.ts
@@ -1,0 +1,232 @@
+import { getDatabase } from "../config/database";
+import {
+  User, Land, RentalRequest, Contract, Payment,
+  Chat, ChatMessage, AuditEvent, Lead
+} from "./schemas";
+
+function getColl(name: string) {
+  const db = getDatabase();
+  if (!db) throw new Error("Database not connected");
+  return db.collection(name);
+}
+
+export async function listLands(filters?: { ownerId?: string; status?: string }) {
+  const coll = getColl("lands");
+  const query: Record<string, unknown> = {};
+  if (filters?.ownerId) query.ownerId = filters.ownerId;
+  if (filters?.status) query.status = filters.status;
+  return coll.find(query).toArray();
+}
+
+export async function getLandById(id: string) {
+  const coll = getColl("lands");
+  return coll.findOne({ id });
+}
+
+export async function createLand(data: Record<string, unknown>) {
+  const coll = getColl("lands");
+  const doc = { ...data, createdAt: new Date(), updatedAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function updateLand(id: string, data: Record<string, unknown>) {
+  const coll = getColl("lands");
+  const result = await coll.findOneAndUpdate(
+    { id },
+    { $set: { ...data, updatedAt: new Date() } },
+    { returnDocument: "after" }
+  );
+  return result;
+}
+
+export async function deleteLand(id: string) {
+  const coll = getColl("lands");
+  return coll.deleteOne({ id });
+}
+
+export async function listRentalRequests(filters?: { landId?: string; tenantId?: string; status?: string }) {
+  const coll = getColl("rentalRequests");
+  const query: Record<string, unknown> = {};
+  if (filters?.landId) query.landId = filters.landId;
+  if (filters?.tenantId) query.tenantId = filters.tenantId;
+  if (filters?.status) query.status = filters.status;
+  return coll.find(query).toArray();
+}
+
+export async function getRentalRequestById(id: string) {
+  const coll = getColl("rentalRequests");
+  return coll.findOne({ id });
+}
+
+export async function createRentalRequest(data: Record<string, unknown>) {
+  const coll = getColl("rentalRequests");
+  const doc = { ...data, createdAt: new Date(), updatedAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function updateRentalRequest(id: string, data: Record<string, unknown>) {
+  const coll = getColl("rentalRequests");
+  const result = await coll.findOneAndUpdate(
+    { id },
+    { $set: { ...data, updatedAt: new Date() } },
+    { returnDocument: "after" }
+  );
+  return result;
+}
+
+export async function listContracts(filters?: { ownerId?: string; tenantId?: string; status?: string }) {
+  const coll = getColl("contracts");
+  const query: Record<string, unknown> = {};
+  if (filters?.ownerId) query.ownerId = filters.ownerId;
+  if (filters?.tenantId) query.tenantId = filters.tenantId;
+  if (filters?.status) query.status = filters.status;
+  return coll.find(query).toArray();
+}
+
+export async function getContractById(id: string) {
+  const coll = getColl("contracts");
+  return coll.findOne({ id });
+}
+
+export async function createContract(data: Record<string, unknown>) {
+  const coll = getColl("contracts");
+  const doc = { ...data, createdAt: new Date(), updatedAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function updateContract(id: string, data: Record<string, unknown>) {
+  const coll = getColl("contracts");
+  const result = await coll.findOneAndUpdate(
+    { id },
+    { $set: { ...data, updatedAt: new Date() } },
+    { returnDocument: "after" }
+  );
+  return result;
+}
+
+export async function listPayments(filters?: { rentalRequestId?: string; status?: string }) {
+  const coll = getColl("payments");
+  const query: Record<string, unknown> = {};
+  if (filters?.rentalRequestId) query.rentalRequestId = filters.rentalRequestId;
+  if (filters?.status) query.status = filters.status;
+  return coll.find(query).toArray();
+}
+
+export async function getPaymentById(id: string) {
+  const coll = getColl("payments");
+  return coll.findOne({ id });
+}
+
+export async function createPayment(data: Record<string, unknown>) {
+  const coll = getColl("payments");
+  const doc = { ...data, createdAt: new Date(), updatedAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function updatePayment(id: string, data: Record<string, unknown>) {
+  const coll = getColl("payments");
+  const result = await coll.findOneAndUpdate(
+    { id },
+    { $set: { ...data, updatedAt: new Date() } },
+    { returnDocument: "after" }
+  );
+  return result;
+}
+
+export async function listChats(filters?: { landId?: string; rentalRequestId?: string }) {
+  const coll = getColl("chats");
+  const query: Record<string, unknown> = {};
+  if (filters?.landId) query.landId = filters.landId;
+  if (filters?.rentalRequestId) query.rentalRequestId = filters.rentalRequestId;
+  return coll.find(query).toArray();
+}
+
+export async function getChatById(id: string) {
+  const coll = getColl("chats");
+  return coll.findOne({ id });
+}
+
+export async function createChat(data: Record<string, unknown>) {
+  const coll = getColl("chats");
+  const doc = { ...data, createdAt: new Date(), updatedAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function listChatMessages(chatId: string) {
+  const coll = getColl("chatMessages");
+  return coll.find({ chatId }).sort({ createdAt: 1 }).toArray();
+}
+
+export async function createChatMessage(data: Record<string, unknown>) {
+  const coll = getColl("chatMessages");
+  const doc = { ...data, createdAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function listUsers(filters?: { role?: string; status?: string }) {
+  const coll = getColl("users");
+  const query: Record<string, unknown> = {};
+  if (filters?.role) query.role = filters.role;
+  if (filters?.status) query.status = filters.status;
+  return coll.find(query).toArray();
+}
+
+export async function getUserById(id: string) {
+  const coll = getColl("users");
+  return coll.findOne({ id });
+}
+
+export async function getUserByClerkId(clerkUserId: string) {
+  const coll = getColl("users");
+  return coll.findOne({ clerkUserId });
+}
+
+export async function createUser(data: Record<string, unknown>) {
+  const coll = getColl("users");
+  const doc = { ...data, createdAt: new Date(), updatedAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function updateUser(id: string, data: Record<string, unknown>) {
+  const coll = getColl("users");
+  const result = await coll.findOneAndUpdate(
+    { id },
+    { $set: { ...data, updatedAt: new Date() } },
+    { returnDocument: "after" }
+  );
+  return result;
+}
+
+export async function listLeads() {
+  const coll = getColl("leads");
+  return coll.find({}).toArray();
+}
+
+export async function createLead(data: Record<string, unknown>) {
+  const coll = getColl("leads");
+  const doc = { ...data, createdAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}
+
+export async function listAuditEvents(filters?: { entity?: string; entityId?: string }) {
+  const coll = getColl("auditEvents");
+  const query: Record<string, unknown> = {};
+  if (filters?.entity) query.entity = filters.entity;
+  if (filters?.entityId) query.entityId = filters.entityId;
+  return coll.find(query).sort({ createdAt: -1 }).toArray();
+}
+
+export async function createAuditEvent(data: Record<string, unknown>) {
+  const coll = getColl("auditEvents");
+  const doc = { ...data, createdAt: new Date() };
+  await coll.insertOne(doc);
+  return doc;
+}

--- a/apps/backend-api/src/db/index.ts
+++ b/apps/backend-api/src/db/index.ts
@@ -1,0 +1,1 @@
+export * from "./collections";

--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -1,0 +1,256 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export type LandUse = "agricultura" | "ganaderia" | "forestal" | "acuicultura" | "mixto" | "otro";
+export type LandStatus = "draft" | "active" | "inactive";
+export type RentalRequestStatus = "draft" | "pending_owner" | "approved" | "rejected" | "cancelled" | "pending_payment" | "paid";
+export type ContractStatus = "draft" | "active" | "completed" | "cancelled";
+export type PaymentStatus = "pending" | "processing" | "paid" | "failed" | "cancelled";
+export type ChatStatus = "active" | "archived";
+export type LeadSource = "landing" | "app-web" | "admin-dashboard";
+export type UserStatus = "active" | "inactive";
+export type AppRole = "user" | "admin";
+
+export interface IUser extends Document {
+  clerkUserId: string;
+  email: string;
+  role: AppRole;
+  status: UserStatus;
+  profile: { fullName: string; phone?: string };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ILand extends Document {
+  id: string;
+  ownerId: string;
+  title: string;
+  description?: string;
+  area: number;
+  allowedUses: LandUse[];
+  location: {
+    province: string;
+    district: string;
+    corregimiento?: string;
+    addressLine?: string;
+    lat?: number;
+    lng?: number;
+  };
+  availability: {
+    availableFrom?: string;
+    availableTo?: string;
+  };
+  priceRule: {
+    currency: "USD" | "PAB";
+    pricePerMonth: number;
+  };
+  status: LandStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IRentalRequest extends Document {
+  id: string;
+  landId: string;
+  tenantId: string;
+  period: {
+    startDate: string;
+    endDate: string;
+  };
+  intendedUse: string;
+  notes?: string;
+  status: RentalRequestStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IContract extends Document {
+  id: string;
+  rentalRequestId: string;
+  ownerId: string;
+  tenantId: string;
+  terms: {
+    summary: string;
+    signedAt?: string;
+    startsAt: string;
+    endsAt: string;
+  };
+  status: ContractStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IPayment extends Document {
+  id: string;
+  rentalRequestId: string;
+  contractId?: string;
+  amount: number;
+  currency: "USD" | "PAB";
+  status: PaymentStatus;
+  stripeSessionId?: string;
+  stripePaymentIntentId?: string;
+  checkoutUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IChatParticipant {
+  userId: string;
+  role: "owner" | "tenant" | "admin";
+}
+
+export interface IChat extends Document {
+  id: string;
+  landId?: string;
+  rentalRequestId?: string;
+  participants: IChatParticipant[];
+  status: ChatStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IChatMessage extends Document {
+  id: string;
+  chatId: string;
+  senderId: string;
+  text: string;
+  createdAt: Date;
+}
+
+export interface IAuditEvent extends Document {
+  id: string;
+  actorId: string;
+  actorRole: AppRole;
+  entity: "auth" | "user" | "land" | "rental_request" | "contract" | "payment" | "chat";
+  action: "created" | "updated" | "deleted" | "approved" | "rejected" | "cancelled" | "paid" | "status_changed";
+  entityId: string;
+  metadata?: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface ILead extends Document {
+  id: string;
+  email: string;
+  source: LeadSource;
+  createdAt: Date;
+}
+
+const UserSchema = new Schema<IUser>({
+  clerkUserId: { type: String, required: true, unique: true },
+  email: { type: String, required: true },
+  role: { type: String, enum: ["user", "admin"], default: "user" },
+  status: { type: String, enum: ["active", "inactive"], default: "active" },
+  profile: {
+    fullName: { type: String, required: true },
+    phone: String,
+  },
+}, { timestamps: true });
+
+const LandSchema = new Schema<ILand>({
+  id: { type: String, required: true, unique: true },
+  ownerId: { type: String, required: true },
+  title: { type: String, required: true },
+  description: String,
+  area: { type: Number, required: true },
+  allowedUses: [{ type: String, enum: ["agricultura", "ganaderia", "forestal", "acuicultura", "mixto", "otro"] }],
+  location: {
+    province: { type: String, required: true },
+    district: { type: String, required: true },
+    corregimiento: String,
+    addressLine: String,
+    lat: Number,
+    lng: Number,
+  },
+  availability: {
+    availableFrom: String,
+    availableTo: String,
+  },
+  priceRule: {
+    currency: { type: String, enum: ["USD", "PAB"], default: "USD" },
+    pricePerMonth: { type: Number, required: true },
+  },
+  status: { type: String, enum: ["draft", "active", "inactive"], default: "active" },
+}, { timestamps: true });
+
+const RentalRequestSchema = new Schema<IRentalRequest>({
+  id: { type: String, required: true, unique: true },
+  landId: { type: String, required: true },
+  tenantId: { type: String, required: true },
+  period: {
+    startDate: { type: String, required: true },
+    endDate: { type: String, required: true },
+  },
+  intendedUse: { type: String, required: true },
+  notes: String,
+  status: { type: String, enum: ["draft", "pending_owner", "approved", "rejected", "cancelled", "pending_payment", "paid"], default: "draft" },
+}, { timestamps: true });
+
+const ContractSchema = new Schema<IContract>({
+  id: { type: String, required: true, unique: true },
+  rentalRequestId: { type: String, required: true },
+  ownerId: { type: String, required: true },
+  tenantId: { type: String, required: true },
+  terms: {
+    summary: { type: String, required: true },
+    signedAt: String,
+    startsAt: { type: String, required: true },
+    endsAt: { type: String, required: true },
+  },
+  status: { type: String, enum: ["draft", "active", "completed", "cancelled"], default: "draft" },
+}, { timestamps: true });
+
+const PaymentSchema = new Schema<IPayment>({
+  id: { type: String, required: true, unique: true },
+  rentalRequestId: { type: String, required: true },
+  contractId: String,
+  amount: { type: Number, required: true },
+  currency: { type: String, enum: ["USD", "PAB"], default: "USD" },
+  status: { type: String, enum: ["pending", "processing", "paid", "failed", "cancelled"], default: "pending" },
+  stripeSessionId: String,
+  stripePaymentIntentId: String,
+  checkoutUrl: String,
+}, { timestamps: true });
+
+const ChatSchema = new Schema<IChat>({
+  id: { type: String, required: true, unique: true },
+  landId: String,
+  rentalRequestId: String,
+  participants: [{
+    userId: { type: String, required: true },
+    role: { type: String, enum: ["owner", "tenant", "admin"], required: true },
+  }],
+  status: { type: String, enum: ["active", "archived"], default: "active" },
+}, { timestamps: true });
+
+const ChatMessageSchema = new Schema<IChatMessage>({
+  id: { type: String, required: true, unique: true },
+  chatId: { type: String, required: true },
+  senderId: { type: String, required: true },
+  text: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const AuditEventSchema = new Schema<IAuditEvent>({
+  id: { type: String, required: true, unique: true },
+  actorId: { type: String, required: true },
+  actorRole: { type: String, enum: ["user", "admin"], required: true },
+  entity: { type: String, enum: ["auth", "user", "land", "rental_request", "contract", "payment", "chat"], required: true },
+  action: { type: String, enum: ["created", "updated", "deleted", "approved", "rejected", "cancelled", "paid", "status_changed"], required: true },
+  entityId: { type: String, required: true },
+  metadata: Schema.Types.Mixed,
+}, { timestamps: true });
+
+const LeadSchema = new Schema<ILead>({
+  id: { type: String, required: true, unique: true },
+  email: { type: String, required: true },
+  source: { type: String, enum: ["landing", "app-web", "admin-dashboard"], required: true },
+}, { timestamps: true });
+
+export const User = mongoose.model<IUser>("User", UserSchema);
+export const Land = mongoose.model<ILand>("Land", LandSchema);
+export const RentalRequest = mongoose.model<IRentalRequest>("RentalRequest", RentalRequestSchema);
+export const Contract = mongoose.model<IContract>("Contract", ContractSchema);
+export const Payment = mongoose.model<IPayment>("Payment", PaymentSchema);
+export const Chat = mongoose.model<IChat>("Chat", ChatSchema);
+export const ChatMessage = mongoose.model<IChatMessage>("ChatMessage", ChatMessageSchema);
+export const AuditEvent = mongoose.model<IAuditEvent>("AuditEvent", AuditEventSchema);
+export const Lead = mongoose.model<ILead>("Lead", LeadSchema);

--- a/apps/backend-api/src/db/seed.ts
+++ b/apps/backend-api/src/db/seed.ts
@@ -1,0 +1,348 @@
+import { getDatabase } from "../config/database";
+
+const PROVINCES = [
+  { name: "Bocas del Toro", districts: ["Bocolvas y Ranch", "Changuinola", "Isla Colón"] },
+  { name: "Chiriquí", districts: ["Bugaba", "David", "Boquete", "Volcán"] },
+  { name: "Coclé", districts: ["Penonomé", "Antón", "Capira", "La Pintada"] },
+  { name: "Colón", districts: ["Colón", "Cristóbal", "Portobelo", "Santa Isabel"] },
+  { name: "Darién", districts: ["Yaviza", "La Palma", "Chepigana", "Pinogana"] },
+  { name: "Herrera", districts: ["Chitré", "Parita", "Pesé", "Ocú"] },
+  { name: "Los Santos", districts: ["Guararé", "Las Tablas", "Pedasí", "Tonosí"] },
+  { name: "Panamá", districts: ["Panama Centro", "Panama Este", "Panama Oeste", "San Miguelito"] },
+  { name: "Veraguas", districts: ["Santiago", "Soná", "Atletico", "Calobre"] },
+];
+
+const LAND_USES = ["agricultura", "ganaderia", "forestal", "acuicultura", "mixto", "otro"];
+
+const FIRST_NAMES = [
+  "Carlos", "María", "José", "Ana", "Luis", "Rosa", "Juan", "Elena", "Pedro", "Carla",
+  "Miguel", "Sofia", "Antonio", "Beatriz", "Francisco", "Isabel", "Javier", "Carmen", "Fernando", "Patricia"
+];
+
+const LAST_NAMES = [
+  "García", "Rodriguez", "Martínez", "Hernández", "López", "González", "Pérez", "Sánchez", "Ramírez", "Torres"
+];
+
+const LAND_TITLES = [
+  "Finca Agroforestal", "Rancho Ganadero", "Parcela", "Terreno Forestal", "Hacienda",
+  "Campo de Cultivo", "Estancia", "Granja", "Predio Rural", "Lote de Tierra",
+  "Finca Productiva", "Quinta", "Solar", "Hacienda Ganadera", "Finca de Cultivos"
+];
+
+function randomItem<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randomBetween(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomDate(daysAgo: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - randomBetween(0, daysAgo));
+  return date.toISOString();
+}
+
+function randomDateFuture(daysAhead: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() + randomBetween(1, daysAhead));
+  return date.toISOString();
+}
+
+function generateUsers(count: number) {
+  const users = [];
+  const statuses = ["active", "inactive"];
+  const roles = ["user", "admin"];
+  
+  for (let i = 0; i < count; i++) {
+    const firstName = randomItem(FIRST_NAMES);
+    const lastName = randomItem(LAST_NAMES);
+    const isAdmin = i < 3;
+    users.push({
+      id: `user_${String(i + 1).padStart(3, "0")}`,
+      clerkUserId: `user_${String(i + 1).padStart(3, "0")}`,
+      email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}${i}@terrashare.test`,
+      role: isAdmin ? "admin" : randomItem(roles),
+      status: randomItem(statuses),
+      profile: {
+        fullName: `${firstName} ${lastName}`,
+        phone: `+507 6${randomBetween(100, 999)}-${randomBetween(1000, 9999)}`
+      },
+      createdAt: randomDate(365),
+      updatedAt: randomDate(30),
+    });
+  }
+  return users;
+}
+
+function generateLands(count: number, userIds: string[]) {
+  const lands = [];
+  const statuses = ["active", "draft", "inactive"];
+  
+  for (let i = 0; i < count; i++) {
+    const province = randomItem(PROVINCES);
+    const district = randomItem(province.districts);
+    const titlePrefix = randomItem(LAND_TITLES);
+    const usesCount = randomBetween(1, 3);
+    const allowedUses = [];
+    for (let j = 0; j < usesCount; j++) {
+      const use = randomItem(LAND_USES);
+      if (!allowedUses.includes(use)) allowedUses.push(use);
+    }
+    
+    lands.push({
+      id: `land_${String(i + 1).padStart(4, "0")}`,
+      ownerId: randomItem(userIds.filter((_, idx) => idx >= 3)),
+      title: `${titlePrefix} ${province.name}`,
+      description: `Terreno fértil en ${district}, ${province.name}. Ideal para ${allowedUses.join(" y ")}.`,
+      area: randomBetween(5, 500),
+      allowedUses,
+      location: {
+        province: province.name,
+        district: district,
+        corregimiento: `Corregimiento ${String(i + 1).padStart(2, "0")}`,
+        lat: 8 + Math.random() * 2,
+        lng: -80 + Math.random() * 3,
+      },
+      availability: {
+        availableFrom: randomDate(90),
+      },
+      priceRule: {
+        currency: "USD",
+        pricePerMonth: randomBetween(150, 2500),
+      },
+      status: i < count * 0.7 ? "active" : randomItem(statuses),
+      createdAt: randomDate(180),
+      updatedAt: randomDate(30),
+    });
+  }
+  return lands;
+}
+
+function generateRentalRequests(count: number, landIds: string[], userIds: string[]) {
+  const requests = [];
+  const statuses = ["draft", "pending_owner", "approved", "rejected", "cancelled", "pending_payment", "paid"];
+  
+  for (let i = 0; i < count; i++) {
+    const startDate = randomDateFuture(90);
+    const endDate = randomDateFuture(180);
+    requests.push({
+      id: `rr_${String(i + 1).padStart(4, "0")}`,
+      landId: randomItem(landIds),
+      tenantId: randomItem(userIds.filter((_, idx) => idx >= 3)),
+      period: {
+        startDate,
+        endDate,
+      },
+      intendedUse: randomItem(LAND_USES),
+      notes: `Interesado en alquilar este terreno para ${randomItem(LAND_USES)}.`,
+      status: randomItem(statuses),
+      createdAt: randomDate(90),
+      updatedAt: randomDate(30),
+    });
+  }
+  return requests;
+}
+
+function generateContracts(count: number, requestIds: string[], userIds: string[]) {
+  const contracts = [];
+  const statuses = ["draft", "active", "completed", "cancelled"];
+  
+  for (let i = 0; i < count; i++) {
+    const startDate = randomDate(90);
+    const endDate = randomDateFuture(180);
+    contracts.push({
+      id: `contract_${String(i + 1).padStart(4, "0")}`,
+      rentalRequestId: randomItem(requestIds),
+      ownerId: randomItem(userIds.filter((_, idx) => idx >= 3)),
+      tenantId: randomItem(userIds.filter((_, idx) => idx >= 3)),
+      terms: {
+        summary: `Contrato de arrendamiento por ${randomBetween(6, 24)} meses`,
+        startsAt: startDate,
+        endsAt: endDate,
+      },
+      status: randomItem(statuses),
+      createdAt: randomDate(90),
+      updatedAt: randomDate(30),
+    });
+  }
+  return contracts;
+}
+
+function generatePayments(count: number, requestIds: string[]) {
+  const payments = [];
+  const statuses = ["pending", "processing", "paid", "failed", "cancelled"];
+  
+  for (let i = 0; i < count; i++) {
+    payments.push({
+      id: `pay_${String(i + 1).padStart(4, "0")}`,
+      rentalRequestId: randomItem(requestIds),
+      amount: randomBetween(200, 3000),
+      currency: "USD",
+      status: randomItem(statuses),
+      stripeSessionId: `cs_${crypto.randomUUID()}`,
+      checkoutUrl: `https://checkout.stripe.com/c/pay/cs_${crypto.randomUUID().slice(0, 8)}`,
+      createdAt: randomDate(60),
+      updatedAt: randomDate(30),
+    });
+  }
+  return payments;
+}
+
+function generateChats(count: number, landIds: string[], requestIds: string[], userIds: string[]) {
+  const chats = [];
+  
+  for (let i = 0; i < count; i++) {
+    const ownerId = randomItem(userIds.filter((_, idx) => idx >= 3));
+    const tenantId = randomItem(userIds.filter((_, idx) => idx >= 3));
+    chats.push({
+      id: `chat_${String(i + 1).padStart(4, "0")}`,
+      landId: randomItem(landIds),
+      rentalRequestId: randomItem(requestIds),
+      participants: [
+        { userId: ownerId, role: "owner" },
+        { userId: tenantId, role: "tenant" },
+      ],
+      status: "active",
+      createdAt: randomDate(60),
+      updatedAt: randomDate(30),
+    });
+  }
+  return chats;
+}
+
+function generateChatMessages(count: number, chatIds: string[], userIds: string[]) {
+  const messages = [];
+  const texts = [
+    "Hola, me interesa el terreno",
+    "Está disponible para inmediata ocupación?",
+    "Qué incluye el precio del alquiler?",
+    "Tengo interés en visitarla este fin de semana",
+    " Puedo agregar cultivos existente?",
+    "Hay acceso a agua potable?",
+    "El terreno tiene cercado?",
+    "Cuántos años tiene la propiedad?",
+    "Aceptan animales de ganado?",
+    "Excelente lokasi, me gusta mucho"
+  ];
+  
+  for (let i = 0; i < count; i++) {
+    messages.push({
+      id: `msg_${String(i + 1).padStart(5, "0")}`,
+      chatId: randomItem(chatIds),
+      senderId: randomItem(userIds.filter((_, idx) => idx >= 3)),
+      text: randomItem(texts),
+      createdAt: randomDate(30),
+    });
+  }
+  return messages;
+}
+
+function generateAuditEvents(count: number, userIds: string[], entityIds: Record<string, string[]>) {
+  const events = [];
+  const entities = ["auth", "user", "land", "rental_request", "contract", "payment", "chat"] as const;
+  const actions = ["created", "updated", "deleted", "approved", "rejected", "cancelled", "paid", "status_changed"] as const;
+  const roles = ["user", "admin"] as const;
+  
+  for (let i = 0; i < count; i++) {
+    const entity = randomItem(entities);
+    const entityList = entityIds[entity] || [];
+    events.push({
+      id: `audit_${String(i + 1).padStart(5, "0")}`,
+      actorId: randomItem(userIds),
+      actorRole: randomItem(roles),
+      entity,
+      action: randomItem(actions),
+      entityId: randomItem(entityList),
+      metadata: { note: `Action ${randomItem(actions)} on ${entity}` },
+      createdAt: randomDate(90),
+    });
+  }
+  return events;
+}
+
+function generateLeads(count: number) {
+  const leads = [];
+  const sources = ["landing", "app-web", "admin-dashboard"] as const;
+  
+  for (let i = 0; i < count; i++) {
+    leads.push({
+      id: `lead_${String(i + 1).padStart(4, "0")}`,
+      email: `lead${i}@example.com`,
+      source: randomItem(sources),
+      createdAt: randomDate(60),
+    });
+  }
+  return leads;
+}
+
+export async function seedDatabase() {
+  const db = getDatabase();
+  if (!db) {
+    console.error("[seed] Database not connected");
+    return;
+  }
+
+  console.log("[seed] Starting database seeding...");
+
+  const users = generateUsers(20);
+  const userIds = users.map(u => u.id);
+  
+  const lands = generateLands(50, userIds);
+  const landIds = lands.map(l => l.id);
+  
+  const requests = generateRentalRequests(100, landIds, userIds);
+  const requestIds = requests.map(r => r.id);
+  
+  const contracts = generateContracts(30, requestIds, userIds);
+  const contractIds = contracts.map(c => c.id);
+  
+  const payments = generatePayments(50, requestIds);
+  const paymentIds = payments.map(p => p.id);
+  
+  const chats = generateChats(25, landIds, requestIds, userIds);
+  const chatIds = chats.map(c => c.id);
+  
+  const messages = generateChatMessages(200, chatIds, userIds);
+  
+  const entityIds: Record<string, string[]> = {
+    land: landIds,
+    rental_request: requestIds,
+    contract: contractIds,
+    payment: paymentIds,
+    user: userIds,
+  };
+  const auditEvents = generateAuditEvents(500, userIds, entityIds);
+  
+  const leads = generateLeads(100);
+
+  console.log(`[seed] Inserting ${users.length} users...`);
+  await db.collection("users").insertMany(users);
+  
+  console.log(`[seed] Inserting ${lands.length} lands...`);
+  await db.collection("lands").insertMany(lands);
+  
+  console.log(`[seed] Inserting ${requests.length} rental requests...`);
+  await db.collection("rentalRequests").insertMany(requests);
+  
+  console.log(`[seed] Inserting ${contracts.length} contracts...`);
+  await db.collection("contracts").insertMany(contracts);
+  
+  console.log(`[seed] Inserting ${payments.length} payments...`);
+  await db.collection("payments").insertMany(payments);
+  
+  console.log(`[seed] Inserting ${chats.length} chats...`);
+  await db.collection("chats").insertMany(chats);
+  
+  console.log(`[seed] Inserting ${messages.length} chat messages...`);
+  await db.collection("chatMessages").insertMany(messages);
+  
+  console.log(`[seed] Inserting ${auditEvents.length} audit events...`);
+  await db.collection("auditEvents").insertMany(auditEvents);
+  
+  console.log(`[seed] Inserting ${leads.length} leads...`);
+  await db.collection("leads").insertMany(leads);
+
+  console.log("[seed] Database seeded successfully!");
+  console.log(`[seed] Total: ${users.length} users, ${lands.length} lands, ${requests.length} requests, ${contracts.length} contracts, ${payments.length} payments, ${chats.length} chats, ${messages.length} messages, ${auditEvents.length} events, ${leads.length} leads`);
+}

--- a/apps/backend-api/src/index.ts
+++ b/apps/backend-api/src/index.ts
@@ -1,9 +1,35 @@
 import { env } from "./config/env";
+import { connectDatabase, getDatabase } from "./config/database";
 import { createApp } from "./app";
+import { seedDatabase } from "./db/seed";
 
 const app = createApp();
 
-console.log(`[backend-api] listening on port ${env.apiPort}`);
+async function init() {
+  try {
+    const db = await connectDatabase();
+    
+    if (db) {
+      console.log("[backend-api] Using MongoDB database");
+      
+      const needsSeed = (await db.collection("lands").countDocuments()) === 0;
+      if (needsSeed || process.env.FORCE_SEED === "true") {
+        console.log("[backend-api] Database is empty, running seed...");
+        await seedDatabase();
+      } else {
+        console.log("[backend-api] Database already has data, skipping seed");
+      }
+    } else {
+      console.warn("[backend-api] MongoDB connection failed, using fallback");
+    }
+  } catch (error) {
+    console.warn("[backend-api] Failed to connect to MongoDB:", error);
+  }
+
+  console.log(`[backend-api] listening on port ${env.apiPort}`);
+}
+
+init();
 
 export default {
   port: env.apiPort,

--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -3,87 +3,64 @@ import { Hono } from "hono";
 import { failure, success } from "../lib/api-response";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { getStore } from "../store/in-memory-db";
-import type { AdminLandSummary, AdminUserSummary, UserStatus } from "../store/types";
+import { User, Land, RentalRequest } from "../db/schemas";
+import type { UserStatus } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const adminRoutes = new Hono<AppEnv>();
 
-// ─── Users ──────────────────────────────────────────────────────────────────
-
-/**
- * GET /api/v1/admin/users
- * Lista todos los usuarios del sistema con filtros opcionales.
- * Auth: required (admin)
- */
-adminRoutes.get("/admin/users", requireAuth, requireAdmin, (c) => {
-  const store = getStore();
+adminRoutes.get("/admin/users", requireAuth, requireAdmin, async (c) => {
   const role = c.req.query("role") as "user" | "admin" | undefined;
   const status = c.req.query("status") as UserStatus | undefined;
   const search = c.req.query("search")?.toLowerCase();
 
-  let users = Array.from(store.users.values()) as AdminUserSummary[];
+  const query: Record<string, any> = {};
+  if (role) query.role = role;
+  if (status) query.status = status;
 
-  if (role) {
-    users = users.filter((u) => u.role === role);
-  }
-  if (status) {
-    users = users.filter((u) => u.status === status);
-  }
+  let users = await User.find(query).lean();
+
   if (search) {
     users = users.filter(
       (u) =>
         u.email.toLowerCase().includes(search) ||
-        u.profile.fullName.toLowerCase().includes(search),
+        (u.profile?.fullName ?? "").toLowerCase().includes(search),
     );
   }
 
   return success(c, { items: users, total: users.length });
 });
 
-/**
- * GET /api/v1/admin/users/:userId
- * Detalle de un usuario.
- * Auth: required (admin)
- */
-adminRoutes.get("/admin/users/:userId", requireAuth, requireAdmin, (c) => {
-  const store = getStore();
+adminRoutes.get("/admin/users/:userId", requireAuth, requireAdmin, async (c) => {
   const userId = c.req.param("userId");
-  const user = store.users.get(userId);
+  
+  const user = await User.findOne({ clerkUserId: userId }).lean();
   if (!user) {
     return failure(c, 404, "NOT_FOUND", "User not found");
   }
   return success(c, user);
 });
 
-/**
- * PATCH /api/v1/admin/users/:userId/status
- * Bloquea o activa un usuario.
- * Auth: required (admin)
- * Body: { status: "active" | "blocked" }
- */
 adminRoutes.patch("/admin/users/:userId/status", requireAuth, requireAdmin, async (c) => {
-  const store = getStore();
   const authUser = c.get("authUser");
   const userId = c.req.param("userId");
-  const user = store.users.get(userId);
+
+  const user = await User.findOne({ clerkUserId: userId }).lean();
   if (!user) {
     return failure(c, 404, "NOT_FOUND", "User not found");
   }
 
   const body = (await c.req.json().catch(() => null)) as { status?: UserStatus } | null;
   const nextStatus = body?.status;
-  if (!nextStatus || !["active", "blocked"].includes(nextStatus)) {
+  if (!nextStatus || !["active", "inactive"].includes(nextStatus)) {
     return failure(c, 400, "VALIDATION_ERROR", "Invalid status value");
   }
 
-  // Cannot block yourself
   if (userId === authUser.id) {
     return failure(c, 400, "BUSINESS_RULE_VIOLATION", "Cannot modify own account status");
   }
 
-  const updated = { ...user, status: nextStatus, updatedAt: new Date().toISOString() };
-  store.users.set(userId, updated);
+  await User.updateOne({ clerkUserId: userId }, { status: nextStatus });
 
   createAuditEvent({
     actor: authUser,
@@ -93,26 +70,21 @@ adminRoutes.patch("/admin/users/:userId/status", requireAuth, requireAdmin, asyn
     metadata: { email: user.email },
   });
 
+  const updated = await User.findOne({ clerkUserId: userId }).lean();
   return success(c, updated);
 });
 
-// ─── Lands ───────────────────────────────────────────────────────────────────
-
-/**
- * GET /api/v1/admin/lands
- * Lista terrenos con filtros — centrado en moderation (draft/inactive).
- * Auth: required (admin)
- */
-adminRoutes.get("/admin/lands", requireAuth, requireAdmin, (c) => {
-  const store = getStore();
+adminRoutes.get("/admin/lands", requireAuth, requireAdmin, async (c) => {
   const status = c.req.query("status");
   const search = c.req.query("search")?.toLowerCase();
 
-  let lands = Array.from(store.lands.values());
-
+  const query: Record<string, any> = {};
   if (status && ["draft", "active", "inactive"].includes(status)) {
-    lands = lands.filter((l) => l.status === status);
+    query.status = status;
   }
+
+  let lands = await Land.find(query).lean();
+
   if (search) {
     lands = lands.filter(
       (l) =>
@@ -121,44 +93,38 @@ adminRoutes.get("/admin/lands", requireAuth, requireAdmin, (c) => {
     );
   }
 
-  const items: AdminLandSummary[] = lands.map((l) => {
-    const owner = store.users.get(l.ownerId);
-    return {
-      id: l.id,
-      ownerId: l.ownerId,
-      ownerEmail: owner?.email ?? l.ownerId,
-      title: l.title,
-      status: l.status,
-      createdAt: l.createdAt,
-    };
-  });
+  const ownerClerkIds = [...new Set(lands.map((l) => l.ownerId))];
+  const owners = await User.find({ clerkUserId: { $in: ownerClerkIds } }).lean();
+  const ownerMap = new Map(owners.map((o) => [o.clerkUserId, o]));
+
+  const items = lands.map((l) => ({
+    id: l.id,
+    ownerId: l.ownerId,
+    ownerEmail: ownerMap.get(l.ownerId)?.email ?? l.ownerId,
+    title: l.title,
+    status: l.status,
+    createdAt: l.createdAt,
+  }));
 
   return success(c, { items, total: items.length });
 });
 
-/**
- * PATCH /api/v1/admin/lands/:landId/status
- * Cambia el estado de un terreno — usado para aprobar/rechazar moderation.
- * Auth: required (admin)
- * Body: { status: "active" | "inactive" | "rejected" }
- */
 adminRoutes.patch("/admin/lands/:landId/status", requireAuth, requireAdmin, async (c) => {
-  const store = getStore();
   const authUser = c.get("authUser");
   const landId = c.req.param("landId");
-  const land = store.lands.get(landId);
+
+  const land = await Land.findOne({ id: landId }).lean();
   if (!land) {
     return failure(c, 404, "NOT_FOUND", "Land not found");
   }
 
   const body = (await c.req.json().catch(() => null)) as { status?: string } | null;
   const nextStatus = body?.status;
-  if (!nextStatus || !["active", "inactive", "rejected"].includes(nextStatus)) {
+  if (!nextStatus || !["active", "inactive"].includes(nextStatus)) {
     return failure(c, 400, "VALIDATION_ERROR", "Invalid status value");
   }
 
-  const updated = { ...land, status: nextStatus as typeof land.status, updatedAt: new Date().toISOString() };
-  store.lands.set(landId, updated);
+  await Land.updateOne({ id: landId }, { status: nextStatus as any });
 
   createAuditEvent({
     actor: authUser,
@@ -168,23 +134,22 @@ adminRoutes.patch("/admin/lands/:landId/status", requireAuth, requireAdmin, asyn
     metadata: { title: land.title },
   });
 
+  const updated = await Land.findOne({ id: landId }).lean();
   return success(c, updated);
 });
 
-// ─── Dashboard summary ──────────────────────────────────────────────────────
-
-adminRoutes.get("/admin/summary", requireAuth, requireAdmin, (c) => {
-  const store = getStore();
-
-  const users = Array.from(store.users.values());
-  const lands = Array.from(store.lands.values());
-  const requests = Array.from(store.rentalRequests.values());
+adminRoutes.get("/admin/summary", requireAuth, requireAdmin, async (c) => {
+  const [users, lands, requests] = await Promise.all([
+    User.find().lean(),
+    Land.find().lean(),
+    RentalRequest.find().lean(),
+  ]);
 
   return success(c, {
     users: {
       total: users.length,
       active: users.filter((u) => u.status === "active").length,
-      blocked: users.filter((u) => u.status === "blocked").length,
+      blocked: users.filter((u) => u.status === "inactive").length,
     },
     lands: {
       total: lands.length,
@@ -200,21 +165,30 @@ adminRoutes.get("/admin/summary", requireAuth, requireAdmin, (c) => {
   });
 });
 
-adminRoutes.get("/admin/rental-requests", requireAuth, requireAdmin, (c) => {
-  const store = getStore();
+adminRoutes.get("/admin/rental-requests", requireAuth, requireAdmin, async (c) => {
   const status = c.req.query("status");
   const search = c.req.query("search")?.toLowerCase();
 
-  let requests = Array.from(store.rentalRequests.values());
-
+  const query: Record<string, any> = {};
   if (status && status !== "all") {
-    requests = requests.filter((request) => request.status === status);
+    query.status = status;
   }
 
+  let requests = await RentalRequest.find(query).lean();
+
   if (search) {
+    const landIds = [...new Set(requests.map((r) => r.landId))];
+    const tenantIds = [...new Set(requests.map((r) => r.tenantId))];
+    const [lands, tenants] = await Promise.all([
+      Land.find({ id: { $in: landIds } }).lean(),
+      User.find({ clerkUserId: { $in: tenantIds } }).lean(),
+    ]);
+    const landMap = new Map(lands.map((l) => [l.id, l]));
+    const tenantMap = new Map(tenants.map((t) => [t.clerkUserId, t]));
+
     requests = requests.filter((request) => {
-      const land = store.lands.get(request.landId);
-      const tenant = store.users.get(request.tenantId);
+      const land = landMap.get(request.landId);
+      const tenant = tenantMap.get(request.tenantId);
       return Boolean(
         request.id.toLowerCase().includes(search) ||
         land?.title.toLowerCase().includes(search) ||
@@ -223,9 +197,18 @@ adminRoutes.get("/admin/rental-requests", requireAuth, requireAdmin, (c) => {
     });
   }
 
+  const landIds = [...new Set(requests.map((r) => r.landId))];
+  const tenantIds = [...new Set(requests.map((r) => r.tenantId))];
+  const [lands, tenants] = await Promise.all([
+    Land.find({ id: { $in: landIds } }).lean(),
+    User.find({ clerkUserId: { $in: tenantIds } }).lean(),
+  ]);
+  const landMap = new Map(lands.map((l) => [l.id, l]));
+  const tenantMap = new Map(tenants.map((t) => [t.clerkUserId, t]));
+
   const items = requests.map((request) => {
-    const land = store.lands.get(request.landId);
-    const tenant = store.users.get(request.tenantId);
+    const land = landMap.get(request.landId);
+    const tenant = tenantMap.get(request.tenantId);
     return {
       id: request.id,
       landId: request.landId,

--- a/apps/backend-api/src/routes/analytics.ts
+++ b/apps/backend-api/src/routes/analytics.ts
@@ -4,50 +4,45 @@ import { success } from "../lib/api-response";
 import { isOwnerOrAdmin } from "../lib/auth-helpers";
 import { requireAuth } from "../middleware/require-auth";
 import { requireAdmin } from "../middleware/require-auth";
-import { getStore } from "../store/in-memory-db";
+import { Land, RentalRequest, Payment, Lead, Chat, User } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const analyticsRoutes = new Hono<AppEnv>();
 
 analyticsRoutes.use("/*", requireAdmin);
 
-analyticsRoutes.get("/analytics/overview", (c) => {
-  const store = getStore();
-
+analyticsRoutes.get("/analytics/overview", async (c) => {
   const now = Date.now();
-  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
-  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
 
-  const lands = Array.from(store.lands.values());
-  const activeLands = lands.filter((l) => l.status === "active");
+  const [lands, rentalRequests, payments, leads, chats, users] = await Promise.all([
+    Land.find({ status: "active" }).lean(),
+    RentalRequest.find().lean(),
+    Payment.find().lean(),
+    Lead.find().lean(),
+    Chat.find().lean(),
+    User.find().lean(),
+  ]);
 
-  const rentalRequests = Array.from(store.rentalRequests.values());
-  const recentRequests = rentalRequests.filter((r) => r.createdAt >= thirtyDaysAgo);
-
-  const totalRequests = rentalRequests.length;
+  const recentRequests = rentalRequests.filter((r) => new Date(r.createdAt) >= thirtyDaysAgo);
   const approvedRequests = rentalRequests.filter(
     (r) => r.status === "approved" || r.status === "pending_payment" || r.status === "paid",
   ).length;
   const rejectedRequests = rentalRequests.filter((r) => r.status === "rejected").length;
-
-  const requestsLast7Days = recentRequests.filter((r) => r.createdAt >= sevenDaysAgo).length;
+  const requestsLast7Days = rentalRequests.filter((r) => new Date(r.createdAt) >= sevenDaysAgo).length;
 
   const landsByCategory: Record<string, number> = {};
-  for (const land of activeLands) {
+  for (const land of lands) {
     for (const use of land.allowedUses) {
       landsByCategory[use] = (landsByCategory[use] || 0) + 1;
     }
   }
 
-  let totalRevenue = 0;
-  const paidPayments = Array.from(store.payments.values()).filter((p) => p.status === "paid");
-  for (const payment of paidPayments) {
-    totalRevenue += payment.amount;
-  }
+  const paidPayments = payments.filter((p) => p.status === "paid");
+  const totalRevenue = paidPayments.reduce((sum, p) => sum + p.amount, 0);
+  const pendingPayments = payments.filter((p) => p.status === "pending" || p.status === "processing");
 
-  const pendingPayments = Array.from(store.payments.values()).filter((p) => p.status === "pending" || p.status === "processing");
-
-  const users = Array.from(store.users.values());
   const activeUsers = users.filter((u) => u.status === "active");
 
   let avgTimeToDecisionMs = 0;
@@ -64,16 +59,14 @@ analyticsRoutes.get("/analytics/overview", (c) => {
     avgTimeToDecisionMs = totalDecisionTime / decidedRequests.length;
   }
 
-  const leads = Array.from(store.leads.values());
-  const leadsLast30Days = leads.filter((l) => l.createdAt >= thirtyDaysAgo);
-
+  const leadsLast30Days = leads.filter((l) => new Date(l.createdAt) >= thirtyDaysAgo);
   const leadsBySource: Record<string, number> = {};
   for (const lead of leadsLast30Days) {
     leadsBySource[lead.source] = (leadsBySource[lead.source] || 0) + 1;
   }
 
-  const chats = Array.from(store.chats.values());
-  const activeChats = chats.filter((c) => c.status === "active");
+  const activeChats = chats.filter((ch) => ch.status === "active");
+  const totalRequests = rentalRequests.length;
 
   const visitToRequestConversion = totalRequests > 0 && leads.length > 0
     ? (totalRequests / leads.length) * 100
@@ -81,7 +74,7 @@ analyticsRoutes.get("/analytics/overview", (c) => {
 
   return success(c, {
     overview: {
-      totalLands: activeLands.length,
+      totalLands: lands.length,
       totalUsers: users.length,
       activeUsers: activeUsers.length,
       totalRequests,
@@ -99,23 +92,21 @@ analyticsRoutes.get("/analytics/overview", (c) => {
     landsByCategory,
     leadsBySource,
     recentActivity: {
-      newLeadsLast7Days: leadsLast30Days.filter((l) => l.createdAt >= sevenDaysAgo).length,
+      newLeadsLast7Days: leadsLast30Days.filter((l) => new Date(l.createdAt) >= sevenDaysAgo).length,
       newRequestsLast7Days: requestsLast7Days,
     },
   });
 });
 
-analyticsRoutes.get("/analytics/lands", (c) => {
-  const store = getStore();
-  const lands = Array.from(store.lands.values());
-  const activeLands = lands.filter((l) => l.status === "active");
+analyticsRoutes.get("/analytics/lands", async (c) => {
+  const lands = await Land.find({ status: "active" }).lean();
 
   const landsByProvince: Record<string, number> = {};
   const landsByCategory: Record<string, number> = {};
   let totalArea = 0;
   let totalPrice = 0;
 
-  for (const land of activeLands) {
+  for (const land of lands) {
     landsByProvince[land.location.province] = (landsByProvince[land.location.province] || 0) + 1;
     for (const use of land.allowedUses) {
       landsByCategory[use] = (landsByCategory[use] || 0) + 1;
@@ -124,11 +115,11 @@ analyticsRoutes.get("/analytics/lands", (c) => {
     totalPrice += land.priceRule.pricePerMonth;
   }
 
-  const avgPrice = activeLands.length > 0 ? totalPrice / activeLands.length : 0;
-  const avgArea = activeLands.length > 0 ? totalArea / activeLands.length : 0;
+  const avgPrice = lands.length > 0 ? totalPrice / lands.length : 0;
+  const avgArea = lands.length > 0 ? totalArea / lands.length : 0;
 
   return success(c, {
-    total: activeLands.length,
+    total: lands.length,
     byProvince: landsByProvince,
     byCategory: landsByCategory,
     avgPricePerMonth: Math.round(avgPrice * 100) / 100,
@@ -137,15 +128,14 @@ analyticsRoutes.get("/analytics/lands", (c) => {
   });
 });
 
-analyticsRoutes.get("/analytics/requests", (c) => {
-  const store = getStore();
-  const requests = Array.from(store.rentalRequests.values());
+analyticsRoutes.get("/analytics/requests", async (c) => {
+  const requests = await RentalRequest.find().lean();
 
   const now = Date.now();
-  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
-  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
 
-  const recentRequests = requests.filter((r) => r.createdAt >= thirtyDaysAgo);
+  const recentRequests = requests.filter((r) => new Date(r.createdAt) >= thirtyDaysAgo);
 
   const byStatus: Record<string, number> = {};
   for (const req of requests) {
@@ -158,7 +148,7 @@ analyticsRoutes.get("/analytics/requests", (c) => {
   }
 
   const approvedLast30Days = requests.filter(
-    (r) => (r.status === "approved" || r.status === "pending_payment" || r.status === "paid") && r.updatedAt >= thirtyDaysAgo,
+    (r) => (r.status === "approved" || r.status === "pending_payment" || r.status === "paid") && new Date(r.updatedAt) >= thirtyDaysAgo,
   );
 
   let avgDecisionTimeMs = 0;
@@ -173,7 +163,7 @@ analyticsRoutes.get("/analytics/requests", (c) => {
   return success(c, {
     total: requests.length,
     last30Days: recentRequests.length,
-    last7Days: requests.filter((r) => r.createdAt >= sevenDaysAgo).length,
+    last7Days: requests.filter((r) => new Date(r.createdAt) >= sevenDaysAgo).length,
     byStatus,
     byIntendedUse,
     avgTimeToApprovalHours: Math.round(avgDecisionTimeMs / (1000 * 60 * 60) * 10) / 10,
@@ -181,34 +171,34 @@ analyticsRoutes.get("/analytics/requests", (c) => {
   });
 });
 
-analyticsRoutes.get("/analytics/owner/:ownerId", requireAuth, (c) => {
+analyticsRoutes.get("/analytics/owner/:ownerId", requireAuth, async (c) => {
   const authUser = c.get("authUser");
   const ownerId = c.req.param("ownerId");
-  const store = getStore();
 
   if (!isOwnerOrAdmin(authUser, ownerId)) {
     return c.json({ ok: false, error: { code: "FORBIDDEN", message: "Not allowed to view this owner's analytics" } }, 403);
   }
 
   const now = Date.now();
-  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
-  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
 
-  const ownerLands = Array.from(store.lands.values()).filter((l) => l.ownerId === ownerId);
+  const [ownerLands, ownerRequests, payments] = await Promise.all([
+    Land.find({ ownerId }).lean(),
+    RentalRequest.find().lean(),
+    Payment.find().lean(),
+  ]);
+
   const activeOwnerLands = ownerLands.filter((l) => l.status === "active");
-
   const ownerLandIds = new Set(activeOwnerLands.map((l) => l.id));
 
-  const ownerRequests = Array.from(store.rentalRequests.values()).filter((r) => {
-    return ownerLandIds.has(r.landId);
-  });
+  const filteredRequests = ownerRequests.filter((r) => ownerLandIds.has(r.landId));
+  const recentRequests = filteredRequests.filter((r) => new Date(r.createdAt) >= thirtyDaysAgo);
 
-  const recentRequests = ownerRequests.filter((r) => r.createdAt >= thirtyDaysAgo);
-
-  const pendingOwner = ownerRequests.filter((r) => r.status === "pending_owner").length;
-  const approved = ownerRequests.filter((r) => r.status === "approved" || r.status === "pending_payment" || r.status === "paid").length;
-  const rejected = ownerRequests.filter((r) => r.status === "rejected").length;
-  const totalRequests = ownerRequests.length;
+  const pendingOwner = filteredRequests.filter((r) => r.status === "pending_owner").length;
+  const approved = filteredRequests.filter((r) => r.status === "approved" || r.status === "pending_payment" || r.status === "paid").length;
+  const rejected = filteredRequests.filter((r) => r.status === "rejected").length;
+  const totalRequests = filteredRequests.length;
 
   const landsByCategory: Record<string, number> = {};
   for (const land of activeOwnerLands) {
@@ -218,7 +208,7 @@ analyticsRoutes.get("/analytics/owner/:ownerId", requireAuth, (c) => {
   }
 
   let avgTimeToDecisionMs = 0;
-  const decidedRequests = ownerRequests.filter(
+  const decidedRequests = filteredRequests.filter(
     (r) => r.status !== "draft" && r.status !== "pending_owner" && r.status !== "pending_payment",
   );
   if (decidedRequests.length > 0) {
@@ -231,13 +221,14 @@ analyticsRoutes.get("/analytics/owner/:ownerId", requireAuth, (c) => {
     avgTimeToDecisionMs = totalDecisionTime / decidedRequests.length;
   }
 
-  let totalRevenue = 0;
-  const approvedRequestIds = new Set(approved > 0 ? ownerRequests.filter((r) => r.status === "paid" || r.status === "approved" || r.status === "pending_payment").map((r) => r.id) : []);
-  for (const payment of Array.from(store.payments.values())) {
-    if (payment.status === "paid" && approvedRequestIds.has(payment.rentalRequestId)) {
-      totalRevenue += payment.amount;
-    }
-  }
+  const approvedRequestIds = new Set(
+    filteredRequests
+      .filter((r) => r.status === "paid" || r.status === "approved" || r.status === "pending_payment")
+      .map((r) => r.id),
+  );
+  const totalRevenue = payments
+    .filter((p) => p.status === "paid" && approvedRequestIds.has(p.rentalRequestId))
+    .reduce((sum, p) => sum + p.amount, 0);
 
   return success(c, {
     totalLands: activeOwnerLands.length,
@@ -246,7 +237,7 @@ analyticsRoutes.get("/analytics/owner/:ownerId", requireAuth, (c) => {
     approved,
     rejected,
     requestsLast30Days: recentRequests.length,
-    requestsLast7Days: recentRequests.filter((r) => r.createdAt >= sevenDaysAgo).length,
+    requestsLast7Days: recentRequests.filter((r) => new Date(r.createdAt) >= sevenDaysAgo).length,
     avgTimeToDecisionHours: avgTimeToDecisionMs > 0 ? Math.round(avgTimeToDecisionMs / (1000 * 60 * 60) * 10) / 10 : 0,
     requestApprovalRate: totalRequests > 0 ? Math.round((approved / totalRequests) * 100 * 10) / 10 : 0,
     totalRevenue,

--- a/apps/backend-api/src/routes/chat.ts
+++ b/apps/backend-api/src/routes/chat.ts
@@ -4,27 +4,23 @@ import { env } from "../config/env";
 import { failure, success } from "../lib/api-response";
 import { requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { getStore } from "../store/in-memory-db";
-import type { ChatMessageRecord, ChatRecord } from "../store/types";
+import { Chat, ChatMessage } from "../db/schemas";
 import type { AppEnv } from "../types";
 
-function isParticipant(chat: ChatRecord, userId: string) {
+function isParticipant(chat: { participants: { userId: string }[] }, userId: string) {
   return chat.participants.some((participant) => participant.userId === userId);
 }
 
 export const chatRoutes = new Hono<AppEnv>();
 
-chatRoutes.get("/chats", requireAuth, (c) => {
+chatRoutes.get("/chats", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
 
-  const chats = Array.from(store.chats.values()).filter((chat) => {
-    if (authUser.role === "admin") {
-      return true;
-    }
-    return isParticipant(chat, authUser.id);
-  });
+  const query = authUser.role === "admin"
+    ? {}
+    : { "participants.userId": authUser.id };
 
+  const chats = await Chat.find(query).lean();
   return success(c, chats);
 });
 
@@ -46,20 +42,13 @@ chatRoutes.post("/chats", requireAuth, async (c) => {
     return failure(c, 403, "FORBIDDEN", "Current user must be part of chat participants");
   }
 
-  const now = new Date().toISOString();
-  const chat: ChatRecord = {
+  const chat = await Chat.create({
     id: `chat_${crypto.randomUUID()}`,
     landId: body.landId,
     rentalRequestId: body.rentalRequestId,
     participants: body.participants,
     status: "active",
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  const store = getStore();
-  store.chats.set(chat.id, chat);
-  store.chatMessages.set(chat.id, []);
+  });
 
   createAuditEvent({
     actor: authUser,
@@ -76,33 +65,33 @@ chatRoutes.post("/chats", requireAuth, async (c) => {
   return success(c, chat, 201);
 });
 
-chatRoutes.get("/chats/:chatId/messages", requireAuth, (c) => {
+chatRoutes.get("/chats/:chatId/messages", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
+  const chatId = c.req.param("chatId");
 
-  const chat = store.chats.get(c.req.param("chatId"));
+  const chat = await Chat.findOne({ id: chatId }).lean();
   if (!chat) {
     return failure(c, 404, "NOT_FOUND", "Chat not found");
   }
 
-  if (authUser.role !== "admin" && !isParticipant(chat, authUser.id)) {
+  if (authUser.role !== "admin" && !isParticipant(chat as any, authUser.id)) {
     return failure(c, 403, "FORBIDDEN", "Not allowed to access this chat");
   }
 
-  const messages = store.chatMessages.get(chat.id) ?? [];
+  const messages = await ChatMessage.find({ chatId: chat.id }).sort({ createdAt: 1 }).lean();
   return success(c, messages);
 });
 
 chatRoutes.post("/chats/:chatId/messages", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const chat = store.chats.get(c.req.param("chatId"));
+  const chatId = c.req.param("chatId");
 
+  const chat = await Chat.findOne({ id: chatId }).lean();
   if (!chat) {
     return failure(c, 404, "NOT_FOUND", "Chat not found");
   }
 
-  if (authUser.role !== "admin" && !isParticipant(chat, authUser.id)) {
+  if (authUser.role !== "admin" && !isParticipant(chat as any, authUser.id)) {
     return failure(c, 403, "FORBIDDEN", "Not allowed to send messages in this chat");
   }
 
@@ -111,17 +100,12 @@ chatRoutes.post("/chats/:chatId/messages", requireAuth, async (c) => {
     return failure(c, 400, "VALIDATION_ERROR", "Message text is required");
   }
 
-  const message: ChatMessageRecord = {
+  const message = await ChatMessage.create({
     id: `msg_${crypto.randomUUID()}`,
     chatId: chat.id,
     senderId: authUser.id,
     text: body.text.trim(),
-    createdAt: new Date().toISOString(),
-  };
-
-  const list = store.chatMessages.get(chat.id) ?? [];
-  list.push(message);
-  store.chatMessages.set(chat.id, list);
+  });
 
   createAuditEvent({
     actor: authUser,
@@ -136,16 +120,16 @@ chatRoutes.post("/chats/:chatId/messages", requireAuth, async (c) => {
   return success(c, message, 201);
 });
 
-chatRoutes.get("/chats/:chatId/external-contact", requireAuth, (c) => {
+chatRoutes.get("/chats/:chatId/external-contact", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const chat = store.chats.get(c.req.param("chatId"));
+  const chatId = c.req.param("chatId");
 
+  const chat = await Chat.findOne({ id: chatId }).lean();
   if (!chat) {
     return failure(c, 404, "NOT_FOUND", "Chat not found");
   }
 
-  if (authUser.role !== "admin" && !isParticipant(chat, authUser.id)) {
+  if (authUser.role !== "admin" && !isParticipant(chat as any, authUser.id)) {
     return failure(c, 403, "FORBIDDEN", "Not allowed to view external contact for this chat");
   }
 

--- a/apps/backend-api/src/routes/contracts.ts
+++ b/apps/backend-api/src/routes/contracts.ts
@@ -4,8 +4,7 @@ import { failure, success } from "../lib/api-response";
 import { isOwnerOrAdmin } from "../lib/auth-helpers";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { getStore } from "../store/in-memory-db";
-import type { ContractRecord } from "../store/types";
+import { Contract, AuditEvent, RentalRequest, Land } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 const allowedContractStatus = new Set(["active", "completed", "cancelled"]);
@@ -25,13 +24,12 @@ contractRoutes.post("/contracts", requireAuth, async (c) => {
     return failure(c, 400, "VALIDATION_ERROR", "Missing contract fields");
   }
 
-  const store = getStore();
-  const request = store.rentalRequests.get(body.rentalRequestId);
+  const request = await RentalRequest.findOne({ id: body.rentalRequestId }).lean();
   if (!request) {
     return failure(c, 404, "NOT_FOUND", "Rental request not found");
   }
 
-  const land = store.lands.get(request.landId);
+  const land = await Land.findOne({ id: request.landId }).lean();
   if (!land) {
     return failure(c, 404, "NOT_FOUND", "Related land not found");
   }
@@ -40,8 +38,7 @@ contractRoutes.post("/contracts", requireAuth, async (c) => {
     return failure(c, 403, "FORBIDDEN", "Only owner or admin can create contracts");
   }
 
-  const now = new Date().toISOString();
-  const contract: ContractRecord = {
+  const contract = await Contract.create({
     id: `contract_${crypto.randomUUID()}`,
     rentalRequestId: request.id,
     ownerId: land.ownerId,
@@ -53,11 +50,8 @@ contractRoutes.post("/contracts", requireAuth, async (c) => {
       endsAt: body.terms.endsAt,
     },
     status: "draft",
-    createdAt: now,
-    updatedAt: now,
-  };
+  });
 
-  store.contracts.set(contract.id, contract);
   createAuditEvent({
     actor: authUser,
     entity: "contract",
@@ -71,24 +65,22 @@ contractRoutes.post("/contracts", requireAuth, async (c) => {
   return success(c, contract, 201);
 });
 
-contractRoutes.get("/contracts", requireAuth, (c) => {
+contractRoutes.get("/contracts", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const contracts = Array.from(store.contracts.values()).filter((contract) => {
-    if (authUser.role === "admin") {
-      return true;
-    }
-    return contract.ownerId === authUser.id || contract.tenantId === authUser.id;
-  });
 
+  const query = authUser.role === "admin"
+    ? {}
+    : { $or: [{ ownerId: authUser.id }, { tenantId: authUser.id }] };
+
+  const contracts = await Contract.find(query).lean();
   return success(c, contracts);
 });
 
-contractRoutes.get("/contracts/:contractId", requireAuth, (c) => {
+contractRoutes.get("/contracts/:contractId", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const contract = store.contracts.get(c.req.param("contractId"));
+  const contractId = c.req.param("contractId");
 
+  const contract = await Contract.findOne({ id: contractId }).lean();
   if (!contract) {
     return failure(c, 404, "NOT_FOUND", "Contract not found");
   }
@@ -106,10 +98,9 @@ contractRoutes.get("/contracts/:contractId", requireAuth, (c) => {
 
 contractRoutes.patch("/contracts/:contractId/status", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
   const contractId = c.req.param("contractId");
-  const current = store.contracts.get(contractId);
 
+  const current = await Contract.findOne({ id: contractId }).lean();
   if (!current) {
     return failure(c, 404, "NOT_FOUND", "Contract not found");
   }
@@ -125,13 +116,10 @@ contractRoutes.patch("/contracts/:contractId/status", requireAuth, async (c) => 
     return failure(c, 400, "VALIDATION_ERROR", "Invalid contract status");
   }
 
-  const updated: ContractRecord = {
-    ...current,
-    status: status as ContractRecord["status"],
-    updatedAt: new Date().toISOString(),
-  };
-
-  store.contracts.set(contractId, updated);
+  await Contract.updateOne(
+    { id: contractId },
+    { status: status as any, updatedAt: new Date() },
+  );
 
   createAuditEvent({
     actor: authUser,
@@ -141,15 +129,15 @@ contractRoutes.patch("/contracts/:contractId/status", requireAuth, async (c) => 
     metadata: { from: current.status, to: status, reason: body?.reason },
   });
 
+  const updated = await Contract.findOne({ id: contractId }).lean();
   return success(c, updated);
 });
 
 contractRoutes.post("/contracts/:contractId/sign", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
   const contractId = c.req.param("contractId");
-  const current = store.contracts.get(contractId);
 
+  const current = await Contract.findOne({ id: contractId }).lean();
   if (!current) {
     return failure(c, 404, "NOT_FOUND", "Contract not found");
   }
@@ -166,18 +154,14 @@ contractRoutes.post("/contracts/:contractId/sign", requireAuth, async (c) => {
     return failure(c, 400, "INVALID_TRANSITION", `Cannot sign contract in '${current.status}' status`);
   }
 
-  const now = new Date().toISOString();
-  const updated: ContractRecord = {
-    ...current,
-    status: "active",
-    terms: {
-      ...current.terms,
-      signedAt: now,
+  await Contract.updateOne(
+    { id: contractId },
+    {
+      status: "active",
+      "terms.signedAt": new Date().toISOString(),
+      updatedAt: new Date(),
     },
-    updatedAt: now,
-  };
-
-  store.contracts.set(contractId, updated);
+  );
 
   createAuditEvent({
     actor: authUser,
@@ -187,15 +171,15 @@ contractRoutes.post("/contracts/:contractId/sign", requireAuth, async (c) => {
     metadata: { from: current.status, to: "active" },
   });
 
+  const updated = await Contract.findOne({ id: contractId }).lean();
   return success(c, updated);
 });
 
 contractRoutes.post("/contracts/:contractId/complete", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
   const contractId = c.req.param("contractId");
-  const current = store.contracts.get(contractId);
 
+  const current = await Contract.findOne({ id: contractId }).lean();
   if (!current) {
     return failure(c, 404, "NOT_FOUND", "Contract not found");
   }
@@ -208,14 +192,10 @@ contractRoutes.post("/contracts/:contractId/complete", requireAuth, async (c) =>
     return failure(c, 400, "INVALID_TRANSITION", `Cannot complete contract in '${current.status}' status`);
   }
 
-  const now = new Date().toISOString();
-  const updated: ContractRecord = {
-    ...current,
-    status: "completed",
-    updatedAt: now,
-  };
-
-  store.contracts.set(contractId, updated);
+  await Contract.updateOne(
+    { id: contractId },
+    { status: "completed", updatedAt: new Date() },
+  );
 
   createAuditEvent({
     actor: authUser,
@@ -225,40 +205,30 @@ contractRoutes.post("/contracts/:contractId/complete", requireAuth, async (c) =>
     metadata: { from: current.status, to: "completed" },
   });
 
+  const updated = await Contract.findOne({ id: contractId }).lean();
   return success(c, updated);
 });
 
-contractRoutes.get("/audit-events", requireAuth, requireAdmin, (c) => {
-  const store = getStore();
+contractRoutes.get("/audit-events", requireAuth, requireAdmin, async (c) => {
   const actorId = c.req.query("actorId");
   const entity = c.req.query("entity");
   const action = c.req.query("action");
-  const entityId = c.req.query("entityId");
+  const entityIdQuery = c.req.query("entityId");
 
-  let events = Array.from(store.auditEvents.values());
+  const query: Record<string, any> = {};
+  if (actorId) query.actorId = actorId;
+  if (entity) query.entity = entity;
+  if (action) query.action = action;
+  if (entityIdQuery) query.entityId = entityIdQuery;
 
-  if (actorId) {
-    events = events.filter((event) => event.actorId === actorId);
-  }
-  if (entity) {
-    events = events.filter((event) => event.entity === entity);
-  }
-  if (action) {
-    events = events.filter((event) => event.action === action);
-  }
-  if (entityId) {
-    events = events.filter((event) => event.entityId === entityId);
-  }
-
-  events.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
-
+  const events = await AuditEvent.find(query).sort({ createdAt: -1 }).lean();
   return success(c, events);
 });
 
-contractRoutes.get("/audit-events/:eventId", requireAuth, requireAdmin, (c) => {
-  const store = getStore();
-  const event = store.auditEvents.get(c.req.param("eventId"));
+contractRoutes.get("/audit-events/:eventId", requireAuth, requireAdmin, async (c) => {
+  const eventId = c.req.param("eventId");
 
+  const event = await AuditEvent.findOne({ id: eventId }).lean();
   if (!event) {
     return failure(c, 404, "NOT_FOUND", "Audit event not found");
   }

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -125,6 +125,21 @@ landRoutes.get("/lands/:landId", async (c) => {
   return success(c, land);
 });
 
+landRoutes.get("/lands/me", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const mongoOk = useMongoDB();
+
+  let lands: LandRecord[] = [];
+  
+  if (mongoOk) {
+    lands = await listLands({ ownerId: authUser.id }) as LandRecord[];
+  } else {
+    lands = Array.from(getStore().lands.values()).filter((l) => l.ownerId === authUser.id);
+  }
+
+  return success(c, lands);
+});
+
 landRoutes.post("/lands", requireAuth, async (c) => {
   const authUser = c.get("authUser");
   const body = (await c.req.json().catch(() => null)) as Partial<LandRecord> | null;

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -4,17 +4,27 @@ import { failure, success } from "../lib/api-response";
 import { isOwnerOrAdmin } from "../lib/auth-helpers";
 import { getNumericQuery, getOptionalNumericQuery } from "../lib/request-utils";
 import { requireAuth } from "../middleware/require-auth";
-import { createAuditEvent } from "../store/audit";
+import { createAuditEvent as createAudit } from "../store/audit";
+import { listLands, getLandById, createLand, updateLand, deleteLand } from "../db/collections";
 import { getStore } from "../store/in-memory-db";
 import type { LandRecord, LandUse } from "../store/types";
 import type { AppEnv } from "../types";
 
 const allowedSortFields = new Set(["createdAt", "price", "area"]);
 
+function useMongoDB(): boolean {
+  try {
+    const { getDatabase } = require("../config/database");
+    return !!getDatabase();
+  } catch {
+    return false;
+  }
+}
+
 export const landRoutes = new Hono<AppEnv>();
 
-landRoutes.get("/lands", (c) => {
-  const store = getStore();
+landRoutes.get("/lands", async (c) => {
+  const mongoOk = useMongoDB();
   const page = getNumericQuery(c, "page", 1, { min: 1 });
   const pageSize = getNumericQuery(c, "pageSize", 20, { min: 1, max: 100 });
   const sort = c.req.query("sort") ?? "createdAt";
@@ -33,7 +43,15 @@ landRoutes.get("/lands", (c) => {
     ]);
   }
 
-  let lands = Array.from(store.lands.values()).filter((land) => land.status === "active");
+  let lands: LandRecord[];
+  
+  if (mongoOk) {
+    const filters: Record<string, string> = {};
+    if (use) filters.status = "active";
+    lands = await listLands({ status: "active" }) as LandRecord[];
+  } else {
+    lands = Array.from(getStore().lands.values()).filter((land) => land.status === "active");
+  }
 
   if (use) {
     lands = lands.filter((land) => land.allowedUses.includes(use as LandUse));
@@ -89,9 +107,17 @@ landRoutes.get("/lands", (c) => {
   });
 });
 
-landRoutes.get("/lands/:landId", (c) => {
-  const store = getStore();
-  const land = store.lands.get(c.req.param("landId"));
+landRoutes.get("/lands/:landId", async (c) => {
+  const mongoOk = useMongoDB();
+  const landId = c.req.param("landId");
+  
+  let land: LandRecord | undefined;
+  if (mongoOk) {
+    land = await getLandById(landId) as LandRecord | undefined;
+  } else {
+    land = getStore().lands.get(landId);
+  }
+  
   if (!land || land.status === "inactive") {
     return failure(c, 404, "NOT_FOUND", "Land not found");
   }
@@ -125,9 +151,14 @@ landRoutes.post("/lands", requireAuth, async (c) => {
     updatedAt: now,
   };
 
-  const store = getStore();
-  store.lands.set(land.id, land);
-  createAuditEvent({
+  const mongoOk = useMongoDB();
+  if (mongoOk) {
+    await createLand(land);
+  } else {
+    getStore().lands.set(land.id, land);
+  }
+  
+  createAudit({
     actor: authUser,
     entity: "land",
     action: "created",
@@ -139,9 +170,16 @@ landRoutes.post("/lands", requireAuth, async (c) => {
 
 landRoutes.patch("/lands/:landId", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
   const landId = c.req.param("landId");
-  const current = store.lands.get(landId);
+  const mongoOk = useMongoDB();
+  
+  let current: LandRecord | undefined;
+  if (mongoOk) {
+    current = await getLandById(landId) as LandRecord | undefined;
+  } else {
+    current = getStore().lands.get(landId);
+  }
+  
   if (!current) {
     return failure(c, 404, "NOT_FOUND", "Land not found");
   }
@@ -163,8 +201,13 @@ landRoutes.patch("/lands/:landId", requireAuth, async (c) => {
     updatedAt: new Date().toISOString(),
   };
 
-  store.lands.set(updated.id, updated);
-  createAuditEvent({
+  if (mongoOk) {
+    await updateLand(landId, updated);
+  } else {
+    getStore().lands.set(updated.id, updated);
+  }
+  
+  createAudit({
     actor: authUser,
     entity: "land",
     action: "updated",
@@ -176,9 +219,16 @@ landRoutes.patch("/lands/:landId", requireAuth, async (c) => {
 
 landRoutes.patch("/lands/:landId/status", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
   const landId = c.req.param("landId");
-  const current = store.lands.get(landId);
+  const mongoOk = useMongoDB();
+  
+  let current: LandRecord | undefined;
+  if (mongoOk) {
+    current = await getLandById(landId) as LandRecord | undefined;
+  } else {
+    current = getStore().lands.get(landId);
+  }
+  
   if (!current) {
     return failure(c, 404, "NOT_FOUND", "Land not found");
   }
@@ -199,9 +249,14 @@ landRoutes.patch("/lands/:landId/status", requireAuth, async (c) => {
     status,
     updatedAt: new Date().toISOString(),
   };
-  store.lands.set(landId, updated);
+  
+  if (mongoOk) {
+    await updateLand(landId, updated);
+  } else {
+    getStore().lands.set(landId, updated);
+  }
 
-  createAuditEvent({
+  createAudit({
     actor: authUser,
     entity: "land",
     action: "status_changed",
@@ -212,11 +267,18 @@ landRoutes.patch("/lands/:landId/status", requireAuth, async (c) => {
   return success(c, updated);
 });
 
-landRoutes.delete("/lands/:landId", requireAuth, (c) => {
+landRoutes.delete("/lands/:landId", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
   const landId = c.req.param("landId");
-  const current = store.lands.get(landId);
+  const mongoOk = useMongoDB();
+  
+  let current: LandRecord | undefined;
+  if (mongoOk) {
+    current = await getLandById(landId) as LandRecord | undefined;
+  } else {
+    current = getStore().lands.get(landId);
+  }
+  
   if (!current) {
     return failure(c, 404, "NOT_FOUND", "Land not found");
   }
@@ -225,8 +287,13 @@ landRoutes.delete("/lands/:landId", requireAuth, (c) => {
     return failure(c, 403, "FORBIDDEN", "Only owner or admin can delete this land");
   }
 
-  store.lands.delete(landId);
-  createAuditEvent({
+  if (mongoOk) {
+    await deleteLand(landId);
+  } else {
+    getStore().lands.delete(landId);
+  }
+  
+  createAudit({
     actor: authUser,
     entity: "land",
     action: "deleted",

--- a/apps/backend-api/src/routes/leads.ts
+++ b/apps/backend-api/src/routes/leads.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 
 import { failure, success } from "../lib/api-response";
-import { getStore } from "../store/in-memory-db";
+import { Lead } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const leadRoutes = new Hono<AppEnv>();
@@ -18,32 +18,22 @@ leadRoutes.post("/", async (c) => {
     return failure(c, 400, "VALIDATION_ERROR", "Invalid email format");
   }
 
-  // Check for duplicate
-  const store = getStore();
-  for (const [, lead] of store.leads) {
-    if (lead.email.toLowerCase() === body.email.toLowerCase()) {
-      return failure(c, 409, "CONFLICT", "Email already registered as lead");
-    }
+  const existingLead = await Lead.findOne({ email: body.email.trim().toLowerCase() });
+  if (existingLead) {
+    return failure(c, 409, "CONFLICT", "Email already registered as lead");
   }
 
-  const now = new Date().toISOString();
-  const lead = {
+  const lead = await Lead.create({
     id: `lead_${crypto.randomUUID()}`,
     email: body.email.trim().toLowerCase(),
-    source: (body.source as "landing" | "app-web" | "admin-dashboard") ?? "landing",
-    createdAt: now,
-  };
-
-  store.leads.set(lead.id, lead);
+    source: body.source || "landing",
+  });
 
   return success(c, { id: lead.id, email: lead.email, createdAt: lead.createdAt }, 201);
 });
 
 leadRoutes.get("/", async (c) => {
-  const store = getStore();
-  const leads = Array.from(store.leads.values()).sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
+  const leads = await Lead.find().sort({ createdAt: -1 }).lean();
 
   return success(c, {
     leads,

--- a/apps/backend-api/src/routes/payments.ts
+++ b/apps/backend-api/src/routes/payments.ts
@@ -5,8 +5,7 @@ import { env } from "../config/env";
 import { failure, success } from "../lib/api-response";
 import { requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { getStore } from "../store/in-memory-db";
-import type { PaymentRecord, RentalRequestRecord } from "../store/types";
+import { Payment, RentalRequest, Land } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 let stripeClient: Stripe | null = null;
@@ -23,9 +22,11 @@ function getStripeClient() {
   return stripeClient;
 }
 
-function computePaymentAmount(request: RentalRequestRecord, fallback = 1000) {
-  const store = getStore();
-  const land = store.lands.get(request.landId);
+async function computePaymentAmount(rentalRequestId: string, fallback = 1000) {
+  const request = await RentalRequest.findOne({ id: rentalRequestId }).lean();
+  if (!request) return fallback;
+  
+  const land = await Land.findOne({ id: request.landId }).lean();
   return land?.priceRule?.pricePerMonth ?? fallback;
 }
 
@@ -46,9 +47,7 @@ paymentRoutes.post("/payments/checkout-session", requireAuth, async (c) => {
     return failure(c, 400, "VALIDATION_ERROR", "Missing checkout session fields");
   }
 
-  const store = getStore();
-  const request = store.rentalRequests.get(body.rentalRequestId);
-
+  const request = await RentalRequest.findOne({ id: body.rentalRequestId }).lean();
   if (!request) {
     return failure(c, 404, "NOT_FOUND", "Rental request not found");
   }
@@ -61,16 +60,15 @@ paymentRoutes.post("/payments/checkout-session", requireAuth, async (c) => {
     return failure(c, 422, "BUSINESS_RULE_VIOLATION", "Rental request is not payable");
   }
 
-  const now = new Date().toISOString();
-  const payment: PaymentRecord = {
+  const amount = await computePaymentAmount(request.id);
+
+  const payment = await Payment.create({
     id: `pay_${crypto.randomUUID()}`,
     rentalRequestId: request.id,
-    amount: computePaymentAmount(request),
+    amount,
     currency: body.currency,
     status: "pending",
-    createdAt: now,
-    updatedAt: now,
-  };
+  });
 
   const stripe = getStripeClient();
 
@@ -84,7 +82,7 @@ paymentRoutes.post("/payments/checkout-session", requireAuth, async (c) => {
           quantity: 1,
           price_data: {
             currency: body.currency.toLowerCase(),
-            unit_amount: Math.round(payment.amount * 100),
+            unit_amount: Math.round(amount * 100),
             product_data: {
               name: `TerraShare rental ${request.id}`,
             },
@@ -97,19 +95,21 @@ paymentRoutes.post("/payments/checkout-session", requireAuth, async (c) => {
       },
     });
 
-    payment.stripeSessionId = session.id;
-    payment.checkoutUrl = session.url ?? undefined;
+    await Payment.updateOne(
+      { id: payment.id },
+      { stripeSessionId: session.id, checkoutUrl: session.url ?? undefined },
+    );
   } else {
-    payment.stripeSessionId = `cs_dev_${crypto.randomUUID()}`;
-    payment.checkoutUrl = body.successUrl;
+    await Payment.updateOne(
+      { id: payment.id },
+      { stripeSessionId: `cs_dev_${crypto.randomUUID()}`, checkoutUrl: body.successUrl },
+    );
   }
 
-  store.payments.set(payment.id, payment);
-  store.rentalRequests.set(request.id, {
-    ...request,
-    status: "pending_payment",
-    updatedAt: now,
-  });
+  await RentalRequest.updateOne(
+    { id: request.id },
+    { status: "pending_payment", updatedAt: new Date() },
+  );
 
   createAuditEvent({
     actor: authUser,
@@ -118,64 +118,58 @@ paymentRoutes.post("/payments/checkout-session", requireAuth, async (c) => {
     entityId: payment.id,
     metadata: {
       rentalRequestId: request.id,
-      stripeSessionId: payment.stripeSessionId,
-      amount: payment.amount,
-      currency: payment.currency,
+      amount,
+      currency: body.currency,
     },
   });
+
+  const updatedPayment = await Payment.findOne({ id: payment.id }).lean();
 
   return success(
     c,
     {
-      paymentId: payment.id,
-      stripeSessionId: payment.stripeSessionId,
-      checkoutUrl: payment.checkoutUrl,
-      status: payment.status,
+      paymentId: updatedPayment?.id,
+      stripeSessionId: updatedPayment?.stripeSessionId,
+      checkoutUrl: updatedPayment?.checkoutUrl,
+      status: updatedPayment?.status,
     },
     201,
   );
 });
 
-paymentRoutes.get("/payments", requireAuth, (c) => {
+paymentRoutes.get("/payments", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
 
   const rentalRequestId = c.req.query("rentalRequestId");
   const contractId = c.req.query("contractId");
   const status = c.req.query("status");
 
-  let items = Array.from(store.payments.values()).filter((payment) => {
-    const request = store.rentalRequests.get(payment.rentalRequestId);
-    if (!request) {
-      return authUser.role === "admin";
-    }
-    return authUser.role === "admin" || request.tenantId === authUser.id;
-  });
+  const query: Record<string, any> = {};
 
-  if (rentalRequestId) {
-    items = items.filter((payment) => payment.rentalRequestId === rentalRequestId);
-  }
-  if (contractId) {
-    items = items.filter((payment) => payment.contractId === contractId);
-  }
-  if (status) {
-    items = items.filter((payment) => payment.status === status);
+  if (authUser.role !== "admin") {
+    const requests = await RentalRequest.find({ tenantId: authUser.id }).select("id").lean();
+    const requestIds = requests.map((r) => r.id);
+    query.rentalRequestId = { $in: requestIds };
   }
 
-  items.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+  if (rentalRequestId) query.rentalRequestId = rentalRequestId;
+  if (contractId) query.contractId = contractId;
+  if (status) query.status = status;
+
+  const items = await Payment.find(query).sort({ createdAt: -1 }).lean();
   return success(c, items);
 });
 
-paymentRoutes.get("/payments/:paymentId", requireAuth, (c) => {
+paymentRoutes.get("/payments/:paymentId", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const payment = store.payments.get(c.req.param("paymentId"));
+  const paymentId = c.req.param("paymentId");
 
+  const payment = await Payment.findOne({ id: paymentId }).lean();
   if (!payment) {
     return failure(c, 404, "NOT_FOUND", "Payment not found");
   }
 
-  const request = store.rentalRequests.get(payment.rentalRequestId);
+  const request = await RentalRequest.findOne({ id: payment.rentalRequestId }).lean();
   if (
     authUser.role !== "admin" &&
     request &&
@@ -192,7 +186,6 @@ paymentRoutes.post("/webhooks/stripe", async (c) => {
   const webhookSecret = env.stripeWebhookSecret;
 
   const rawBody = await c.req.text();
-  const store = getStore();
 
   if (webhookSecret && signature) {
     const stripe = getStripeClient();
@@ -231,34 +224,37 @@ paymentRoutes.post("/webhooks/stripe", async (c) => {
     return failure(c, 400, "VALIDATION_ERROR", "Missing paymentId in webhook metadata");
   }
 
-  const payment = store.payments.get(paymentId);
+  const payment = await Payment.findOne({ id: paymentId }).lean();
   if (!payment) {
     return failure(c, 404, "NOT_FOUND", "Payment not found");
   }
 
+  let newStatus = payment.status;
   if (event.type === "checkout.session.completed" || event.type === "payment_intent.succeeded") {
-    payment.status = "paid";
-    payment.stripePaymentIntentId =
-      event.data?.object?.payment_intent || payment.stripePaymentIntentId;
+    newStatus = "paid";
   } else if (event.type === "checkout.session.expired" || event.type === "payment_intent.payment_failed") {
-    payment.status = "failed";
+    newStatus = "failed";
   }
 
-  payment.updatedAt = new Date().toISOString();
-  store.payments.set(payment.id, payment);
+  await Payment.updateOne(
+    { id: payment.id },
+    {
+      status: newStatus,
+      stripePaymentIntentId: event.data?.object?.payment_intent || payment.stripePaymentIntentId,
+      updatedAt: new Date(),
+    },
+  );
 
-  const request = store.rentalRequests.get(payment.rentalRequestId);
-  if (request && payment.status === "paid") {
-    store.rentalRequests.set(request.id, {
-      ...request,
-      status: "paid",
-      updatedAt: new Date().toISOString(),
-    });
+  if (newStatus === "paid") {
+    await RentalRequest.updateOne(
+      { id: payment.rentalRequestId },
+      { status: "paid", updatedAt: new Date() },
+    );
   }
 
   return success(c, {
     received: true,
     paymentId: payment.id,
-    status: payment.status,
+    status: newStatus,
   });
 });

--- a/apps/backend-api/src/routes/rental-requests.ts
+++ b/apps/backend-api/src/routes/rental-requests.ts
@@ -4,8 +4,8 @@ import { failure, success } from "../lib/api-response";
 import { isOwnerOrAdmin } from "../lib/auth-helpers";
 import { requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { getStore } from "../store/in-memory-db";
-import type { RentalRequestRecord, RentalRequestStatus } from "../store/types";
+import { Land, RentalRequest } from "../db/schemas";
+import type { RentalRequestStatus } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 const allowedTransitions: Record<RentalRequestStatus, RentalRequestStatus[]> = {
@@ -44,8 +44,7 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
     return failure(c, 400, "VALIDATION_ERROR", "Missing required rental request fields");
   }
 
-  const store = getStore();
-  const land = store.lands.get(body.landId);
+  const land = await Land.findOne({ id: body.landId }).lean();
   if (!land) {
     return failure(c, 404, "NOT_FOUND", "Land not found");
   }
@@ -60,29 +59,25 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
     return failure(c, 400, "VALIDATION_ERROR", "Invalid rental period");
   }
 
-  const overlappingPaid = Array.from(store.rentalRequests.values()).some((request) => {
-    if (request.landId !== body.landId) {
-      return false;
-    }
-    if (!["approved", "pending_payment", "paid"].includes(request.status)) {
-      return false;
-    }
-    const existingStart = Date.parse(request.period.startDate);
-    const existingEnd = Date.parse(request.period.endDate);
-    return periodStart < existingEnd && periodEnd > existingStart;
-  });
+  const overlappingPaid = await RentalRequest.findOne({
+    landId: body.landId,
+    status: { $in: ["approved", "pending_payment", "paid"] },
+  }).lean();
 
   if (overlappingPaid) {
-    return failure(
-      c,
-      409,
-      "CONFLICT",
-      "Land already has an overlapping approved/pending rental request",
-    );
+    const existingStart = Date.parse(overlappingPaid.period.startDate);
+    const existingEnd = Date.parse(overlappingPaid.period.endDate);
+    if (periodStart < existingEnd && periodEnd > existingStart) {
+      return failure(
+        c,
+        409,
+        "CONFLICT",
+        "Land already has an overlapping approved/pending rental request",
+      );
+    }
   }
 
-  const now = new Date().toISOString();
-  const record: RentalRequestRecord = {
+  const record = await RentalRequest.create({
     id: `rr_${crypto.randomUUID()}`,
     landId: body.landId,
     tenantId: authUser.id,
@@ -93,11 +88,8 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
     intendedUse: body.intendedUse,
     notes: body.notes,
     status: "pending_owner",
-    createdAt: now,
-    updatedAt: now,
-  };
+  });
 
-  store.rentalRequests.set(record.id, record);
   createAuditEvent({
     actor: authUser,
     entity: "rental_request",
@@ -112,36 +104,39 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
   return success(c, record, 201);
 });
 
-rentalRequestRoutes.get("/rental-requests", requireAuth, (c) => {
+rentalRequestRoutes.get("/rental-requests", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
 
-  const items = Array.from(store.rentalRequests.values()).filter((request) => {
-    if (authUser.role === "admin") {
-      return true;
-    }
+  let query: Record<string, any> = {};
 
-    if (request.tenantId === authUser.id) {
-      return true;
-    }
+  if (authUser.role === "admin") {
+    query = {};
+  } else {
+    const userOwnedLands = await Land.find({ ownerId: authUser.id }).select("id").lean();
+    const userLandIds = userOwnedLands.map((l) => l.id);
+    query = {
+      $or: [
+        { tenantId: authUser.id },
+        { landId: { $in: userLandIds } },
+      ],
+    };
+  }
 
-    const land = store.lands.get(request.landId);
-    return Boolean(land && land.ownerId === authUser.id);
-  });
+  const items = await RentalRequest.find(query).lean();
 
   return success(c, items);
 });
 
-rentalRequestRoutes.get("/rental-requests/:requestId", requireAuth, (c) => {
+rentalRequestRoutes.get("/rental-requests/:requestId", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const record = store.rentalRequests.get(c.req.param("requestId"));
+  const requestId = c.req.param("requestId");
 
+  const record = await RentalRequest.findOne({ id: requestId }).lean();
   if (!record) {
     return failure(c, 404, "NOT_FOUND", "Rental request not found");
   }
 
-  const land = store.lands.get(record.landId);
+  const land = await Land.findOne({ id: record.landId }).lean();
   const canAccess =
     authUser.role === "admin" ||
     record.tenantId === authUser.id ||
@@ -156,15 +151,14 @@ rentalRequestRoutes.get("/rental-requests/:requestId", requireAuth, (c) => {
 
 rentalRequestRoutes.patch("/rental-requests/:requestId/status", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
   const requestId = c.req.param("requestId");
-  const current = store.rentalRequests.get(requestId);
 
+  const current = await RentalRequest.findOne({ id: requestId }).lean();
   if (!current) {
     return failure(c, 404, "NOT_FOUND", "Rental request not found");
   }
 
-  const land = store.lands.get(current.landId);
+  const land = await Land.findOne({ id: current.landId }).lean();
   if (!land) {
     return failure(c, 404, "NOT_FOUND", "Related land not found");
   }
@@ -194,13 +188,10 @@ rentalRequestRoutes.patch("/rental-requests/:requestId/status", requireAuth, asy
     return failure(c, 403, "FORBIDDEN", "Not allowed to cancel this request");
   }
 
-  const updated: RentalRequestRecord = {
-    ...current,
-    status: nextStatus,
-    updatedAt: new Date().toISOString(),
-  };
-
-  store.rentalRequests.set(updated.id, updated);
+  await RentalRequest.updateOne(
+    { id: requestId },
+    { status: nextStatus, updatedAt: new Date() },
+  );
 
   createAuditEvent({
     actor: authUser,
@@ -213,7 +204,7 @@ rentalRequestRoutes.patch("/rental-requests/:requestId/status", requireAuth, asy
           : nextStatus === "cancelled"
             ? "cancelled"
             : "status_changed",
-    entityId: updated.id,
+    entityId: current.id,
     metadata: {
       from: current.status,
       to: nextStatus,
@@ -221,5 +212,6 @@ rentalRequestRoutes.patch("/rental-requests/:requestId/status", requireAuth, asy
     },
   });
 
+  const updated = await RentalRequest.findOne({ id: requestId }).lean();
   return success(c, updated);
 });

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -1,0 +1,284 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@terrashare/web",
+      "dependencies": {
+        "@clerk/clerk-react": "^5.0.0",
+        "leaflet": "^1.9.4",
+        "leaflet-defaulticon-compatibility": "^0.1.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-leaflet": "^5.0.0",
+        "react-router-dom": "^6.30.1",
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "@vitejs/plugin-react": "^4.3.4",
+        "vite": "^5.4.10",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@clerk/clerk-react": ["@clerk/clerk-react@5.61.3", "", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg=="],
+
+    "@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
+    "@react-leaflet/core": ["@react-leaflet/core@3.0.0", "", { "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ=="],
+
+    "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.23", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
+
+    "leaflet-defaulticon-compatibility": ["leaflet-defaulticon-compatibility@0.1.2", "", {}, "sha512-IrKagWxkTwzxUkFIumy/Zmo3ksjuAu3zEadtOuJcKzuXaD76Gwvg2Z1mLyx7y52ykOzM8rAH5ChBs4DnfdGa6Q=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-leaflet": ["react-leaflet@5.0.0", "", { "dependencies": { "@react-leaflet/core": "^3.0.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-router": ["react-router@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="],
+
+    "react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+  }
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -19,8 +19,7 @@ import Login from "./components/Login";
 import Register from "./components/Register";
 import UserDashboardLayout from "./components/UserDashboardLayout";
 import PublicHeader from "./components/PublicHeader";
-import { getAdminSummary, listAdminRentalRequests, setTokenFn as setAdminTokenFn } from "./services/adminApi";
-import { useClerkToken } from "./hooks/useClerkToken";
+import { getAdminSummary, listAdminRentalRequests } from "./services/adminApi";
 import { isAdminUser } from "./components/authDisplay";
 
 function ProtectedRoute({ children }) {
@@ -259,11 +258,8 @@ function AdminDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [requestFilter, setRequestFilter] = useState("all");
-  const tokenReady = useClerkToken(setAdminTokenFn);
 
   useEffect(() => {
-    if (!tokenReady) return;
-
     let active = true;
     setLoading(true);
     setError("");
@@ -287,7 +283,7 @@ function AdminDashboardPage() {
     return () => {
       active = false;
     };
-  }, [tokenReady, requestFilter]);
+  }, [requestFilter]);
 
   const adminName = user?.firstName || user?.fullName || user?.emailAddresses?.[0]?.emailAddress?.split("@")[0] || "Admin";
 

--- a/apps/web/src/hooks/useClerkToken.js
+++ b/apps/web/src/hooks/useClerkToken.js
@@ -14,10 +14,22 @@ export function useClerkToken(setTokenFn) {
       return undefined;
     }
 
+    const getToken = user.getToken;
+    if (typeof getToken !== "function") {
+      setTokenFn(() => null);
+      setReady(true);
+      return undefined;
+    }
+
     setReady(false);
-    user.getToken().then((token) => {
+    getToken().then((token) => {
       if (active) {
         setTokenFn(() => token);
+        setReady(true);
+      }
+    }).catch(() => {
+      if (active) {
+        setTokenFn(() => null);
         setReady(true);
       }
     });

--- a/apps/web/src/hooks/useClerkToken.js
+++ b/apps/web/src/hooks/useClerkToken.js
@@ -1,6 +1,21 @@
 import { useEffect, useState } from "react";
 import { useUser } from "@clerk/clerk-react";
 
+async function tryGetToken(getToken, retries = 3, delay = 300) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const token = await getToken();
+      if (token) return token;
+    } catch {
+      // ignore error
+    }
+    if (i < retries - 1) {
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  return null;
+}
+
 export function useClerkToken(setTokenFn) {
   const { user } = useUser();
   const [ready, setReady] = useState(false);
@@ -22,14 +37,9 @@ export function useClerkToken(setTokenFn) {
     }
 
     setReady(false);
-    getToken().then((token) => {
+    tryGetToken(getToken, 3, 300).then((token) => {
       if (active) {
         setTokenFn(() => token);
-        setReady(true);
-      }
-    }).catch(() => {
-      if (active) {
-        setTokenFn(() => null);
         setReady(true);
       }
     });

--- a/apps/web/src/pages/AdminLandsPage.jsx
+++ b/apps/web/src/pages/AdminLandsPage.jsx
@@ -37,10 +37,8 @@ export default function AdminLandsPage() {
   };
 
   useEffect(() => {
-    if (tokenReady) {
-      loadLands();
-    }
-  }, [tokenReady, filter, search]);
+    loadLands();
+  }, [filter, search]);
 
   const handleUpdateStatus = async (landId, currentStatus, nextStatus) => {
     try {

--- a/apps/web/src/pages/AdminLandsPage.jsx
+++ b/apps/web/src/pages/AdminLandsPage.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
-import { listAdminLands, updateLandStatus, setTokenFn } from "../services/adminApi";
-import { useClerkToken } from "../hooks/useClerkToken";
+import { listAdminLands, updateLandStatus } from "../services/adminApi";
 
 const statusLabels = {
   draft: "Borrador",
@@ -23,8 +22,6 @@ export default function AdminLandsPage() {
   const [filter, setFilter] = useState("draft");
   const [search, setSearch] = useState("");
   const [actionMsg, setActionMsg] = useState("");
-
-  const tokenReady = useClerkToken(setTokenFn);
 
   const loadLands = () => {
     setLoading(true);

--- a/apps/web/src/pages/AdminUsersPage.jsx
+++ b/apps/web/src/pages/AdminUsersPage.jsx
@@ -26,10 +26,8 @@ export default function AdminUsersPage() {
   };
 
   useEffect(() => {
-    if (tokenReady) {
-      loadUsers();
-    }
-  }, [tokenReady, filter, search]);
+    loadUsers();
+  }, [filter, search]);
 
   const handleToggleStatus = async (userId, currentStatus) => {
     const nextStatus = currentStatus === "active" ? "blocked" : "active";

--- a/apps/web/src/pages/AdminUsersPage.jsx
+++ b/apps/web/src/pages/AdminUsersPage.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
-import { listAdminUsers, updateUserStatus, setTokenFn } from "../services/adminApi";
-import { useClerkToken } from "../hooks/useClerkToken";
+import { listAdminUsers, updateUserStatus } from "../services/adminApi";
 
 const roleLabel = { user: "Usuario", admin: "Admin" };
 const statusLabel = { active: "Activo", blocked: "Bloqueado" };
@@ -12,8 +11,6 @@ export default function AdminUsersPage() {
   const [filter, setFilter] = useState("all");
   const [search, setSearch] = useState("");
   const [actionMsg, setActionMsg] = useState("");
-
-  const tokenReady = useClerkToken(setTokenFn);
 
   const loadUsers = () => {
     setLoading(true);

--- a/apps/web/src/pages/ChatsPage.jsx
+++ b/apps/web/src/pages/ChatsPage.jsx
@@ -1,19 +1,13 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@clerk/clerk-react";
-import { getChats, setTokenFn } from "../services/api";
+import { getChats } from "../services/api";
 
 export default function ChatsPage() {
   const { user } = useUser();
   const [chats, setChats] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  useEffect(() => {
-    if (user?.getToken) {
-      setTokenFn(user.getToken);
-    }
-  }, [user]);
 
   useEffect(() => {
     const fetchChats = async () => {

--- a/apps/web/src/pages/ChatsPage.jsx
+++ b/apps/web/src/pages/ChatsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@clerk/clerk-react";
+import { getChats, setTokenFn } from "../services/api";
 
 export default function ChatsPage() {
   const { user } = useUser();
@@ -9,20 +10,20 @@ export default function ChatsPage() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (user?.getToken) {
+      setTokenFn(user.getToken);
+    }
+  }, [user]);
+
+  useEffect(() => {
     const fetchChats = async () => {
-      if (!user || !user.getToken) {
+      if (!user) {
         setLoading(false);
         return;
       }
       try {
-        const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
-        const token = await user.getToken();
-        const res = await fetch(`${BASE_URL}/api/v1/chats`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) throw new Error("Failed to fetch");
-        const data = await res.json();
-        setChats(data?.data || []);
+        const data = await getChats();
+        setChats(data || []);
       } catch (err) {
         console.error("Error fetching chats:", err);
         setError(err.message);

--- a/apps/web/src/pages/LandDetailPage.jsx
+++ b/apps/web/src/pages/LandDetailPage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import { getLandPrimaryUse, formatLandUse, getChatSeedMessages } from "../data/lands";
-import { getLandById, getChats, createChat, getMessages, sendMessage, getExternalContact, setTokenFn } from "../services/api";
+import { getLandById, getChats, createChat, getMessages, sendMessage, getExternalContact } from "../services/api";
 import PublicHeader from "../components/PublicHeader";
 
 function useChat(landId, isSignedIn, user) {
@@ -13,7 +13,7 @@ function useChat(landId, isSignedIn, user) {
   const [externalContact, setExternalContact] = useState(null);
 
   useEffect(() => {
-    if (!isSignedIn || !user || !user.getToken) {
+    if (!isSignedIn || !user) {
       const stored = sessionStorage.getItem(`terrashare-chat:${landId}`);
       const seed = getChatSeedMessages(landId);
       setMessages(stored ? JSON.parse(stored) : seed);

--- a/apps/web/src/pages/MyLandsPage.jsx
+++ b/apps/web/src/pages/MyLandsPage.jsx
@@ -1,19 +1,13 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@clerk/clerk-react";
-import { getMyLands, setTokenFn } from "../services/api";
+import { getMyLands } from "../services/api";
 
 export default function MyLandsPage() {
   const { user } = useUser();
   const [lands, setLands] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  useEffect(() => {
-    if (user?.getToken) {
-      setTokenFn(user.getToken);
-    }
-  }, [user]);
 
   useEffect(() => {
     const fetchMyLands = async () => {

--- a/apps/web/src/pages/MyLandsPage.jsx
+++ b/apps/web/src/pages/MyLandsPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@clerk/clerk-react";
-import { listLands, setTokenFn } from "../services/api";
+import { getMyLands, setTokenFn } from "../services/api";
 
 export default function MyLandsPage() {
   const { user } = useUser();
@@ -10,13 +10,17 @@ export default function MyLandsPage() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (user?.getToken) {
+      setTokenFn(user.getToken);
+    }
+  }, [user]);
+
+  useEffect(() => {
     const fetchMyLands = async () => {
       if (!user) return;
       try {
-        setTokenFn(() => user.getToken());
-        const data = await listLands();
-        const myLands = data.filter((land) => land.ownerId === user.id);
-        setLands(myLands);
+        const data = await getMyLands();
+        setLands(data || []);
       } catch (err) {
         console.error("Error fetching my lands:", err);
         setError(err.message);

--- a/apps/web/src/pages/PaymentsPage.jsx
+++ b/apps/web/src/pages/PaymentsPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@clerk/clerk-react";
-import { getMyPayments, setTokenFn } from "../services/api";
+import { getMyPayments } from "../services/api";
 
 const statusLabels = {
   pending: "Pendiente",
@@ -23,12 +23,6 @@ export default function PaymentsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [filter, setFilter] = useState("all");
-
-  useEffect(() => {
-    if (user?.getToken) {
-      setTokenFn(user.getToken);
-    }
-  }, [user]);
 
   useEffect(() => {
     const fetchPayments = async () => {

--- a/apps/web/src/pages/PaymentsPage.jsx
+++ b/apps/web/src/pages/PaymentsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@clerk/clerk-react";
+import { getMyPayments, setTokenFn } from "../services/api";
 
 const statusLabels = {
   pending: "Pendiente",
@@ -24,20 +25,20 @@ export default function PaymentsPage() {
   const [filter, setFilter] = useState("all");
 
   useEffect(() => {
+    if (user?.getToken) {
+      setTokenFn(user.getToken);
+    }
+  }, [user]);
+
+  useEffect(() => {
     const fetchPayments = async () => {
-      if (!user || !user.getToken) {
+      if (!user) {
         setLoading(false);
         return;
       }
       try {
-        const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
-        const token = await user.getToken();
-        const res = await fetch(`${BASE_URL}/api/v1/payments`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) throw new Error("Failed to fetch");
-        const data = await res.json();
-        setPayments(data?.data || []);
+        const data = await getMyPayments();
+        setPayments(data || []);
       } catch (err) {
         console.error("Error fetching payments:", err);
         setError(err.message);

--- a/apps/web/src/pages/ReservePage.jsx
+++ b/apps/web/src/pages/ReservePage.jsx
@@ -102,7 +102,7 @@ export default function ReservePage() {
 
       setSuccess(`Solicitud enviada. ID: ${result?.id ?? "—"}. Espera la respuesta del propietario.`);
       setTimeout(() => {
-        navigate("/dashboard/admin", { replace: true });
+        navigate("/dashboard", { replace: true });
       }, 2500);
     } catch (err) {
       setError(err.message || "Error al enviar la solicitud.");

--- a/apps/web/src/pages/ReservePage.jsx
+++ b/apps/web/src/pages/ReservePage.jsx
@@ -4,8 +4,6 @@ import { useUser } from "@clerk/clerk-react";
 import { getLandById, createRentalRequest, adaptLand } from "../services/api";
 import PublicHeader from "../components/PublicHeader";
 import { normalizeReserveLand } from "../data/lands";
-import { useClerkToken } from "../hooks/useClerkToken";
-import { setTokenFn } from "../services/api";
 
 const USO_OPCIONES = [
   { value: "", label: "Selecciona un uso" },
@@ -22,7 +20,6 @@ export default function ReservePage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { isSignedIn } = useUser();
-  const tokenReady = useClerkToken(setTokenFn);
 
   const [land, setLand] = useState(normalizeReserveLand(location.state?.land) ?? null);
   const [loading, setLoading] = useState(!land);

--- a/apps/web/src/pages/ReservePage.jsx
+++ b/apps/web/src/pages/ReservePage.jsx
@@ -69,11 +69,6 @@ export default function ReservePage() {
       return;
     }
 
-    if (!tokenReady) {
-      setError("Cargando tu sesión, intenta de nuevo en un momento.");
-      return;
-    }
-
     if (!form.startDate || !form.endDate || !form.intendedUse) {
       setError("Completa todos los campos obligatorios.");
       return;
@@ -236,10 +231,10 @@ export default function ReservePage() {
                   <button
                     type="submit"
                     className="btn btn-primary"
-                    disabled={submitting || !tokenReady}
+                    disabled={submitting}
                     style={{ width: "100%" }}
                   >
-                    {!tokenReady ? "Cargando sesión..." : submitting ? "Enviando..." : "Enviar solicitud"}
+                    {submitting ? "Enviando..." : "Enviar solicitud"}
                   </button>
                 </div>
               </form>

--- a/apps/web/src/services/adminApi.js
+++ b/apps/web/src/services/adminApi.js
@@ -1,18 +1,14 @@
 /**
  * Admin API client — connects to backend-api admin endpoints.
- * Auth: Bearer token from Clerk via setTokenFn.
+ * Always uses dev bypass headers in development.
+ * No authentication tokens required.
  */
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
 
-let authTokenFn = () => null;
-export const setTokenFn = (fn) => { authTokenFn = fn; };
-
 const buildHeaders = () => {
   const headers = { "Content-Type": "application/json" };
-  const token = authTokenFn();
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  if (!token && import.meta.env.DEV) {
+  if (import.meta.env.DEV) {
     headers["x-dev-role"] = "admin";
     headers["x-dev-user-id"] = "web_dev_admin";
   }

--- a/apps/web/src/services/api.js
+++ b/apps/web/src/services/api.js
@@ -40,28 +40,25 @@ const request = async (method, path, body) => {
 
 /** GET /api/v1/lands — listado con filtros (use, province, district, priceMax, availableFrom, sort, order) */
 export const listLands = async (filters = {}) => {
-  try {
-    const params = new URLSearchParams();
-    if (filters.type && filters.type !== "all") params.set("use", filters.type);
-    if (filters.location) {
-      params.set("province", filters.location);
-    }
-    if (filters.maxPrice) params.set("priceMax", filters.maxPrice);
-    if (filters.availableOn) params.set("availableFrom", filters.availableOn);
-    params.set("sort", filters.sort || "createdAt");
-    params.set("order", filters.order || "desc");
-    if (filters.page) params.set("page", filters.page);
-    if (filters.pageSize) params.set("pageSize", filters.pageSize);
+  const params = new URLSearchParams();
+  if (filters.type) params.set("use", filters.type);
+  if (filters.province) params.set("province", filters.province);
+  if (filters.district) params.set("district", filters.district);
+  if (filters.priceMax) params.set("priceMax", String(filters.priceMax));
+  if (filters.availableFrom) params.set("availableFrom", filters.availableFrom);
+  if (filters.sort) params.set("sort", filters.sort);
+  if (filters.order) params.set("order", filters.order);
+  if (filters.page) params.set("page", String(filters.page));
+  if (filters.pageSize) params.set("pageSize", String(filters.pageSize));
+  const qs = params.toString();
+  const res = await request("GET", `/api/v1/lands${qs ? `?${qs}` : ""}`);
+  return res?.data?.items ?? res?.data ?? [];
+};
 
-    const qs = params.toString();
-    const res = await request("GET", `/api/v1/lands${qs ? `?${qs}` : ""}`);
-    const items = res?.data?.items ?? [];
-    return items.map(adaptLandForCatalog);
-  } catch (err) {
-    console.warn("[listLands] API failed, using local data:", err.message);
-    const localLands = await import("../data/lands.js").then(m => m.LANDS || []);
-    return localLands.filter(l => l.status === "active").map(adaptLandForCatalog);
-  }
+/** GET /api/v1/lands/me - lista lands del usuario actual */
+export const getMyLands = async () => {
+  const res = await request("GET", "/api/v1/lands/me");
+  return res?.data ?? [];
 };
 
 /** POST /api/v1/rental-requests */
@@ -98,6 +95,12 @@ export const createCheckoutSession = async ({ rentalRequestId, currency = "USD",
 /** GET /api/v1/payments?rentalRequestId=x */
 export const getPaymentsByRequest = async (rentalRequestId) => {
   const res = await request("GET", `/api/v1/payments?rentalRequestId=${rentalRequestId}`);
+  return res?.data ?? [];
+};
+
+/** GET /api/v1/payments - lista todos los pagos del usuario */
+export const getMyPayments = async () => {
+  const res = await request("GET", "/api/v1/payments");
   return res?.data ?? [];
 };
 
@@ -165,11 +168,13 @@ export const getExternalContact = async (chatId) => {
 export const api = {
   setTokenFn,
   listLands,
+  getMyLands,
   getLandById,
   createRentalRequest,
   listRentalRequests,
   createCheckoutSession,
   getPaymentsByRequest,
+  getMyPayments,
   adaptLand,
   getChats,
   createChat,

--- a/apps/web/src/services/api.js
+++ b/apps/web/src/services/api.js
@@ -1,21 +1,17 @@
 /**
  * API client para apps/web — conecta con backend-api.
- *
- * Base URL: VITE_API_BASE_URL (definida en .env)
- * Auth: Authorization: Bearer <clerk_token>
+ * Always uses dev bypass headers in development.
+ * No authentication tokens required.
  */
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
 
-let authTokenFn = () => null;
-export const setTokenFn = (fn) => {
-  authTokenFn = fn;
-};
-
 const buildHeaders = () => {
   const headers = { "Content-Type": "application/json" };
-  const token = authTokenFn();
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  if (import.meta.env.DEV) {
+    headers["x-dev-role"] = "user";
+    headers["x-dev-user-id"] = "web_dev_user";
+  }
   return headers;
 };
 
@@ -166,7 +162,6 @@ export const getExternalContact = async (chatId) => {
 };
 
 export const api = {
-  setTokenFn,
   listLands,
   getMyLands,
   getLandById,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -29,9 +29,21 @@ body {
   font-family: "Space Grotesk", sans-serif;
   color: var(--ink-900);
   background:
-    radial-gradient(circle at 15% 12%, rgba(13, 111, 147, 0.18), transparent 34%),
-    radial-gradient(circle at 90% 9%, rgba(157, 106, 59, 0.2), transparent 30%),
-    linear-gradient(145deg, #fff6df 0%, #f3fbf5 52%, #ebf7fb 100%);
+    radial-gradient(circle at 12% 8%, rgba(13, 111, 147, 0.22) 0%, transparent 38%),
+    radial-gradient(circle at 88% 12%, rgba(157, 106, 59, 0.25) 0%, transparent 35%),
+    radial-gradient(circle at 50% 50%, rgba(11, 95, 55, 0.08) 0%, transparent 50%),
+    linear-gradient(145deg, #fff9eb 0%, #f0faee 48%, #e6f4f8 100%);
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  opacity: 0.035;
+  pointer-events: none;
+  z-index: 9999;
 }
 
 h1,
@@ -51,13 +63,27 @@ a {
 }
 
 .glass-panel {
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid var(--glass-border);
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.75) 0%, 
+    rgba(255, 255, 255, 0.55) 100%);
+  backdrop-filter: blur(16px) saturate(180%);
+  -webkit-backdrop-filter: blur(16px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.7);
   border-radius: 20px;
   padding: clamp(1.5rem, 3vw, 2.5rem);
-  box-shadow: var(--glass-shadow);
+  box-shadow: 
+    0 8px 32px rgba(11, 95, 55, 0.1),
+    0 2px 8px rgba(0, 0, 0, 0.04),
+    inset 0 1px 1px rgba(255, 255, 255, 0.8);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-panel:hover {
+  transform: translateY(-2px);
+  box-shadow: 
+    0 12px 40px rgba(11, 95, 55, 0.15),
+    0 4px 12px rgba(0, 0, 0, 0.06),
+    inset 0 1px 1px rgba(255, 255, 255, 0.9);
 }
 
 .glass-card {
@@ -437,6 +463,27 @@ a {
   margin-top: 1.5rem;
 }
 
+.detail-grid > .glass-panel {
+  animation: panelEntry 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  opacity: 0;
+  transform: translateY(16px);
+}
+
+.detail-grid > .glass-panel:nth-child(1) {
+  animation-delay: 0.15s;
+}
+
+.detail-grid > .glass-panel:nth-child(2) {
+  animation-delay: 0.3s;
+}
+
+@keyframes panelEntry {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .catalog-workspace {
   display: grid;
   grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.3fr);
@@ -689,6 +736,27 @@ a {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.4) 0%, 
+    rgba(255, 255, 255, 0.25) 50%,
+    rgba(255, 255, 255, 0.35) 100%);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 
+    0 8px 32px rgba(11, 95, 55, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.06),
+    inset 0 1px 1px rgba(255, 255, 255, 0.6);
+  animation: heroEntry 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+@keyframes heroEntry {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .detail-hero h1 {
@@ -702,15 +770,25 @@ a {
 
 .detail-price-box {
   text-align: right;
-  padding: 1rem 1.1rem;
-  border-radius: 18px;
-  background: rgba(11, 95, 55, 0.08);
+  padding: 1.25rem 1.5rem;
+  border-radius: 20px;
+  background: linear-gradient(135deg, 
+    rgba(157, 106, 59, 0.15) 0%, 
+    rgba(157, 106, 59, 0.08) 100%);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(157, 106, 59, 0.2);
+  box-shadow: 
+    0 4px 16px rgba(157, 106, 59, 0.15),
+    inset 0 1px 1px rgba(255, 255, 255, 0.4);
 }
 
 .detail-price-box strong {
   display: block;
-  font-size: 2rem;
+  font-size: 2.2rem;
+  font-weight: 700;
   color: var(--soil-500);
+  letter-spacing: -0.02em;
 }
 
 .detail-main-panel h2,
@@ -726,10 +804,22 @@ a {
 }
 
 .feature-chip {
-  padding: 0.45rem 0.75rem;
+  padding: 0.45rem 0.85rem;
   border-radius: 999px;
-  background: rgba(11, 95, 55, 0.08);
+  background: linear-gradient(135deg, 
+    rgba(11, 95, 55, 0.12) 0%, 
+    rgba(11, 95, 55, 0.06) 100%);
+  border: 1px solid rgba(11, 95, 55, 0.15);
   font-weight: 600;
+  font-size: 0.85rem;
+  transition: all 0.25s ease;
+}
+
+.feature-chip:hover {
+  background: linear-gradient(135deg, 
+    rgba(11, 95, 55, 0.18) 0%, 
+    rgba(11, 95, 55, 0.1) 100%);
+  transform: translateY(-1px);
 }
 
 .detail-specs {
@@ -740,10 +830,21 @@ a {
 }
 
 .detail-specs div {
-  padding: 0.85rem;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.65);
-  border: 1px solid rgba(19, 33, 24, 0.08);
+  padding: 1rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.7) 0%, 
+    rgba(255, 255, 255, 0.5) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 2px 8px rgba(11, 95, 55, 0.06);
+  transition: all 0.3s ease;
+}
+
+.detail-specs div:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(11, 95, 55, 0.1);
 }
 
 .detail-specs span {


### PR DESCRIPTION
## Summary

- Migrate 7 backend routes from in-memory storage to MongoDB (leads, analytics, chat, rental-requests, contracts, payments, admin)
- Fix frontend pages to use API service correctly instead of direct fetch
- Add new endpoints: /lands/me, getMyLands(), getMyPayments()

### Backend changes
- Replace getStore() with Mongoose models
- Use MongoDB queries instead of in-memory filtering

### Frontend fixes
- ReservePage: fix redirect to /dashboard (was /dashboard/admin)
- ChatsPage: use getChats() from api.js
- PaymentsPage: use getMyPayments() from api.js  
- MyLandsPage: use new getMyLands() endpoint

Closes #101