### PR TITLE
fix(backend): el bloqueo de usuarios ahora funciona de verdad (28/28)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -7,7 +7,7 @@ export type ContractStatus = "draft" | "active" | "completed" | "cancelled";
 export type PaymentStatus = "pending" | "processing" | "paid" | "failed" | "cancelled";
 export type ChatStatus = "active" | "archived";
 export type LeadSource = "landing" | "app-web" | "admin-dashboard";
-export type UserStatus = "active" | "inactive";
+export type UserStatus = "active" | "blocked";
 export type AppRole = "user" | "admin";
 
 export interface IUser extends Document {
@@ -138,7 +138,7 @@ const UserSchema = new Schema<IUser>({
   clerkUserId: { type: String, required: true, unique: true },
   email: { type: String, required: true },
   role: { type: String, enum: ["user", "admin"], default: "user" },
-  status: { type: String, enum: ["active", "inactive"], default: "active" },
+  status: { type: String, enum: ["active", "blocked"], default: "active" },
   profile: {
     fullName: { type: String, required: true },
     phone: String,

--- a/apps/backend-api/src/db/seed.ts
+++ b/apps/backend-api/src/db/seed.ts
@@ -51,7 +51,7 @@ function randomDateFuture(daysAhead: number): string {
 
 function generateUsers(count: number) {
   const users = [];
-  const statuses = ["active", "inactive"];
+  const statuses = ["active", "blocked"];
   const roles = ["user", "admin"];
   
   for (let i = 0; i < count; i++) {

--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { failure, success } from "../lib/api-response";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
+import { getStore } from "../store/in-memory-db";
 import { User, Land, RentalRequest } from "../db/schemas";
 import type { UserStatus } from "../db/schemas";
 import type { AppEnv } from "../types";
@@ -44,15 +45,19 @@ adminRoutes.get("/admin/users/:userId", requireAuth, requireAdmin, async (c) => 
 adminRoutes.patch("/admin/users/:userId/status", requireAuth, requireAdmin, async (c) => {
   const authUser = c.get("authUser");
   const userId = c.req.param("userId");
+  const store = getStore();
 
-  const user = await User.findOne({ clerkUserId: userId }).lean();
-  if (!user) {
+  // A user may live in Mongo (real Clerk users) and/or in the in-memory store
+  // (dev-bypass and the runtime cache require-auth enforces against).
+  const mongoUser = await User.findOne({ clerkUserId: userId }).lean();
+  const memUser = store.users.get(userId);
+  if (!mongoUser && !memUser) {
     return failure(c, 404, "NOT_FOUND", "User not found");
   }
 
   const body = (await c.req.json().catch(() => null)) as { status?: UserStatus } | null;
   const nextStatus = body?.status;
-  if (!nextStatus || !["active", "inactive"].includes(nextStatus)) {
+  if (!nextStatus || !["active", "blocked"].includes(nextStatus)) {
     return failure(c, 400, "VALIDATION_ERROR", "Invalid status value");
   }
 
@@ -60,17 +65,23 @@ adminRoutes.patch("/admin/users/:userId/status", requireAuth, requireAdmin, asyn
     return failure(c, 400, "BUSINESS_RULE_VIOLATION", "Cannot modify own account status");
   }
 
-  await User.updateOne({ clerkUserId: userId }, { status: nextStatus });
+  if (mongoUser) {
+    await User.updateOne({ clerkUserId: userId }, { status: nextStatus });
+  }
+  // Mirror the change into the in-memory store so require-auth enforces it.
+  if (memUser) {
+    store.users.set(userId, { ...memUser, status: nextStatus });
+  }
 
   createAuditEvent({
     actor: authUser,
     entity: "user",
     action: "status_changed",
     entityId: userId,
-    metadata: { email: user.email },
+    metadata: { email: mongoUser?.email ?? memUser?.email },
   });
 
-  const updated = await User.findOne({ clerkUserId: userId }).lean();
+  const updated = (await User.findOne({ clerkUserId: userId }).lean()) ?? store.users.get(userId);
   return success(c, updated);
 });
 
@@ -149,7 +160,7 @@ adminRoutes.get("/admin/summary", requireAuth, requireAdmin, async (c) => {
     users: {
       total: users.length,
       active: users.filter((u) => u.status === "active").length,
-      blocked: users.filter((u) => u.status === "inactive").length,
+      blocked: users.filter((u) => u.status === "blocked").length,
     },
     lands: {
       total: lands.length,


### PR DESCRIPTION
Cierra el último test que fallaba y arregla un **bug real**: el botón de bloquear usuarios estaba roto de punta a punta.

### Causas
1. El route admin validaba contra `inactive`, pero la UI y `packages/shared` usan `active|blocked`.
2. El route solo tocaba Mongo, pero el dev-bypass y `require-auth` leen el **store en memoria**.

### Fix
- Vocabulario de estado de usuario unificado a `active|blocked` (enum del schema, validación del route, conteo del summary, seed) para coincidir con shared + la UI.
- El route `/admin/users/:id/status` ahora busca y actualiza al usuario en **Mongo y en el store en memoria** (que es lo que `require-auth` aplica).

Backend typecheck 0 · **28/28 tests** (antes 27/28).