### PR TITLE
fix: dejar el proyecto 'listo' — typecheck en verde y build global funcional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ apps/**/.vite/
 # Temporary PR body drafts
 pr_body*.txt
 pr_body*.md
+
+# Local tooling config (MCP / OpenCode)
+opencode.json

--- a/apps/backend-api/.env.example
+++ b/apps/backend-api/.env.example
@@ -5,5 +5,13 @@ MONGODB_URI=mongodb://localhost:27017/terrashare
 
 CLERK_JWKS_URL=https://your-clerk-domain.clerk.accounts.dev/.well-known/jwks.json
 CLERK_ISSUER=https://your-clerk-domain.clerk.accounts.dev
+CLERK_SECRET_KEY=sk_test_your_clerk_secret_key
+
+# Set to "true" to bypass Clerk auth in local dev (NEVER enable in production)
+ALLOW_DEV_AUTH_BYPASS=false
+
+# Stripe — get these from the Stripe dashboard
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret
 
 WHATSAPP_CONTACT_ENABLED=true

--- a/apps/backend-api/package.json
+++ b/apps/backend-api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
+    "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "bun test"
   },

--- a/apps/backend-api/src/db/collections.ts
+++ b/apps/backend-api/src/db/collections.ts
@@ -1,4 +1,5 @@
 import { getDatabase } from "../config/database";
+import type { LandRecord } from "../store/types";
 import {
   User, Land, RentalRequest, Contract, Payment,
   Chat, ChatMessage, AuditEvent, Lead
@@ -10,27 +11,29 @@ function getColl(name: string) {
   return db.collection(name);
 }
 
-export async function listLands(filters?: { ownerId?: string; status?: string }) {
+export async function listLands(filters?: { ownerId?: string; status?: string }): Promise<LandRecord[]> {
   const coll = getColl("lands");
   const query: Record<string, unknown> = {};
   if (filters?.ownerId) query.ownerId = filters.ownerId;
   if (filters?.status) query.status = filters.status;
-  return coll.find(query).toArray();
+  const docs = await coll.find(query).toArray();
+  return docs as unknown as LandRecord[];
 }
 
-export async function getLandById(id: string) {
+export async function getLandById(id: string): Promise<LandRecord | null> {
   const coll = getColl("lands");
-  return coll.findOne({ id });
+  const doc = await coll.findOne({ id });
+  return doc as unknown as LandRecord | null;
 }
 
-export async function createLand(data: Record<string, unknown>) {
+export async function createLand(data: LandRecord) {
   const coll = getColl("lands");
   const doc = { ...data, createdAt: new Date(), updatedAt: new Date() };
   await coll.insertOne(doc);
   return doc;
 }
 
-export async function updateLand(id: string, data: Record<string, unknown>) {
+export async function updateLand(id: string, data: Partial<LandRecord>) {
   const coll = getColl("lands");
   const result = await coll.findOneAndUpdate(
     { id },

--- a/apps/backend-api/src/db/seed.ts
+++ b/apps/backend-api/src/db/seed.ts
@@ -29,7 +29,7 @@ const LAND_TITLES = [
   "Finca Productiva", "Quinta", "Solar", "Hacienda Ganadera", "Finca de Cultivos"
 ];
 
-function randomItem<T>(arr: T[]): T {
+function randomItem<T>(arr: readonly T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
@@ -84,7 +84,7 @@ function generateLands(count: number, userIds: string[]) {
     const district = randomItem(province.districts);
     const titlePrefix = randomItem(LAND_TITLES);
     const usesCount = randomBetween(1, 3);
-    const allowedUses = [];
+    const allowedUses: string[] = [];
     for (let j = 0; j < usesCount; j++) {
       const use = randomItem(LAND_USES);
       if (!allowedUses.includes(use)) allowedUses.push(use);

--- a/apps/backend-api/src/lib/api-response.ts
+++ b/apps/backend-api/src/lib/api-response.ts
@@ -12,6 +12,7 @@ type ErrorCode =
   | "NOT_FOUND"
   | "CONFLICT"
   | "BUSINESS_RULE_VIOLATION"
+  | "INVALID_TRANSITION"
   | "INTERNAL_ERROR";
 
 type SuccessStatus = 200 | 201 | 202;

--- a/apps/backend-api/src/store/in-memory-db.ts
+++ b/apps/backend-api/src/store/in-memory-db.ts
@@ -22,6 +22,7 @@ const store: InMemoryStore = {
   chatMessages: new Map(),
   auditEvents: new Map(),
   leads: new Map(),
+  notifications: new Map(),
 };
 
 const now = new Date().toISOString();

--- a/apps/backend-api/src/store/types.ts
+++ b/apps/backend-api/src/store/types.ts
@@ -149,9 +149,22 @@ export interface AuditEventRecord {
     | "rejected"
     | "cancelled"
     | "paid"
+    | "signed"
+    | "completed"
     | "status_changed";
   entityId: string;
   metadata?: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface NotificationRecord {
+  id: string;
+  userId: string;
+  type: string;
+  title: string;
+  body?: string;
+  read: boolean;
+  readAt?: string;
   createdAt: string;
 }
 
@@ -174,6 +187,7 @@ export interface InMemoryStore {
   chatMessages: Map<string, ChatMessageRecord[]>;
   auditEvents: Map<string, AuditEventRecord>;
   leads: Map<string, LeadRecord>;
+  notifications: Map<string, NotificationRecord>;
 }
 
 export interface UserRecord extends AuthContextUser {

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -14,5 +14,8 @@
   },
   "include": [
     "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
## Objetivo
Dejar el proyecto **listo para desarrollar**: typecheck en verde y `npm run build` funcional.

## Cambios
### 🔴 Backend: 28 errores de TypeScript → 0
- **`collections.ts`**: tipadas `listLands` / `getLandById` / `createLand` / `updateLand` con `LandRecord` (elimina los desajustes `WithId<Document>` vs `LandRecord` en `lands.ts` sin tocar las rutas).
- **`seed.ts`**: `randomItem` acepta arrays `readonly` (arregla las tuplas `as const`); `allowedUses` tipado como `string[]`.
- **`api-response.ts`**: añadido `INVALID_TRANSITION` al union `ErrorCode`.
- **`store/types.ts`**: añadidas acciones de auditoría `signed`/`completed`, tipo `NotificationRecord` y mapa `notifications` en `InMemoryStore`.
- **`in-memory-db.ts`**: inicializado el mapa `notifications`.

### 🟠 Build global
- **`backend-api`**: añadido script `build` (`tsc --noEmit`) — `npm run build` del root ya no falla.
- **`shared/tsconfig`**: excluidos `*.test.ts` del typecheck (tipos `bun:test`), igual que el backend.

### 🟡 DX / config
- **`.env.example`**: documentadas `ALLOW_DEV_AUTH_BYPASS`, `CLERK_SECRET_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`.
- **`.gitignore`**: ignorado `opencode.json` (config local de MCP).

## Verificación
- ✅ `tsc --noEmit` backend → **0 errores**
- ✅ `tsc --noEmit` shared → **0 errores**
- ✅ `npm run build` (root) → **exit 0** (api typecheck + web vite build)
- ✅ Tests: **18 pass / 10 fail idéntico a `main`** — los 10 fallos son pre-existentes (requieren MongoDB local; rutas de rental-requests/payments/contracts usan Mongoose sin fallback). Este PR no cambia el comportamiento en runtime.

## Pendiente (fuera de este PR)
- Los 10 tests que fallan necesitan **MongoDB local** (o mongodb-memory-server) para pasar.

