### PR TITLE
feat(web): fundación del sistema de diseño editorial (Fase 1) — Refs #134

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -38,6 +38,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;700;800&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <!-- Sistema de diseño editorial (issue #134): Spectral (serif) + Hanken Grotesk (sans) -->
+    <link href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;500&family=Hanken+Grotesk:wght@400;500;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import Login from "./components/Login";
 import Register from "./components/Register";
 import UserDashboardLayout from "./components/UserDashboardLayout";
 import PublicHeader from "./components/PublicHeader";
+import StyleguidePage from "./pages/StyleguidePage";
 import { getAdminSummary, listAdminRentalRequests } from "./services/adminApi";
 import { isAdminUser } from "./components/authDisplay";
 
@@ -499,6 +500,7 @@ export default function App() {
   return (
     <Routes>
       <Route path="/" element={<LandingPage />} />
+      <Route path="/styleguide" element={<StyleguidePage />} />
       <Route path="/catalog" element={<UserDashboardLayout><CatalogPage /></UserDashboardLayout>} />
       <Route path="/lands/:id" element={<LandDetailPage />} />
       <Route path="/reserve/:landId" element={<ProtectedRoute><ReservePage /></ProtectedRoute>} />

--- a/apps/web/src/components/ui/Badge.tsx
+++ b/apps/web/src/components/ui/Badge.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+export type BadgeTone = "green" | "clay" | "beige" | "neutral";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone;
+  dot?: boolean;
+  children?: ReactNode;
+}
+
+export default function Badge({ tone = "green", dot = false, className, children, ...rest }: BadgeProps) {
+  const cls = ["ds-badge", `ds-badge--${tone}`, className ?? ""].filter(Boolean).join(" ");
+
+  return (
+    <span className={cls} {...rest}>
+      {dot ? <span className="ds-badge__dot" aria-hidden="true" /> : null}
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -1,0 +1,57 @@
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes, ReactNode } from "react";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+export type ButtonSize = "sm" | "md" | "lg";
+
+interface ButtonBaseProps {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  block?: boolean;
+  children?: ReactNode;
+}
+
+type ButtonAsButton = ButtonBaseProps &
+  Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> & { href?: undefined };
+
+type ButtonAsAnchor = ButtonBaseProps &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "children"> & { href: string };
+
+export type ButtonProps = ButtonAsButton | ButtonAsAnchor;
+
+function buildClassName(
+  variant: ButtonVariant,
+  size: ButtonSize,
+  block: boolean,
+  extra?: string,
+): string {
+  return [
+    "ds-btn",
+    `ds-btn--${variant}`,
+    size !== "md" ? `ds-btn--${size}` : "",
+    block ? "ds-btn--block" : "",
+    extra ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export default function Button(props: ButtonProps) {
+  const { variant = "primary", size = "md", block = false, className, children, ...rest } = props;
+  const cls = buildClassName(variant, size, block, className);
+
+  if (rest.href !== undefined) {
+    const anchorRest = rest as AnchorHTMLAttributes<HTMLAnchorElement>;
+    return (
+      <a className={cls} {...anchorRest}>
+        {children}
+      </a>
+    );
+  }
+
+  const buttonRest = rest as ButtonHTMLAttributes<HTMLButtonElement>;
+  return (
+    <button className={cls} {...buttonRest}>
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -1,0 +1,24 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  flat?: boolean;
+  interactive?: boolean;
+  children?: ReactNode;
+}
+
+export default function Card({ flat, interactive, className, children, ...rest }: CardProps) {
+  const cls = [
+    "ds-card",
+    flat ? "ds-card--flat" : "",
+    interactive ? "ds-card--interactive" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={cls} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/Field.tsx
+++ b/apps/web/src/components/ui/Field.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+export interface FieldProps {
+  label: string;
+  /** id del control asociado; se usa en el `htmlFor` del label. */
+  htmlFor?: string;
+  hint?: ReactNode;
+  error?: ReactNode;
+  required?: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function Field({
+  label,
+  htmlFor,
+  hint,
+  error,
+  required = false,
+  children,
+  className,
+}: FieldProps) {
+  const cls = ["ds-field", className ?? ""].filter(Boolean).join(" ");
+
+  return (
+    <div className={cls}>
+      <label className="ds-field__label" htmlFor={htmlFor}>
+        {label}
+        {required ? (
+          <span className="ds-field__required" aria-hidden="true">
+            *
+          </span>
+        ) : null}
+      </label>
+      {children}
+      {error ? (
+        <span className="ds-field__error" role="alert">
+          {error}
+        </span>
+      ) : hint ? (
+        <span className="ds-field__hint">{hint}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -1,0 +1,13 @@
+import type { InputHTMLAttributes } from "react";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  invalid?: boolean;
+}
+
+export default function Input({ invalid = false, className, ...rest }: InputProps) {
+  const cls = ["ds-input", invalid ? "ds-input--invalid" : "", className ?? ""]
+    .filter(Boolean)
+    .join(" ");
+
+  return <input className={cls} aria-invalid={invalid || undefined} {...rest} />;
+}

--- a/apps/web/src/components/ui/Navbar.tsx
+++ b/apps/web/src/components/ui/Navbar.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+export type BuscoOfrezcoMode = "busco" | "ofrezco";
+
+export interface UserMenuItem {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  danger?: boolean;
+}
+
+export interface NavbarProps {
+  /** Marca a la izquierda; por defecto un enlace "TerraShare" a "/". */
+  brand?: ReactNode;
+  /** Modo activo del switch Busco / Ofrezco. */
+  mode?: BuscoOfrezcoMode;
+  /** Si se pasa, se muestra el switch Busco / Ofrezco. */
+  onModeChange?: (mode: BuscoOfrezcoMode) => void;
+  /** Nombre mostrado en el menú de usuario. Si falta, no se muestra el menú. */
+  userName?: string;
+  userMenuItems?: UserMenuItem[];
+  /** Acción de cerrar sesión (se añade al final del menú de usuario). */
+  onSignOut?: () => void;
+  className?: string;
+}
+
+const MODES: { value: BuscoOfrezcoMode; label: string }[] = [
+  { value: "busco", label: "Busco" },
+  { value: "ofrezco", label: "Ofrezco" },
+];
+
+export default function Navbar({
+  brand,
+  mode,
+  onModeChange,
+  userName,
+  userMenuItems = [],
+  onSignOut,
+  className,
+}: NavbarProps) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointer = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const cls = ["ds-navbar", className ?? ""].filter(Boolean).join(" ");
+  const initial = userName?.trim().charAt(0).toUpperCase() || "?";
+
+  const handleItemClick = (item: UserMenuItem) => {
+    setOpen(false);
+    item.onClick?.();
+  };
+
+  return (
+    <nav className={cls}>
+      <div className="ds-navbar__brand-slot">
+        {brand ?? (
+          <a className="ds-navbar__brand" href="/">
+            TerraShare
+          </a>
+        )}
+      </div>
+
+      {onModeChange && mode ? (
+        <div className="ds-navbar__center">
+          <div className="ds-segment" role="tablist" aria-label="Modo Busco u Ofrezco">
+            {MODES.map((m) => (
+              <button
+                key={m.value}
+                type="button"
+                role="tab"
+                aria-selected={mode === m.value}
+                className={["ds-segment__btn", mode === m.value ? "is-active" : ""]
+                  .filter(Boolean)
+                  .join(" ")}
+                onClick={() => onModeChange(m.value)}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="ds-navbar__actions">
+        {userName ? (
+          <div className="ds-usermenu" ref={menuRef}>
+            <button
+              type="button"
+              className="ds-usermenu__trigger"
+              aria-haspopup="menu"
+              aria-expanded={open}
+              onClick={() => setOpen((v) => !v)}
+            >
+              <span className="ds-usermenu__avatar" aria-hidden="true">
+                {initial}
+              </span>
+              {userName}
+            </button>
+            {open ? (
+              <div className="ds-usermenu__panel" role="menu">
+                {userMenuItems.map((item) =>
+                  item.href ? (
+                    <a
+                      key={item.label}
+                      role="menuitem"
+                      href={item.href}
+                      className={[
+                        "ds-usermenu__item",
+                        item.danger ? "ds-usermenu__item--danger" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      onClick={() => setOpen(false)}
+                    >
+                      {item.label}
+                    </a>
+                  ) : (
+                    <button
+                      key={item.label}
+                      type="button"
+                      role="menuitem"
+                      className={[
+                        "ds-usermenu__item",
+                        item.danger ? "ds-usermenu__item--danger" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      onClick={() => handleItemClick(item)}
+                    >
+                      {item.label}
+                    </button>
+                  ),
+                )}
+                {onSignOut ? (
+                  <>
+                    {userMenuItems.length > 0 ? <div className="ds-usermenu__sep" /> : null}
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="ds-usermenu__item ds-usermenu__item--danger"
+                      onClick={() => {
+                        setOpen(false);
+                        onSignOut();
+                      }}
+                    >
+                      Cerrar sesión
+                    </button>
+                  </>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/ui/Sidebar.tsx
+++ b/apps/web/src/components/ui/Sidebar.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+
+export interface SidebarLink {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  icon?: ReactNode;
+  active?: boolean;
+  separator?: false;
+}
+
+/** Un ítem del sidebar: un enlace/acción o un separador. */
+export type SidebarItem = SidebarLink | { separator: true };
+
+export interface SidebarProps {
+  /** Marca superior; por defecto un enlace "TerraShare · Admin". */
+  brand?: ReactNode;
+  items: SidebarItem[];
+  footer?: ReactNode;
+  className?: string;
+}
+
+export default function Sidebar({ brand, items, footer, className }: SidebarProps) {
+  const cls = ["ds-sidebar", className ?? ""].filter(Boolean).join(" ");
+
+  return (
+    <aside className={cls}>
+      {brand ?? (
+        <a className="ds-sidebar__brand" href="/dashboard/admin">
+          TerraShare · Admin
+        </a>
+      )}
+
+      <nav>
+        {items.map((item, i) => {
+          if (item.separator) {
+            return <div key={`sep-${i}`} className="ds-sidebar__sep" />;
+          }
+
+          const itemCls = ["ds-sidebar__item", item.active ? "is-active" : ""]
+            .filter(Boolean)
+            .join(" ");
+          const content = (
+            <>
+              {item.icon ? (
+                <span className="ds-sidebar__icon" aria-hidden="true">
+                  {item.icon}
+                </span>
+              ) : null}
+              {item.label}
+            </>
+          );
+
+          return item.href ? (
+            <a
+              key={item.label}
+              href={item.href}
+              className={itemCls}
+              aria-current={item.active ? "page" : undefined}
+            >
+              {content}
+            </a>
+          ) : (
+            <button key={item.label} type="button" className={itemCls} onClick={item.onClick}>
+              {content}
+            </button>
+          );
+        })}
+      </nav>
+
+      {footer ? (
+        <>
+          <div className="ds-sidebar__spacer" />
+          {footer}
+        </>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/web/src/components/ui/Stepper.tsx
+++ b/apps/web/src/components/ui/Stepper.tsx
@@ -1,0 +1,42 @@
+export interface StepperProps {
+  steps: string[];
+  /** Índice (0-based) del paso activo. */
+  current: number;
+  className?: string;
+  /** Muestra el número de cada paso dentro de un círculo. */
+  showIndex?: boolean;
+}
+
+export default function Stepper({ steps, current, className, showIndex = true }: StepperProps) {
+  const total = steps.length;
+  const clamped = Math.max(0, Math.min(current, total - 1));
+  const fill = total > 1 ? (clamped / (total - 1)) * 100 : 100;
+  const cls = ["ds-stepper", className ?? ""].filter(Boolean).join(" ");
+
+  return (
+    <div
+      className={cls}
+      role="group"
+      aria-label={`Paso ${clamped + 1} de ${total}: ${steps[clamped] ?? ""}`}
+    >
+      <div className="ds-stepper__track">
+        <div className="ds-stepper__fill" style={{ width: `${fill}%` }} />
+      </div>
+      <div className="ds-stepper__labels">
+        {steps.map((step, i) => {
+          const state = i < clamped ? "is-done" : i === clamped ? "is-active" : "";
+          return (
+            <span
+              key={step}
+              className={["ds-stepper__label", state].filter(Boolean).join(" ")}
+              aria-current={i === clamped ? "step" : undefined}
+            >
+              {showIndex ? <span className="ds-stepper__index">{i + 1}</span> : null}
+              {step}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,0 +1,23 @@
+export { default as Button } from "./Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button";
+
+export { default as Card } from "./Card";
+export type { CardProps } from "./Card";
+
+export { default as Badge } from "./Badge";
+export type { BadgeProps, BadgeTone } from "./Badge";
+
+export { default as Field } from "./Field";
+export type { FieldProps } from "./Field";
+
+export { default as Input } from "./Input";
+export type { InputProps } from "./Input";
+
+export { default as Navbar } from "./Navbar";
+export type { NavbarProps, BuscoOfrezcoMode, UserMenuItem } from "./Navbar";
+
+export { default as Sidebar } from "./Sidebar";
+export type { SidebarProps, SidebarItem } from "./Sidebar";
+
+export { default as Stepper } from "./Stepper";
+export type { StepperProps } from "./Stepper";

--- a/apps/web/src/components/ui/ui.css
+++ b/apps/web/src/components/ui/ui.css
@@ -1,0 +1,506 @@
+/* TerraShare — primitivos del sistema de diseño editorial (issue #134).
+   Clases con prefijo `ds-` para no colisionar con el CSS legacy (styles.css). */
+
+/* ---------- Button ---------- */
+.ds-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-family: var(--ts-font-sans);
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1;
+  border-radius: var(--ts-radius);
+  border: 1px solid transparent;
+  padding: 0.7rem 1.15rem;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease, color 0.15s ease;
+}
+
+.ds-btn:active {
+  transform: scale(0.98);
+}
+
+.ds-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}
+
+.ds-btn:disabled,
+.ds-btn[aria-disabled="true"] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.ds-btn--primary {
+  background: var(--ts-green);
+  color: var(--ts-on-green);
+  border-color: var(--ts-green);
+}
+
+.ds-btn--primary:hover:not(:disabled) {
+  background: var(--ts-green-ink);
+  border-color: var(--ts-green-ink);
+}
+
+.ds-btn--secondary {
+  background: var(--ts-surface);
+  color: var(--ts-text);
+  border-color: var(--ts-border);
+}
+
+.ds-btn--secondary:hover:not(:disabled) {
+  background: var(--ts-paper-tint);
+  border-color: var(--ts-beige-2);
+}
+
+.ds-btn--ghost {
+  background: transparent;
+  color: var(--ts-text);
+  border-color: transparent;
+}
+
+.ds-btn--ghost:hover:not(:disabled) {
+  background: var(--ts-tint-green);
+}
+
+.ds-btn--danger {
+  background: var(--ts-clay);
+  color: var(--ts-on-green);
+  border-color: var(--ts-clay);
+}
+
+.ds-btn--danger:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.ds-btn--sm {
+  padding: 0.45rem 0.8rem;
+  font-size: 0.85rem;
+}
+
+.ds-btn--lg {
+  padding: 0.9rem 1.6rem;
+  font-size: 1.05rem;
+}
+
+.ds-btn--block {
+  width: 100%;
+}
+
+/* ---------- Card ---------- */
+.ds-card {
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--ts-shadow-sm);
+}
+
+.ds-card--flat {
+  box-shadow: none;
+}
+
+.ds-card--interactive {
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.ds-card--interactive:hover {
+  transform: translateY(-3px);
+  border-color: var(--ts-sage-3);
+  box-shadow: var(--ts-shadow);
+}
+
+/* ---------- Badge ---------- */
+.ds-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.28rem 0.7rem;
+  border-radius: var(--ts-radius-pill);
+  font-family: var(--ts-font-sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.2;
+  border: 1px solid transparent;
+}
+
+.ds-badge--green {
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+}
+
+.ds-badge--clay {
+  background: var(--ts-clay-tint);
+  color: var(--ts-clay);
+}
+
+.ds-badge--beige {
+  background: var(--ts-beige);
+  color: var(--ts-green-soft);
+}
+
+.ds-badge--neutral {
+  background: var(--ts-paper-tint);
+  color: var(--ts-text-secondary);
+  border-color: var(--ts-border);
+}
+
+.ds-badge__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* ---------- Field / Input ---------- */
+.ds-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.ds-field__label {
+  font-family: var(--ts-font-sans);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ts-text);
+}
+
+.ds-field__required {
+  color: var(--ts-clay);
+  margin-left: 0.15rem;
+}
+
+.ds-field__hint {
+  font-size: 0.8rem;
+  color: var(--ts-text-muted);
+}
+
+.ds-field__error {
+  font-size: 0.8rem;
+  color: var(--ts-clay);
+  font-weight: 500;
+}
+
+.ds-input {
+  width: 100%;
+  font-family: var(--ts-font-sans);
+  font-size: 0.95rem;
+  color: var(--ts-text);
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  padding: 0.7rem 0.9rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ds-input::placeholder {
+  color: var(--ts-text-muted);
+}
+
+.ds-input:focus {
+  outline: none;
+  border-color: var(--ts-green);
+  box-shadow: var(--ts-ring);
+}
+
+.ds-input--invalid {
+  border-color: var(--ts-clay);
+}
+
+.ds-input--invalid:focus {
+  box-shadow: 0 0 0 3px rgba(184, 98, 63, 0.24);
+}
+
+/* ---------- Navbar ---------- */
+.ds-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-lg);
+  padding: 0.65rem 1.1rem;
+}
+
+.ds-navbar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--ts-font-serif);
+  font-size: 1.3rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--ts-green);
+  text-decoration: none;
+}
+
+.ds-navbar__center {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ds-navbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* switch Busco / Ofrezco (segmented control) */
+.ds-segment {
+  display: inline-flex;
+  background: var(--ts-tint-green);
+  border-radius: var(--ts-radius-pill);
+  padding: 3px;
+  gap: 2px;
+}
+
+.ds-segment__btn {
+  border: 0;
+  background: transparent;
+  border-radius: var(--ts-radius-pill);
+  padding: 0.4rem 1rem;
+  font-family: var(--ts-font-sans);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ts-text-secondary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ds-segment__btn:hover:not(.is-active) {
+  color: var(--ts-text);
+}
+
+.ds-segment__btn.is-active {
+  background: var(--ts-green);
+  color: var(--ts-on-green);
+}
+
+.ds-segment__btn:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}
+
+/* menú de usuario */
+.ds-usermenu {
+  position: relative;
+}
+
+.ds-usermenu__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--ts-paper-tint);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-pill);
+  padding: 0.35rem 0.85rem 0.35rem 0.4rem;
+  font-family: var(--ts-font-sans);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ts-text);
+  cursor: pointer;
+}
+
+.ds-usermenu__trigger:hover {
+  background: var(--ts-tint-green);
+}
+
+.ds-usermenu__trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}
+
+.ds-usermenu__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 50%;
+  background: var(--ts-green);
+  color: var(--ts-on-green);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.ds-usermenu__panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  min-width: 200px;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  box-shadow: var(--ts-shadow);
+  padding: 0.4rem;
+  z-index: 50;
+}
+
+.ds-usermenu__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: var(--ts-radius-sm);
+  padding: 0.55rem 0.7rem;
+  font-family: var(--ts-font-sans);
+  font-size: 0.9rem;
+  color: var(--ts-text);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.ds-usermenu__item:hover {
+  background: var(--ts-tint-green);
+}
+
+.ds-usermenu__item--danger {
+  color: var(--ts-clay);
+}
+
+.ds-usermenu__sep {
+  height: 1px;
+  background: var(--ts-border);
+  margin: 0.35rem 0.2rem;
+}
+
+/* ---------- Sidebar (admin) ---------- */
+.ds-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: var(--ts-green-ink);
+  color: var(--ts-on-green);
+  border-radius: var(--ts-radius-lg);
+  padding: 1.1rem 0.85rem;
+  min-width: 232px;
+}
+
+.ds-sidebar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--ts-font-serif);
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: var(--ts-on-green);
+  text-decoration: none;
+  padding: 0.4rem 0.7rem 1rem;
+}
+
+.ds-sidebar__item {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: var(--ts-radius);
+  color: var(--ts-sage-3);
+  font-family: var(--ts-font-sans);
+  font-size: 0.92rem;
+  font-weight: 500;
+  text-decoration: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ds-sidebar__item:hover {
+  background: rgba(244, 239, 228, 0.08);
+  color: var(--ts-on-green);
+}
+
+.ds-sidebar__item.is-active {
+  background: var(--ts-surface);
+  color: var(--ts-green-ink);
+  font-weight: 600;
+}
+
+.ds-sidebar__sep {
+  height: 1px;
+  background: rgba(244, 239, 228, 0.12);
+  margin: 0.5rem 0.4rem;
+}
+
+.ds-sidebar__spacer {
+  flex: 1;
+}
+
+/* ---------- Stepper ---------- */
+.ds-stepper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ds-stepper__track {
+  position: relative;
+  height: 4px;
+  background: var(--ts-tint-green-3);
+  border-radius: var(--ts-radius-pill);
+  overflow: hidden;
+}
+
+.ds-stepper__fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--ts-green);
+  border-radius: var(--ts-radius-pill);
+  transition: width 0.3s ease;
+}
+
+.ds-stepper__labels {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.ds-stepper__label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--ts-font-sans);
+  font-size: 0.82rem;
+  color: var(--ts-text-muted);
+}
+
+.ds-stepper__label.is-active {
+  color: var(--ts-green);
+  font-weight: 600;
+}
+
+.ds-stepper__label.is-done {
+  color: var(--ts-text-secondary);
+}
+
+.ds-stepper__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  background: var(--ts-tint-green-3);
+  color: var(--ts-text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.ds-stepper__label.is-active .ds-stepper__index,
+.ds-stepper__label.is-done .ds-stepper__index {
+  background: var(--ts-green);
+  color: var(--ts-on-green);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,9 @@ import { BrowserRouter } from "react-router-dom";
 import { ClerkProvider } from "@clerk/clerk-react";
 import App from "./App";
 import "./styles.css";
+import "./styles/tokens.css";
+import "./styles/base.css";
+import "./components/ui/ui.css";
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 

--- a/apps/web/src/pages/StyleguidePage.tsx
+++ b/apps/web/src/pages/StyleguidePage.tsx
@@ -1,0 +1,234 @@
+import { useId, useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  Field,
+  Input,
+  Navbar,
+  Sidebar,
+  Stepper,
+} from "../components/ui";
+import type { BuscoOfrezcoMode } from "../components/ui";
+
+const sectionStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "1rem",
+  marginBottom: "3rem",
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.75rem",
+  alignItems: "center",
+};
+
+export default function StyleguidePage() {
+  const [mode, setMode] = useState<BuscoOfrezcoMode>("busco");
+  const [step, setStep] = useState(1);
+  const emailId = useId();
+  const nameId = useId();
+  const errId = useId();
+
+  const steps = ["Datos", "Ubicación", "Precio", "Fotos"];
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: "2rem 1.25rem 4rem" }}>
+      <header style={{ marginBottom: "2.5rem" }}>
+        <h1 className="ts-display">Styleguide</h1>
+        <p style={{ color: "var(--ts-text-secondary)", maxWidth: "60ch" }}>
+          Sistema de diseño editorial de TerraShare (issue #134, Fase 1). Tokens, tipografía y
+          primitivos base.
+        </p>
+      </header>
+
+      {/* Tipografía */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Tipografía</h2>
+        <div className="ts-display">Display · Spectral</div>
+        <h1 className="ts-title">Título H1 · Spectral</h1>
+        <h2 className="ts-title">Título H2 · Spectral</h2>
+        <h3 className="ts-title">Título H3 · Spectral</h3>
+        <p>
+          Cuerpo en Hanken Grotesk. La interfaz usa esta sans legible para párrafos, labels,
+          botones y navegación. Referencia: <span className="ts-mono">pay_a1b2c3</span>.
+        </p>
+      </section>
+
+      {/* Colores */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Paleta</h2>
+        <div style={rowStyle}>
+          {(
+            [
+              ["Crema", "--ts-bg"],
+              ["Superficie", "--ts-surface"],
+              ["Bosque", "--ts-green"],
+              ["Verde tinta", "--ts-green-ink"],
+              ["Sage", "--ts-sage"],
+              ["Terracota", "--ts-clay"],
+              ["Borde", "--ts-border"],
+            ] as const
+          ).map(([label, token]) => (
+            <div key={token} style={{ textAlign: "center", fontSize: "0.75rem" }}>
+              <div
+                style={{
+                  width: 72,
+                  height: 72,
+                  borderRadius: "var(--ts-radius)",
+                  background: `var(${token})`,
+                  border: "1px solid var(--ts-border)",
+                }}
+              />
+              <div style={{ marginTop: 6, color: "var(--ts-text-secondary)" }}>{label}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Buttons */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Button</h2>
+        <div style={rowStyle}>
+          <Button variant="primary">Primario</Button>
+          <Button variant="secondary">Secundario</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="danger">Peligro</Button>
+          <Button variant="primary" disabled>
+            Deshabilitado
+          </Button>
+        </div>
+        <div style={rowStyle}>
+          <Button size="sm">Small</Button>
+          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+          <Button href="#" variant="secondary">
+            Como enlace
+          </Button>
+        </div>
+      </section>
+
+      {/* Badges */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Badge</h2>
+        <div style={rowStyle}>
+          <Badge tone="green">Publicada</Badge>
+          <Badge tone="beige">Pendiente</Badge>
+          <Badge tone="clay" dot>
+            Sin leer
+          </Badge>
+          <Badge tone="neutral">Borrador</Badge>
+        </div>
+      </section>
+
+      {/* Card */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Card</h2>
+        <div style={{ ...rowStyle, alignItems: "stretch" }}>
+          <Card style={{ maxWidth: 280 }}>
+            <h3 className="ts-title" style={{ marginBottom: "0.5rem" }}>
+              Finca La Esperanza
+            </h3>
+            <p style={{ color: "var(--ts-text-secondary)", margin: 0 }}>
+              Chiriquí · 2.4 ha · riego por goteo.
+            </p>
+          </Card>
+          <Card interactive style={{ maxWidth: 280 }}>
+            <Badge tone="green">Alquiler</Badge>
+            <h3 className="ts-title" style={{ margin: "0.6rem 0 0.25rem" }}>
+              Tarjeta interactiva
+            </h3>
+            <p style={{ color: "var(--ts-text-secondary)", margin: 0 }}>Pasa el cursor.</p>
+          </Card>
+          <Card flat style={{ maxWidth: 280 }}>
+            <p style={{ margin: 0 }}>Variante flat (sin sombra).</p>
+          </Card>
+        </div>
+      </section>
+
+      {/* Fields */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Field / Input</h2>
+        <div style={{ display: "grid", gap: "1rem", maxWidth: 380 }}>
+          <Field label="Nombre" htmlFor={nameId} required>
+            <Input id={nameId} placeholder="Finca La Esperanza" />
+          </Field>
+          <Field label="Correo" htmlFor={emailId} hint="No lo compartiremos.">
+            <Input id={emailId} type="email" placeholder="tu@correo.com" />
+          </Field>
+          <Field label="Precio" htmlFor={errId} error="Ingresa un monto válido.">
+            <Input id={errId} invalid defaultValue="-10" />
+          </Field>
+        </div>
+      </section>
+
+      {/* Stepper */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Stepper</h2>
+        <Card>
+          <Stepper steps={steps} current={step} />
+          <div style={{ ...rowStyle, marginTop: "1.25rem" }}>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setStep((s) => Math.max(0, s - 1))}
+            >
+              Anterior
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => setStep((s) => Math.min(steps.length - 1, s + 1))}
+            >
+              Siguiente
+            </Button>
+          </div>
+        </Card>
+      </section>
+
+      {/* Navbar */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Navbar</h2>
+        <Navbar
+          mode={mode}
+          onModeChange={setMode}
+          userName="Ana Torres"
+          userMenuItems={[
+            { label: "Mi perfil", href: "#" },
+            { label: "Mis terrenos", href: "#" },
+          ]}
+          onSignOut={() => window.alert("Cerrar sesión")}
+        />
+        <p style={{ color: "var(--ts-text-secondary)", fontSize: "0.85rem" }}>
+          Modo activo: <strong>{mode}</strong>
+        </p>
+      </section>
+
+      {/* Sidebar */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Sidebar (admin)</h2>
+        <div style={{ maxWidth: 260 }}>
+          <Sidebar
+            items={[
+              { label: "Dashboard", href: "#", active: true },
+              { label: "Usuarios", href: "#" },
+              { label: "Terrenos", href: "#" },
+              { separator: true },
+              { label: "Leads", href: "#" },
+            ]}
+            footer={
+              <button
+                type="button"
+                className="ds-sidebar__item"
+                onClick={() => window.alert("Salir")}
+              >
+                Cerrar sesión
+              </button>
+            }
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -1,0 +1,75 @@
+/* TerraShare — tema base editorial (issue #134).
+   Aplica fondo crema + tipografía a toda la app. NO reescribe las páginas
+   legacy: styles.css sigue vigente y muchas reglas legacy fijan sus propias
+   fuentes/fondos, por lo que conviven durante la transición. */
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  background: var(--ts-bg);
+  color: var(--ts-text);
+  font-family: var(--ts-font-sans);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Títulos en serif con tracking negativo (fuera de las páginas legacy, que
+   fijan sus propios estilos). */
+.ts-title,
+.ts-display {
+  font-family: var(--ts-font-serif);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--ts-text);
+  margin: 0;
+}
+
+.ts-display {
+  font-size: clamp(2.5rem, 6vw, 4.6rem);
+  font-weight: 400;
+}
+
+h1.ts-title {
+  font-size: clamp(2.5rem, 5vw, 3.25rem);
+}
+
+h2.ts-title {
+  font-size: clamp(1.6rem, 3.4vw, 2.6rem);
+}
+
+h3.ts-title {
+  font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+}
+
+.ts-mono {
+  font-family: var(--ts-font-mono);
+}
+
+/* Entrada suave reutilizable. */
+@keyframes ts-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.ts-fade-up {
+  animation: ts-fade-up 0.6s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ts-fade-up {
+    animation: none;
+  }
+}

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,0 +1,69 @@
+/* TerraShare — tokens del sistema de diseño editorial (issue #134).
+   Fuente de verdad: design/DESIGN_SYSTEM.md + design/prototipo-editorial.html.
+   Tema claro. El tema oscuro se añadirá en una fase posterior. */
+
+:root {
+  /* superficies (papel) */
+  --ts-bg: #f4efe4;            /* fondo de página (crema) */
+  --ts-surface: #fffdf8;       /* tarjetas / paneles */
+  --ts-surface-alt: #fbf7ee;   /* bloques alternos */
+  --ts-paper-tint: #f7f2e7;
+
+  /* marca (verde) */
+  --ts-green: #2f5138;         /* primario: botones, activo, marca */
+  --ts-green-ink: #24312a;     /* verde muy oscuro: sidebar admin, tinta fuerte */
+  --ts-green-soft: #55654f;
+  --ts-sage: #8a9784;          /* verde-gris apagado */
+  --ts-sage-2: #7c8a76;
+  --ts-sage-3: #a0ad98;
+
+  /* tintes claros (chips, éxito, hover) */
+  --ts-tint-green: #eef2e6;
+  --ts-tint-green-2: #e7efe0;
+  --ts-tint-green-3: #c9d3c4;
+
+  /* acento */
+  --ts-clay: #b8623f;          /* terracota: acentos, badges, punto de notificación */
+  --ts-clay-tint: #f3e4dc;
+
+  /* neutros cálidos */
+  --ts-border: #e6ddc9;        /* bordes/hairlines */
+  --ts-beige: #ece2cd;
+  --ts-beige-2: #e0dbcb;
+
+  /* texto */
+  --ts-text: #24312a;          /* principal */
+  --ts-text-secondary: #55654f;
+  --ts-text-muted: #8a9784;
+
+  /* texto sobre relleno verde */
+  --ts-on-green: #f4efe4;
+
+  /* tipografía */
+  --ts-font-serif: "Spectral", Georgia, "Times New Roman", serif;
+  --ts-font-sans: "Hanken Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --ts-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  /* radios */
+  --ts-radius-sm: 8px;
+  --ts-radius: 12px;           /* botones */
+  --ts-radius-lg: 16px;        /* tarjetas */
+  --ts-radius-xl: 20px;
+  --ts-radius-pill: 999px;
+
+  /* espaciado base */
+  --ts-space-1: 4px;
+  --ts-space-2: 8px;
+  --ts-space-3: 12px;
+  --ts-space-4: 16px;
+  --ts-space-5: 24px;
+  --ts-space-6: 32px;
+  --ts-space-8: 48px;
+
+  /* sombras (mínimas, estilo papel) */
+  --ts-shadow-sm: 0 1px 2px rgba(36, 49, 42, 0.05);
+  --ts-shadow: 0 6px 24px rgba(36, 49, 42, 0.08);
+
+  /* foco accesible */
+  --ts-ring: 0 0 0 3px rgba(47, 81, 56, 0.28);
+}


### PR DESCRIPTION
## Resumen

Fase 1 del rediseño UX (épico **#134**): lleva el sistema de diseño **editorial** a `apps/web` **sin reescribir páginas ni tocar el backend**. Fuente de verdad: `design/DESIGN_SYSTEM.md` + `design/prototipo-editorial.html`.

`Refs #134` (no cierra el issue: es un épico).

## Qué incluye

- **Fuentes**: Spectral (serif, títulos) + Hanken Grotesk (sans, UI) vía Google Fonts en `index.html`.
- **Tokens** del DESIGN_SYSTEM.md como variables CSS globales (tema claro): `src/styles/tokens.css` (`--ts-*`) + tema base `src/styles/base.css` (fondo crema, tipografía, `fadeUp`, `prefers-reduced-motion`).
- **Primitivos tipados** en `src/components/ui/`: `Button`, `Card`, `Badge`, `Field`, `Input`, `Navbar` (switch **Busco/Ofrezco** + menú usuario con cerrar sesión), `Sidebar` (admin, verde tinta), `Stepper`. Clases con prefijo `ds-` para no colisionar con el CSS legacy.
- **`/styleguide`**: página que muestra todos los primitivos.

## Decisiones

- **No-destructivo (opción A acordada)**: `styles.css` legacy se mantiene intacto. Las páginas actuales siguen funcionando y quedan con un look de transición mixto hasta portarse en fases siguientes.
- Fuera de alcance: portar las 26 pantallas, cablear el switch a estado/rutas reales, tema oscuro, retirar CSS legacy.

## Verificación

- `tsc --noEmit` en estricto: **limpio**, sin `@ts-nocheck`.
- `/styleguide` renderiza tipografía, paleta, botones, badges, cards, fields, stepper, navbar (switch + dropdown) y sidebar en estilo editorial.
- La ruta `/` (landing legacy) sigue cargando sin romperse.

## Notas

- Los errores `Failed to fetch featured lands` en dev son preexistentes (API no levantada), ajenos a este cambio.