### PR TITLE
fix(payments): auto-crear contrato al confirmar pago (#84 crítico)

### DIFF
--- a/apps/backend-api/src/routes/payments.test.ts
+++ b/apps/backend-api/src/routes/payments.test.ts
@@ -74,4 +74,56 @@ describe("payments routes", () => {
     expect(payload.ok).toBe(true);
     expect(payload.data.status).toBe("paid");
   });
+
+  it("auto-creates a draft contract once payment is confirmed", async () => {
+    // A fresh request on a land without a seeded contract.
+    const createReq = await requestJson("/api/v1/rental-requests", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_99" },
+      body: {
+        landId: "land_seed_02",
+        period: {
+          startDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 300).toISOString(),
+          endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 360).toISOString(),
+        },
+        intendedUse: "ganaderia",
+      },
+    });
+    const requestId = createReq.payload.data.id as string;
+
+    await requestJson(`/api/v1/rental-requests/${requestId}/status`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_owner_02" },
+      body: { status: "approved" },
+    });
+
+    const checkout = await requestJson("/api/v1/payments/checkout-session", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_99" },
+      body: {
+        rentalRequestId: requestId,
+        currency: "USD",
+        successUrl: "http://localhost:5174/payments/success",
+        cancelUrl: "http://localhost:5174/payments/cancel",
+      },
+    });
+    const paymentId = checkout.payload.data.paymentId as string;
+
+    await requestJson("/api/v1/webhooks/stripe", {
+      method: "POST",
+      body: {
+        type: "checkout.session.completed",
+        data: { object: { metadata: { paymentId }, payment_intent: "pi_test_contract" } },
+      },
+    });
+
+    const contracts = await requestJson("/api/v1/contracts", {
+      headers: { "x-dev-user-id": "user_tenant_99" },
+    });
+    const created = (contracts.payload.data as Array<{ rentalRequestId: string; status: string }>).find(
+      (ct) => ct.rentalRequestId === requestId,
+    );
+    expect(created).toBeTruthy();
+    expect(created?.status).toBe("draft");
+  });
 });

--- a/apps/backend-api/src/routes/payments.ts
+++ b/apps/backend-api/src/routes/payments.ts
@@ -5,7 +5,7 @@ import { env } from "../config/env";
 import { failure, success } from "../lib/api-response";
 import { requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { Payment, RentalRequest, Land } from "../db/schemas";
+import { Payment, RentalRequest, Land, Contract } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 let stripeClient: Stripe | null = null;
@@ -444,6 +444,29 @@ paymentRoutes.post("/webhooks/stripe", async (c) => {
       { id: payment.rentalRequestId },
       { status: "paid", updatedAt: new Date() },
     );
+
+    // Auto-create a draft contract for the now-paid rental. Idempotent: a
+    // webhook can be delivered more than once, so skip if one already exists.
+    const existingContract = await Contract.findOne({ rentalRequestId: payment.rentalRequestId }).lean();
+    if (!existingContract) {
+      const request = await RentalRequest.findOne({ id: payment.rentalRequestId }).lean();
+      if (request) {
+        const land = await Land.findOne({ id: request.landId }).lean();
+        const nowIso = new Date().toISOString();
+        await Contract.create({
+          id: `contract_${crypto.randomUUID()}`,
+          rentalRequestId: request.id,
+          ownerId: land?.ownerId ?? "",
+          tenantId: request.tenantId,
+          terms: {
+            summary: `Contrato de alquiler para ${land?.title ?? request.landId}`,
+            startsAt: request.period?.startDate ?? nowIso,
+            endsAt: request.period?.endDate ?? nowIso,
+          },
+          status: "draft",
+        });
+      }
+    }
   }
 
   return success(c, {


### PR DESCRIPTION
Cierra el issue **#84 [CRÍTICO]**. Cuando el webhook de Stripe confirma el pago y la solicitud pasa a `paid`, ahora se crea automáticamente un **contrato `draft`** (dueño tomado del terreno, arrendatario/período de la solicitud).

- **Idempotente**: si ya existe un contrato para la solicitud, no duplica (los webhooks pueden reintentarse).
- Test de flujo completo: crear → aprobar → checkout → webhook → contrato.

Backend typecheck 0 · **29/29 tests**.

Closes #84