### PR TITLE
fix(backend): corregir 2 fallos de tests pre-existentes (27/28)

### DIFF
--- a/apps/backend-api/src/routes/payments.test.ts
+++ b/apps/backend-api/src/routes/payments.test.ts
@@ -33,6 +33,13 @@ describe("payments routes", () => {
   });
 
   it("updates payment status via webhook", async () => {
+    // The request must be payable before a checkout session can be created.
+    await requestJson("/api/v1/rental-requests/rr_seed_01/status", {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_owner_01" },
+      body: { status: "approved" },
+    });
+
     const createResponse = await requestJson("/api/v1/payments/checkout-session", {
       method: "POST",
       headers: {

--- a/apps/backend-api/src/routes/rental-requests.ts
+++ b/apps/backend-api/src/routes/rental-requests.ts
@@ -77,8 +77,8 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
     }
   }
 
-  const isDev = process.env.NODE_ENV !== "production";
-  const initialStatus = isDev ? "approved" : "pending_owner";
+  // A new request always awaits owner approval; it must not be auto-approved.
+  const initialStatus = "pending_owner";
 
   const record = await RentalRequest.create({
     id: `rr_${crypto.randomUUID()}`,


### PR DESCRIPTION
Corrige 2 de los 3 tests que fallaban (no eran de DB):

- **rental-requests**: una solicitud nueva siempre arranca en `pending_owner` — se elimina el auto-aprobar en dev que saltaba la aprobación del dueño.
- **payments.test**: se aprueba `rr_seed_01` antes del checkout del webhook, igual que su test hermano.

Backend typecheck 0, **27/28 tests** (antes 25/28).

### Pendiente (bug real, no quick fix)
El test `auth > usuario bloqueado` sigue fallando porque **bloquear usuarios no funciona en modo dev-bypass**: el route admin solo acepta active/inactive (no 'blocked'), `blocked_user` vive en memoria pero el route lee Mongo, y el dev-bypass hardcodea `status:active`. Requiere unificar el almacenamiento de usuarios (decisión de arquitectura).