### PR TITLE
feat: página de leads admin (rescatada de #113, reconstruida en TS)

### DIFF
--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -4,7 +4,7 @@ import { failure, success } from "../lib/api-response";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
 import { getStore } from "../store/in-memory-db";
-import { User, Land, RentalRequest } from "../db/schemas";
+import { User, Land, RentalRequest, Lead } from "../db/schemas";
 import type { UserStatus } from "../db/schemas";
 import type { AppEnv } from "../types";
 
@@ -83,6 +83,17 @@ adminRoutes.patch("/admin/users/:userId/status", requireAuth, requireAdmin, asyn
 
   const updated = (await User.findOne({ clerkUserId: userId }).lean()) ?? store.users.get(userId);
   return success(c, updated);
+});
+
+adminRoutes.get("/admin/leads", requireAuth, requireAdmin, async (c) => {
+  const source = c.req.query("source");
+  const search = c.req.query("search");
+  const query: Record<string, unknown> = {};
+  if (source) query.source = source;
+  if (search) query.email = { $regex: search, $options: "i" };
+
+  const leads = await Lead.find(query).sort({ createdAt: -1 }).lean();
+  return success(c, { leads, total: leads.length });
 });
 
 adminRoutes.get("/admin/lands", requireAuth, requireAdmin, async (c) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import PaymentCancelPage from "./pages/PaymentCancelPage";
 import PaymentPage from "./pages/PaymentPage";
 import PaymentButton from "./components/PaymentButton";
 import AdminLandsPage from "./pages/AdminLandsPage";
+import AdminLeadsPage from "./pages/AdminLeadsPage";
 import MyLandsPage from "./pages/MyLandsPage";
 import AdminUsersPage from "./pages/AdminUsersPage";
 import ProfilePage from "./pages/ProfilePage";
@@ -156,6 +157,11 @@ function AdminLayout({ children, onSignOut }: LayoutProps) {
       to: "/dashboard/admin/lands",
       label: "Terrenos",
       icon: <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>,
+    },
+    {
+      to: "/dashboard/admin/leads",
+      label: "Leads",
+      icon: <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 4h16v16H4z"/><path d="m22 6-10 7L2 6"/></svg>,
     },
   ];
 
