### PR TITLE
fix(web): botones de auth del header navegan a /login y /register (#107)

### DIFF
--- a/apps/web/src/components/PublicHeader.tsx
+++ b/apps/web/src/components/PublicHeader.tsx
@@ -7,24 +7,20 @@ interface PublicHeaderProps {
 }
 
 export default function PublicHeader({ showDashboardLink }: PublicHeaderProps = {}) {
-  const { openSignIn, openSignUp, signOut } = useClerk();
+  const { signOut } = useClerk();
   const { isSignedIn, user } = useUser();
   const location = useLocation();
   const navigate = useNavigate();
   const userName = getDisplayName(user);
 
+  // Navigate to the full /login and /register pages (which host the Clerk
+  // forms) instead of popping Clerk's modal overlay.
   const handleSignIn = () => {
-    openSignIn({ redirectUrl: "/dashboard" });
+    navigate("/login");
   };
 
   const handleSignUp = () => {
-    if (isSignedIn) {
-      signOut({ redirectUrl: "/" }).then(() => {
-        openSignUp({});
-      });
-    } else {
-      openSignUp({});
-    }
+    navigate("/register");
   };
 
   const handleSignOut = async () => {


### PR DESCRIPTION
Cierra **#107 [BUG]**. Los botones 'Iniciar sesión' / 'Crear cuenta' de `PublicHeader` abrían el **modal de Clerk** (`openSignIn/openSignUp`). Ahora **navegan a `/login` y `/register`** (páginas completas que ya alojan los formularios de Clerk).

web typecheck 0 · build verde.

Closes #107