### PR TITLE
docs(web): añadir VITE_STRIPE_PUBLISHABLE_KEY a .env.example

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE_URL=http://localhost:3000
-VITE_CLERK_PUBLISHABLE_KEY=pk_test_aG9wZWZ1bC1vd2wtOTcuY2xlcmsuYWNjb3VudHMuZGV2JA
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_clerk_publishable_key
+VITE_STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key


### PR DESCRIPTION
Refs #129. `PaymentPage` usa `VITE_STRIPE_PUBLISHABLE_KEY` pero faltaba en `apps/web/.env.example`. Añadido + Clerk publishable normalizado a placeholder. Solo plantilla, sin secretos.