@@ -509,6 +515,7 @@ export default function App() {
       <Route path="/dashboard/admin" element={<AdminRoute><AdminLayout><AdminDashboardPage /></AdminLayout></AdminRoute>} />
       <Route path="/dashboard/admin/users" element={<AdminRoute><AdminLayout><AdminUsersPage /></AdminLayout></AdminRoute>} />
       <Route path="/dashboard/admin/lands" element={<AdminRoute><AdminLayout><AdminLandsPage /></AdminLayout></AdminRoute>} />
+      <Route path="/dashboard/admin/leads" element={<AdminRoute><AdminLayout><AdminLeadsPage /></AdminLayout></AdminRoute>} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/apps/web/src/pages/AdminLeadsPage.tsx
+++ b/apps/web/src/pages/AdminLeadsPage.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { listAdminLeads, type AdminLead } from "../services/adminApi";
+
+const sourceLabels: Record<string, string> = {
+  landing: "Landing Page",
+  "app-web": "App Web",
+  "admin-dashboard": "Admin Dashboard",
+};
+
+export default function AdminLeadsPage() {
+  const [leads, setLeads] = useState<AdminLead[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [filter, setFilter] = useState("all");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError("");
+    const filters: { source?: string; search?: string } = {};
+    if (filter !== "all") filters.source = filter;
+    if (search.trim()) filters.search = search.trim();
+
+    listAdminLeads(filters)
+      .then((res) => {
+        if (active) setLeads(res.data?.leads ?? []);
+      })
+      .catch((e) => {
+        if (active) setError(e instanceof Error ? e.message : "Error al cargar leads");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [filter, search]);
+
+  const formatDate = (dateStr?: string) => {
+    if (!dateStr) return "—";
+    try {
+      return new Date(dateStr).toLocaleDateString("es-PA", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return dateStr;
+    }
+  };
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Leads</h1>
+        <p>Correos captados desde la landing y la plataforma</p>
+      </div>
+
+      <div className="admin-toolbar" style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", marginTop: "1rem" }}>
+        <input
+          type="search"
+          placeholder="Buscar por email..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="admin-input"
+        />
+        <select value={filter} onChange={(e) => setFilter(e.target.value)} className="admin-input">
+          <option value="all">Todas las fuentes</option>
+          <option value="landing">Landing Page</option>
+          <option value="app-web">App Web</option>
+          <option value="admin-dashboard">Admin Dashboard</option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="glass-panel" style={{ marginTop: "1rem", background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)" }}>
+          <p style={{ color: "var(--danger)" }}>Error: {error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="glass-panel" style={{ marginTop: "1.5rem", textAlign: "center", padding: "3rem" }}>
+          <p>Cargando leads...</p>
+        </div>
+      ) : leads.length === 0 ? (
+        <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+          <p>No hay leads que coincidan.</p>
+        </div>
+      ) : (
+        <div className="glass-panel" style={{ marginTop: "1.5rem", overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ textAlign: "left", opacity: 0.7 }}>
+                <th style={{ padding: "0.5rem" }}>Email</th>
+                <th style={{ padding: "0.5rem" }}>Fuente</th>
+                <th style={{ padding: "0.5rem" }}>Fecha</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leads.map((lead) => (
+                <tr key={lead.id} style={{ borderTop: "1px solid var(--border, rgba(0,0,0,0.08))" }}>
+                  <td style={{ padding: "0.5rem" }}>{lead.email}</td>
+                  <td style={{ padding: "0.5rem" }}>
+                    <span className="card-badge">{sourceLabels[lead.source] ?? lead.source}</span>
+                  </td>
+                  <td style={{ padding: "0.5rem", whiteSpace: "nowrap", opacity: 0.7 }}>{formatDate(lead.createdAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p style={{ marginTop: "0.75rem", opacity: 0.6, fontSize: "0.85rem" }}>{leads.length} lead{leads.length !== 1 ? "s" : ""}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/services/adminApi.ts
+++ b/apps/web/src/services/adminApi.ts
@@ -93,3 +93,29 @@ export const listAdminRentalRequests = (filters: AdminLandFilters = {}) => {
 
 /** GET /api/v1/admin/summary */
 export const getAdminSummary = () => request("GET", "/api/v1/admin/summary");
+
+// ─── Leads ───────────────────────────────────────────────────────────────────
+
+export interface AdminLead {
+  id: string;
+  email: string;
+  source: string;
+  createdAt?: string;
+}
+
+interface AdminLeadFilters {
+  source?: string;
+  search?: string;
+}
+
+/** GET /api/v1/admin/leads?source=&search= */
+export const listAdminLeads = (filters: AdminLeadFilters = {}) => {
+  const params = new URLSearchParams();
+  if (filters.source) params.set("source", filters.source);
+  if (filters.search) params.set("search", filters.search);
+  const qs = params.toString();
+  return request<{ leads: AdminLead[]; total: number }>(
+    "GET",
+    `/api/v1/admin/leads${qs ? `?${qs}` : ""}`,
+  );
+};


### PR DESCRIPTION
Rescata la pieza valiosa de #113 (página de leads admin) reconstruida sobre el `main` actual en TypeScript.

- **Backend**: nuevo `GET /admin/leads` protegido (filtro por fuente + búsqueda por email), evitando el `leadRoutes` público mal montado.
- **Web**: `listAdminLeads` en adminApi + `AdminLeadsPage.tsx` (tipada, patrón dev-bypass), enrutada en App + nav admin.

typecheck 0 (backend + web) · web compila · 28/28 tests.

Tras esto se cierra #113 (estaba 8 semanas atrás, en `.jsx` pre-migración; el resto no aplica al main actual).