### PR TITLE
test(e2e): actualizar smoke tests de login/register a la UI actual

### DIFF
--- a/apps/web/tests/e2e/auth-protected.smoke.spec.js
+++ b/apps/web/tests/e2e/auth-protected.smoke.spec.js
@@ -7,9 +7,7 @@ test.describe("Smoke E2E auth y flujo protegido", () => {
     await expect(page.getByRole("heading", { name: /Iniciar sesion/i })).toBeVisible();
     await expect(page.getByText(/Accede a tu cuenta TerraShare/)).toBeVisible();
 
-    await expect(page.getByRole("button", { name: /Continuar con Google/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /Continuar con Microsoft/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /Continuar con email/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Iniciar sesion/i })).toBeVisible();
 
     await expect(page.getByRole("link", { name: /Registrate/ })).toBeVisible();
   });
@@ -20,9 +18,7 @@ test.describe("Smoke E2E auth y flujo protegido", () => {
     await expect(page.getByRole("heading", { name: /Crear cuenta/i })).toBeVisible();
     await expect(page.getByText(/Unete a TerraShare/)).toBeVisible();
 
-    await expect(page.getByRole("button", { name: /Continuar con Google/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /Continuar con Microsoft/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /Continuar con email/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Crear cuenta/i })).toBeVisible();
 
     await expect(page.getByRole("link", { name: /Inicia sesion/ })).toBeVisible();
   });


### PR DESCRIPTION
Al correr los E2E para verificar la config de credenciales, 2 tests fallaban porque las páginas `/login` y `/register` se consolidaron a **un solo botón** ('Iniciar sesion' / 'Crear cuenta') — `openSignIn` de Clerk no permite pre-seleccionar proveedor. Los tests aún esperaban los 3 botones viejos ('Continuar con Google/Microsoft/email').

Actualizados para coincidir con la UI actual. **Verificado: 9/9 E2E pasan** contra la app real.

(No es regresión de las credenciales — los E2E de Clerk/auth funcionan correctamente; los redirects de rutas protegidas pasan.)