### PR TITLE
feat: endpoint de perfil + WhatsApp real (#83 alto)

### DIFF
--- a/apps/backend-api/src/routes/auth.test.ts
+++ b/apps/backend-api/src/routes/auth.test.ts
@@ -8,6 +8,22 @@ describe("Smoke E2E auth y flujo protegido", () => {
   });
 
   describe("auth basico", () => {
+    it("PATCH /auth/profile actualiza el telefono y persiste", async () => {
+      const update = await requestJson("/api/v1/auth/profile", {
+        method: "PATCH",
+        headers: { "x-dev-user-id": "user_profile_01" },
+        body: { phone: "+50761234567" },
+      });
+      expect(update.response.status).toBe(200);
+      expect(update.payload.data.profile.phone).toBe("+50761234567");
+
+      const me = await requestJson("/api/v1/auth/me", {
+        method: "GET",
+        headers: { "x-dev-user-id": "user_profile_01" },
+      });
+      expect(me.payload.data.profile.phone).toBe("+50761234567");
+    });
+
     it("registro/login: /auth/me retorna usuario autenticado", async () => {
       const { response, payload } = await requestJson("/api/v1/auth/me", {
         method: "GET",

--- a/apps/backend-api/src/routes/auth.ts
+++ b/apps/backend-api/src/routes/auth.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 
-import { success } from "../lib/api-response";
+import { failure, success } from "../lib/api-response";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
+import { getStore } from "../store/in-memory-db";
+import { User } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const authRoutes = new Hono<AppEnv>();
@@ -9,6 +11,34 @@ export const authRoutes = new Hono<AppEnv>();
 authRoutes.get("/auth/me", requireAuth, (c) => {
   const authUser = c.get("authUser");
   return success(c, authUser);
+});
+
+authRoutes.patch("/auth/profile", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const body = (await c.req.json().catch(() => null)) as
+    | { fullName?: string; phone?: string }
+    | null;
+
+  if (!body || (body.fullName === undefined && body.phone === undefined)) {
+    return failure(c, 400, "VALIDATION_ERROR", "Provide fullName and/or phone");
+  }
+
+  const store = getStore();
+  const existing = store.users.get(authUser.id) ?? authUser;
+  const nextProfile = {
+    ...existing.profile,
+    ...(body.fullName !== undefined ? { fullName: body.fullName } : {}),
+    ...(body.phone !== undefined ? { phone: body.phone } : {}),
+  };
+
+  // Update the in-memory store (the source require-auth reads from).
+  const updatedUser = { ...existing, profile: nextProfile };
+  store.users.set(authUser.id, updatedUser);
+
+  // Persist to Mongo if the user exists there (no-op for dev-bypass users).
+  await User.updateOne({ clerkUserId: authUser.id }, { profile: nextProfile });
+
+  return success(c, updatedUser);
 });
 
 authRoutes.get("/auth/admin/ping", requireAuth, requireAdmin, (c) => {

--- a/apps/backend-api/src/routes/chat.ts
+++ b/apps/backend-api/src/routes/chat.ts
@@ -4,7 +4,8 @@ import { env } from "../config/env";
 import { failure, success } from "../lib/api-response";
 import { requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { Chat, ChatMessage } from "../db/schemas";
+import { getStore } from "../store/in-memory-db";
+import { Chat, ChatMessage, User } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 function isParticipant(chat: { participants: { userId: string }[] }, userId: string) {
@@ -138,12 +139,23 @@ chatRoutes.get("/chats/:chatId/external-contact", requireAuth, async (c) => {
   }
 
   const ownerParticipant = chat.participants.find((participant) => participant.role === "owner");
+  const ownerId = ownerParticipant?.userId;
+
+  // Resolve the owner's real contact details from the in-memory store (dev /
+  // runtime cache) or Mongo, instead of a hardcoded placeholder.
+  const store = getStore();
+  const ownerInMemory = ownerId ? store.users.get(ownerId) : undefined;
+  const ownerInMongo = ownerId ? await User.findOne({ clerkUserId: ownerId }).lean() : null;
+  const phone = ownerInMemory?.profile?.phone ?? ownerInMongo?.profile?.phone ?? null;
+  const displayName =
+    ownerInMemory?.profile?.fullName ?? ownerInMongo?.profile?.fullName ?? ownerId ?? "Propietario";
 
   return success(c, {
     whatsappEnabled: true,
     contact: {
-      phone: "+50760000000",
-      displayName: ownerParticipant?.userId ?? "Propietario",
+      phone,
+      displayName,
+      available: Boolean(phone),
     },
   });
 });

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from "react";
 import { useClerk, useUser } from "@clerk/clerk-react";
+import { getMe, updateMyProfile } from "../services/api";
 
 export default function ProfilePage() {
   const { user } = useUser();
@@ -7,6 +9,37 @@ export default function ProfilePage() {
   const userName = user?.fullName || user?.firstName || user?.emailAddresses?.[0]?.emailAddress?.split("@")[0] || "Usuario";
   const userEmail = user?.emailAddresses?.[0]?.emailAddress || "No disponible";
   const userImage = user?.imageUrl;
+
+  const [phone, setPhone] = useState("");
+  const [savingPhone, setSavingPhone] = useState(false);
+  const [phoneMsg, setPhoneMsg] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    getMe()
+      .then((me) => {
+        if (active && me?.profile?.phone) setPhone(me.profile.phone);
+      })
+      .catch(() => {
+        /* ignore — phone stays empty */
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleSavePhone = async () => {
+    setSavingPhone(true);
+    setPhoneMsg("");
+    try {
+      await updateMyProfile({ phone: phone.trim() });
+      setPhoneMsg("Teléfono guardado");
+    } catch (err) {
+      setPhoneMsg(err instanceof Error ? err.message : "Error al guardar");
+    } finally {
+      setSavingPhone(false);
+    }
+  };
 
   const handleSignOut = async () => {
     await signOut({ redirectUrl: "/" });
@@ -43,6 +76,27 @@ export default function ProfilePage() {
             Cerrar sesion
           </button>
         </div>
+      </div>
+
+      <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+        <h3 style={{ margin: "0 0 0.5rem" }}>Teléfono de contacto (WhatsApp)</h3>
+        <p style={{ margin: "0 0 1rem", opacity: 0.7, fontSize: "0.9rem" }}>
+          Se mostrará a los interesados que quieran contactarte por tus terrenos.
+        </p>
+        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+          <input
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="+507 6000-0000"
+            className="admin-input"
+            style={{ flex: 1, minWidth: "200px" }}
+          />
+          <button className="btn btn-primary" onClick={handleSavePhone} disabled={savingPhone}>
+            {savingPhone ? "Guardando..." : "Guardar"}
+          </button>
+        </div>
+        {phoneMsg && <p style={{ marginTop: "0.75rem", opacity: 0.8, fontSize: "0.9rem" }}>{phoneMsg}</p>}
       </div>
 
       <div className="glass-panel" style={{ marginTop: "1.5rem" }}>

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -230,6 +230,32 @@ export const getExternalContact = async (chatId: string): Promise<ExternalContac
   return res?.data ?? null;
 };
 
+// ─── Profile ──────────────────────────────────────────────────────────────────
+
+export interface UserProfile {
+  fullName?: string;
+  phone?: string;
+}
+
+interface MeResponse {
+  id: string;
+  email: string;
+  role: string;
+  profile: UserProfile;
+}
+
+/** GET /api/v1/auth/me */
+export const getMe = async (): Promise<MeResponse | null> => {
+  const res = await request<MeResponse>("GET", "/api/v1/auth/me");
+  return res?.data ?? null;
+};
+
+/** PATCH /api/v1/auth/profile — update fullName / phone */
+export const updateMyProfile = async (payload: UserProfile): Promise<MeResponse | null> => {
+  const res = await request<MeResponse>("PATCH", "/api/v1/auth/profile", payload);
+  return res?.data ?? null;
+};
+
 export const api = {
   listLands,
   getMyLands,


### PR DESCRIPTION
Cierra **#83 [ALTO]**.

- **Backend**: `PATCH /auth/profile` actualiza `fullName`/`phone` (en memoria + Mongo).
- **WhatsApp**: el contacto externo ahora usa el **teléfono y nombre reales del dueño** en vez del placeholder hardcodeado `+50760000000`.
- **Web**: `ProfilePage` tiene un campo de teléfono (WhatsApp) conectado al endpoint.
- **Test**: actualización de teléfono persiste entre requests.

(El test 409 de rental-requests que menciona el issue ya se arregló antes.)

backend + web typecheck 0 · web compila · **30/30 tests**.

Closes #83