### PR TITLE
feat(lands): validación de uso + paginación admin + fotos (#85)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -27,6 +27,7 @@ export interface ILand extends Document {
   description?: string;
   area: number;
   allowedUses: LandUse[];
+  photos?: string[];
   location: {
     province: string;
     district: string;
@@ -152,6 +153,7 @@ const LandSchema = new Schema<ILand>({
   description: String,
   area: { type: Number, required: true },
   allowedUses: [{ type: String, enum: ["agricultura", "ganaderia", "forestal", "acuicultura", "mixto", "otro"] }],
+  photos: [String],
   location: {
     province: { type: String, required: true },
     district: { type: String, required: true },

--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -29,7 +29,16 @@ adminRoutes.get("/admin/users", requireAuth, requireAdmin, async (c) => {
     );
   }
 
-  return success(c, { items: users, total: users.length });
+  const page = Math.max(1, Number(c.req.query("page") ?? 1) || 1);
+  const pageSize = Math.min(100, Math.max(1, Number(c.req.query("pageSize") ?? 20) || 20));
+  const total = users.length;
+  const start = (page - 1) * pageSize;
+
+  return success(c, {
+    items: users.slice(start, start + pageSize),
+    total,
+    pagination: { page, pageSize, total, totalPages: Math.max(1, Math.ceil(total / pageSize)) },
+  });
 });
 
 adminRoutes.get("/admin/users/:userId", requireAuth, requireAdmin, async (c) => {
@@ -128,7 +137,16 @@ adminRoutes.get("/admin/lands", requireAuth, requireAdmin, async (c) => {
     createdAt: l.createdAt,
   }));
 
-  return success(c, { items, total: items.length });
+  const page = Math.max(1, Number(c.req.query("page") ?? 1) || 1);
+  const pageSize = Math.min(100, Math.max(1, Number(c.req.query("pageSize") ?? 20) || 20));
+  const total = items.length;
+  const start = (page - 1) * pageSize;
+
+  return success(c, {
+    items: items.slice(start, start + pageSize),
+    total,
+    pagination: { page, pageSize, total, totalPages: Math.max(1, Math.ceil(total / pageSize)) },
+  });
 });
 
 adminRoutes.patch("/admin/lands/:landId/status", requireAuth, requireAdmin, async (c) => {

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -158,6 +158,7 @@ landRoutes.post("/lands", requireAuth, async (c) => {
     description: body.description,
     area: Number(body.area),
     allowedUses: body.allowedUses,
+    photos: body.photos ?? [],
     location: body.location,
     availability: body.availability ?? {},
     priceRule: body.priceRule,

--- a/apps/backend-api/src/routes/rental-requests.test.ts
+++ b/apps/backend-api/src/routes/rental-requests.test.ts
@@ -51,4 +51,23 @@ describe("rental requests routes", () => {
     expect(payload.ok).toBe(true);
     expect(payload.data.status).toBe("approved");
   });
+
+  it("rejects a request whose intended use is not allowed on the land", async () => {
+    // land_seed_02 only allows "ganaderia".
+    const { response, payload } = await requestJson("/api/v1/rental-requests", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_99" },
+      body: {
+        landId: "land_seed_02",
+        period: {
+          startDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 400).toISOString(),
+          endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 430).toISOString(),
+        },
+        intendedUse: "acuicultura",
+      },
+    });
+
+    expect(response.status).toBe(422);
+    expect(payload.ok).toBe(false);
+  });
 });

--- a/apps/backend-api/src/routes/rental-requests.ts
+++ b/apps/backend-api/src/routes/rental-requests.ts
@@ -53,6 +53,16 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
     return failure(c, 422, "BUSINESS_RULE_VIOLATION", "Owner cannot create request for own land");
   }
 
+  const allowedUses = (land.allowedUses ?? []) as string[];
+  if (allowedUses.length > 0 && !allowedUses.includes(body.intendedUse)) {
+    return failure(
+      c,
+      422,
+      "BUSINESS_RULE_VIOLATION",
+      `El uso '${body.intendedUse}' no esta permitido en este terreno`,
+    );
+  }
+
   const periodStart = Date.parse(body.period.startDate);
   const periodEnd = Date.parse(body.period.endDate);
   if (Number.isNaN(periodStart) || Number.isNaN(periodEnd) || periodEnd <= periodStart) {

--- a/apps/backend-api/src/store/types.ts
+++ b/apps/backend-api/src/store/types.ts
@@ -20,6 +20,7 @@ export interface LandRecord {
   description?: string;
   area: number;
   allowedUses: LandUse[];
+  photos?: string[];
   location: {
     province: string;
     district: string;


### PR DESCRIPTION
Cierra **#85 [MEDIO]**. Cumple las 3 condiciones de aceptación:

- **Validación de uso** ✅ — `POST /rental-requests` rechaza (422) si `intendedUse` no está en `allowedUses` del terreno. + test.
- **Paginación admin** ✅ — `GET /admin/users` y `/admin/lands` aceptan `page`/`pageSize` con metadata de paginación.
- **Fotos** ✅ — campo `photos: string[]` en el schema/tipo de land, aceptado en `POST /lands`. (El endpoint de upload a S3/Cloudinary es infra para cuando se provisione el storage.)

Backend typecheck 0 · **31/31 tests**.

Closes #85