### PR TITLE
feat(web): landing + login/onboarding editorial (Fase 2, Grupo 1) — Refs #134

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -6,16 +6,24 @@
       "name": "@terrashare/web",
       "dependencies": {
         "@clerk/clerk-react": "^5.0.0",
+        "@clerk/localizations": "^4.12.0",
+        "@stripe/react-stripe-js": "^6.3.0",
+        "@stripe/stripe-js": "^9.3.1",
         "leaflet": "^1.9.4",
         "leaflet-defaulticon-compatibility": "^0.1.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-leaflet": "^5.0.0",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.30.1",
       },
       "devDependencies": {
         "@playwright/test": "^1.55.0",
+        "@types/leaflet": "^1.9.21",
+        "@types/node": "^26.0.0",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^6.0.3",
         "vite": "^5.4.10",
       },
     },
@@ -60,6 +68,8 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@clerk/clerk-react": ["@clerk/clerk-react@5.61.3", "", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg=="],
+
+    "@clerk/localizations": ["@clerk/localizations@4.12.0", "", { "dependencies": { "@clerk/shared": "^4.23.0" } }, "sha512-uuSQeB/HLg4Fkd0lJPBuG3jaW1o/enzh2ZsKaPCiAqZG39x109RkjyU3AP2dreVwXoXL572PYGT0JqKW+6THCA=="],
 
     "@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
 
@@ -121,7 +131,7 @@
 
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
-    "@react-leaflet/core": ["@react-leaflet/core@3.0.0", "", { "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ=="],
+    "@react-leaflet/core": ["@react-leaflet/core@2.1.0", "", { "peerDependencies": { "leaflet": "^1.9.0", "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg=="],
 
     "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
 
@@ -177,6 +187,12 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
+    "@stripe/react-stripe-js": ["@stripe/react-stripe-js@6.7.0", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "@stripe/stripe-js": ">=9.5.0 <10.0.0", "react": ">=16.8.0 <20.0.0", "react-dom": ">=16.8.0 <20.0.0" } }, "sha512-KSWTQHcDlAOlxcOz+uq0pTA/k9G4+IBF/X8mtSFkkBX+nb74buMTIFcCUCHWNhjuPqfD+yJm7NWDan1EaxSyzQ=="],
+
+    "@stripe/stripe-js": ["@stripe/stripe-js@9.9.0", "", {}, "sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -186,6 +202,16 @@
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/leaflet": ["@types/leaflet@1.9.21", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -197,7 +223,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -237,6 +263,8 @@
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
@@ -245,11 +273,15 @@
 
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
-    "react-leaflet": ["react-leaflet@5.0.0", "", { "dependencies": { "@react-leaflet/core": "^3.0.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw=="],
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-leaflet": ["react-leaflet@4.2.1", "", { "dependencies": { "@react-leaflet/core": "^2.1.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
@@ -271,6 +303,10 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
@@ -279,6 +315,12 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@clerk/localizations/@clerk/shared": ["@clerk/shared@4.23.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-v4roxB9AwEVq56luLc9MtQ+RkVR66XZJGAfTbQXD0ArdW+fs1P/FhlKwm6OQfvDFNiCCVZA6GoP648t9dGtfrw=="],
+
+    "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "@clerk/localizations/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.0.0",
+    "@clerk/localizations": "^4.12.0",
     "@stripe/react-stripe-js": "^6.3.0",
     "@stripe/stripe-js": "^9.3.1",
     "leaflet": "^1.9.4",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,7 @@ import NotificationsPage from "./pages/NotificationsPage";
 import PaymentsPage from "./pages/PaymentsPage";
 import Login from "./components/Login";
 import Register from "./components/Register";
+import OnboardingPage from "./pages/OnboardingPage";
 import UserDashboardLayout from "./components/UserDashboardLayout";
 import PublicHeader from "./components/PublicHeader";
 import StyleguidePage from "./pages/StyleguidePage";
@@ -506,6 +507,7 @@ export default function App() {
       <Route path="/reserve/:landId" element={<ProtectedRoute><ReservePage /></ProtectedRoute>} />
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
+      <Route path="/onboarding" element={<ProtectedRoute><OnboardingPage /></ProtectedRoute>} />
       <Route path="/checkout/success" element={<PaymentSuccessPage />} />
       <Route path="/checkout/cancel" element={<PaymentCancelPage />} />
       <Route path="/dashboard" element={<ProtectedRoute><UserDashboardLayout><DashboardPage /></UserDashboardLayout></ProtectedRoute>} />

--- a/apps/web/src/clerkAppearance.ts
+++ b/apps/web/src/clerkAppearance.ts
@@ -1,0 +1,49 @@
+import type { ComponentProps } from "react";
+import type { ClerkProvider } from "@clerk/clerk-react";
+
+// El tipo `Appearance` no se expone como paquete resoluble aquí; lo derivamos
+// de la prop `appearance` de ClerkProvider para mantener el chequeo estricto.
+type Appearance = NonNullable<ComponentProps<typeof ClerkProvider>["appearance"]>;
+
+/**
+ * Tema editorial para los componentes de Clerk (SignIn / SignUp / modales).
+ * Los valores replican los tokens `--ts-*` de src/styles/tokens.css; se
+ * mantienen como literales porque `appearance` de Clerk no lee variables CSS
+ * en tiempo de construcción. Si cambian los tokens, actualizar aquí también.
+ */
+export const clerkAppearance: Appearance = {
+  variables: {
+    colorPrimary: "#2f5138", // --ts-green
+    colorText: "#24312a", // --ts-text
+    colorTextSecondary: "#55654f", // --ts-text-secondary
+    colorBackground: "#fffdf8", // --ts-surface
+    colorInputBackground: "#fffdf8", // --ts-surface
+    colorInputText: "#24312a", // --ts-text
+    colorDanger: "#b8623f", // --ts-clay
+    borderRadius: "12px", // --ts-radius
+    fontFamily: '"Hanken Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  },
+  elements: {
+    card: {
+      backgroundColor: "#fffdf8",
+      border: "1px solid #e6ddc9", // --ts-border
+      boxShadow: "0 6px 24px rgba(36, 49, 42, 0.08)",
+    },
+    headerTitle: {
+      fontFamily: '"Spectral", Georgia, serif',
+      fontWeight: 500,
+      letterSpacing: "-0.02em",
+    },
+    formButtonPrimary: {
+      backgroundColor: "#2f5138",
+      fontWeight: 600,
+      textTransform: "none",
+      "&:hover": { backgroundColor: "#24312a" }, // --ts-green-ink
+      "&:focus": { boxShadow: "0 0 0 3px rgba(47, 81, 56, 0.28)" }, // --ts-ring
+    },
+    footerActionLink: {
+      color: "#2f5138",
+      "&:hover": { color: "#24312a" },
+    },
+  },
+};

--- a/apps/web/src/components/Login.tsx
+++ b/apps/web/src/components/Login.tsx
@@ -1,10 +1,18 @@
 import { useEffect } from "react";
-import { Link, useLocation, useSearchParams } from "react-router-dom";
-import { useClerk } from "@clerk/clerk-react";
+import { Link, useSearchParams } from "react-router-dom";
+import { SignIn } from "@clerk/clerk-react";
+import "../pages/auth.css";
+
+function LeafMark() {
+  return (
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z" />
+      <path d="M2 21c0-3 1.85-5.36 5.08-6" />
+    </svg>
+  );
+}
 
 export default function Login() {
-  const { openSignIn } = useClerk();
-  const location = useLocation();
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
@@ -14,42 +22,30 @@ export default function Login() {
     }
   }, [searchParams]);
 
-  const handleSignIn = () => {
-    const fromPath = location.state?.from?.pathname || location.state?.from;
-    const hasValidFrom = typeof fromPath === "string" && fromPath.startsWith("/");
-    const isAuthRoute = hasValidFrom && (fromPath.startsWith("/login") || fromPath.startsWith("/register"));
-    const redirectTarget = hasValidFrom && !isAuthRoute ? fromPath : "/dashboard";
-    openSignIn({ redirectUrl: redirectTarget });
-  };
-
   return (
-    <div className="page-shell">
-      <div className="glass-panel" style={{ marginTop: "2rem", maxWidth: "400px", margin: "2rem auto" }}>
-        <div className="section-header compact">
-          <h1>Iniciar sesion</h1>
-          <p>Accede a tu cuenta TerraShare</p>
-        </div>
+    <div className="au-shell">
+      <Link to="/" className="au-brand" aria-label="TerraShare, inicio">
+        <LeafMark />
+        TerraShare
+      </Link>
 
-        <div className="btn-stack">
-          {/* Clerk's modal presents every provider enabled in the dashboard
-              (Google, Microsoft, email). openSignIn has no per-provider option,
-              so a single entry point is the correct flow. */}
-          <button className="btn btn-primary btn-full" onClick={handleSignIn}>
-            Iniciar sesion
-          </button>
-        </div>
-
-        <div className="auth-link">
-          <p>
-            ¿No tienes cuenta?{" "}
-            <Link to="/register" state={{ from: location.state?.from }} className="auth-link-text">Registrate</Link>
-          </p>
-        </div>
-
-        <div className="back-link">
-          <Link to="/" className="back-link-text">← Volver al inicio</Link>
-        </div>
+      <div className="au-intro">
+        <h1 className="ts-title">Entra a tu cuenta</h1>
+        <p>Inicia sesión para continuar en TerraShare.</p>
       </div>
+
+      {/* Clerk maneja Google / correo; el tema editorial se aplica vía
+          `appearance` en el ClerkProvider (main.tsx). Routing "virtual" para
+          embeber sin necesidad de una ruta comodín. El destino tras iniciar
+          sesión lo resuelve `signInFallbackRedirectUrl` del provider. */}
+      <div className="au-widget">
+        <SignIn routing="virtual" signUpUrl="/register" />
+      </div>
+
+      <p className="au-note">Autenticación con Clerk</p>
+      <Link to="/" className="au-back">
+        ← Volver al inicio
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/Register.tsx
+++ b/apps/web/src/components/Register.tsx
@@ -1,59 +1,53 @@
 import { useEffect } from "react";
-import { Link, useLocation, useSearchParams } from "react-router-dom";
-import { useClerk } from "@clerk/clerk-react";
+import { Link, useSearchParams } from "react-router-dom";
+import { SignUp } from "@clerk/clerk-react";
+import "../pages/auth.css";
+
+function LeafMark() {
+  return (
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z" />
+      <path d="M2 21c0-3 1.85-5.36 5.08-6" />
+    </svg>
+  );
+}
 
 export default function Register() {
-  const { openSignUp } = useClerk();
-  const location = useLocation();
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
     const utmSource = searchParams.get("utm_source");
     if (utmSource) {
+      // TODO(#137): adjuntar utm_source a unsafeMetadata del usuario al crear la
+      // cuenta. El <SignUp/> embebido no expone metadata como prop; se guarda en
+      // sessionStorage para conectarlo en el onboarding/backend más adelante.
       sessionStorage.setItem("terrashare_utm_source", utmSource);
     }
   }, [searchParams]);
 
-  const handleSignUp = () => {
-    const fromPath = location.state?.from?.pathname || location.state?.from;
-    const hasValidFrom = typeof fromPath === "string" && fromPath.startsWith("/");
-    const isAuthRoute = hasValidFrom && (fromPath.startsWith("/login") || fromPath.startsWith("/register"));
-    const redirectTarget = hasValidFrom && !isAuthRoute ? fromPath : "/dashboard";
-    const utmSource = sessionStorage.getItem("terrashare_utm_source");
-    openSignUp({
-      redirectUrl: redirectTarget,
-      ...(utmSource && { unsafeMetadata: { utm_source: utmSource } }),
-    });
-  };
-
   return (
-    <div className="page-shell">
-      <div className="glass-panel" style={{ marginTop: "2rem", maxWidth: "400px", margin: "2rem auto" }}>
-        <div className="section-header compact">
-          <h1>Crear cuenta</h1>
-          <p>Unete a TerraShare</p>
-        </div>
+    <div className="au-shell">
+      <Link to="/" className="au-brand" aria-label="TerraShare, inicio">
+        <LeafMark />
+        TerraShare
+      </Link>
 
-        <div className="btn-stack">
-          {/* Clerk's modal presents every provider enabled in the dashboard
-              (Google, Microsoft, email). openSignUp has no per-provider option,
-              so a single entry point is the correct flow. */}
-          <button className="btn btn-primary btn-full" onClick={handleSignUp}>
-            Crear cuenta
-          </button>
-        </div>
-
-        <div className="auth-link">
-          <p>
-            ¿Ya tienes cuenta?{" "}
-            <Link to="/login" state={{ from: location.state?.from }} className="auth-link-text">Inicia sesion</Link>
-          </p>
-        </div>
-
-        <div className="back-link">
-          <Link to="/" className="back-link-text">← Volver al inicio</Link>
-        </div>
+      <div className="au-intro">
+        <h1 className="ts-title">Crea tu cuenta</h1>
+        <p>Regístrate para publicar o solicitar tierra en Panamá.</p>
       </div>
+
+      {/* Tras registrarse, `forceRedirectUrl` lleva SIEMPRE al onboarding
+          (reforzado por `signUpForceRedirectUrl` del provider), de modo que
+          todos los caminos de registro pasen por ese paso. */}
+      <div className="au-widget">
+        <SignUp routing="virtual" signInUrl="/login" forceRedirectUrl="/onboarding" />
+      </div>
+
+      <p className="au-note">Autenticación con Clerk</p>
+      <Link to="/" className="au-back">
+        ← Volver al inicio
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/data/panama-provinces.ts
+++ b/apps/web/src/data/panama-provinces.ts
@@ -1,0 +1,19 @@
+/**
+ * Provincias de Panamá para selects de onboarding/filtros.
+ * Los nombres coinciden EXACTAMENTE con los del seed del backend
+ * (apps/backend-api/src/db/seed.ts) para que los filtros del catálogo casen.
+ * Si el backend añade provincias/comarcas, sincronizar aquí.
+ */
+export const PANAMA_PROVINCES = [
+  "Bocas del Toro",
+  "Chiriquí",
+  "Coclé",
+  "Colón",
+  "Darién",
+  "Herrera",
+  "Los Santos",
+  "Panamá",
+  "Veraguas",
+] as const;
+
+export type PanamaProvince = (typeof PANAMA_PROVINCES)[number];

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { ClerkProvider } from "@clerk/clerk-react";
+import { esES } from "@clerk/localizations";
 import App from "./App";
+import { clerkAppearance } from "./clerkAppearance";
 import "./styles.css";
 import "./styles/tokens.css";
 import "./styles/base.css";
@@ -12,7 +14,15 @@ const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <ClerkProvider publishableKey={PUBLISHABLE_KEY}>
+    <ClerkProvider
+      publishableKey={PUBLISHABLE_KEY}
+      appearance={clerkAppearance}
+      localization={esES}
+      // Todo registro (embed o modal) pasa por el onboarding; inicio de sesión
+      // cae al dashboard salvo que exista un `from` previo.
+      signUpForceRedirectUrl="/onboarding"
+      signInFallbackRedirectUrl="/dashboard"
+    >
       <BrowserRouter>
         <App />
       </BrowserRouter>

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -2,280 +2,442 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@clerk/clerk-react";
 import type { LandDto } from "@terrashare/shared";
-import PublicHeader from "../components/PublicHeader";
+import { Badge, Button, Card } from "../components/ui";
 import { listLands } from "../services/api";
 import { isAdminUser } from "../components/authDisplay";
+import "./landing.css";
 
-type FeaturedLand = LandDto & {
-  type?: string;
-  areaHectares?: number;
-  water?: string;
-  access?: string;
-  monthlyPrice?: number;
+// ─── Iconos inline (el app no carga el webfont Tabler del prototipo) ──────────
+type IconProps = { size?: number };
+
+const stroke = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
 };
 
-const metrics = [
-  { value: "+120", label: "Terrenos disponibles" },
-  { value: "2 días", label: "Tiempo promedio de respuesta" },
-  { value: "6", label: "Provincias en Panamá" },
+function LeafIcon({ size = 26 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z" />
+      <path d="M2 21c0-3 1.85-5.36 5.08-6" />
+    </svg>
+  );
+}
+
+function MapSearchIcon({ size = 24 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <path d="M11 18.5 9 20l-6-3V4l6 3 6-3 6 3v6" />
+      <path d="M9 7v13M15 4v8" />
+      <circle cx="18" cy="18" r="3" />
+      <path d="m20.5 20.5 1.5 1.5" />
+    </svg>
+  );
+}
+
+function UploadIcon({ size = 24 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+      <path d="M7 9l5-5 5 5M12 4v12" />
+    </svg>
+  );
+}
+
+function ShieldIcon({ size = 24 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <path d="M12 3l7 3v6c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3Z" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  );
+}
+
+function CheckIcon({ size = 18 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+function LockIcon({ size = 24 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <rect x="3" y="11" width="18" height="10" rx="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+
+function PinIcon({ size = 15 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
+function TargetIcon({ size = 22 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="12" cy="12" r="5" />
+      <circle cx="12" cy="12" r="1" />
+    </svg>
+  );
+}
+
+function EyeIcon({ size = 22 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" {...stroke} aria-hidden="true">
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+// ─── Contenido estático ───────────────────────────────────────────────────────
+const HOW = [
+  { icon: <MapSearchIcon />, title: "Explora con mapa", desc: "Filtra por provincia, uso, área y precio." },
+  { icon: <UploadIcon />, title: "Publica en minutos", desc: "Sube fotos, ubicación y condiciones." },
+  { icon: <ShieldIcon />, title: "Cierra seguro", desc: "Chat, acuerdo y pago en un solo lugar." },
 ];
 
-const benefits = [
-  {
-    icon: "📊",
-    title: "Información completa",
-    desc: "Tamaño exacto, fuentes de agua, acceso y precio mensual.",
-  },
-  {
-    icon: "🔍",
-    title: "Explora sin registro",
-    desc: "Navega el catálogo completo antes de registrarte.",
-  },
-  {
-    icon: "⚡",
-    title: "Respuesta rápida",
-    desc: "Te notificamos por email cuando el propietario responda.",
-  },
-  {
-    icon: "📋",
-    title: "Historial guardado",
-    desc: "Solicitudes, mensajes y acuerdos en un solo lugar.",
-  },
-];
+const USE_LABELS: Record<string, string> = {
+  agricultura: "Agricultura",
+  ganaderia: "Ganadería",
+  forestal: "Forestal",
+  acuicultura: "Acuicultura",
+  mixto: "Mixto",
+  otro: "Otro",
+};
 
-const steps = [
-  { number: "1", title: "Regístrate", desc: "Con tu email en menos de 1 minuto." },
-  { number: "2", title: "Publica o busca", desc: "Sube fotos de tu terreno o explora el catálogo." },
-  { number: "3", title: "Recibe ofertas", desc: "Los interesados te contactan." },
-  { number: "4", title: "Cierran el trato", desc: "Acuerdan fechas y formalizan." },
-];
+function formatUse(use?: string): string {
+  if (!use) return "Terreno";
+  return USE_LABELS[use] ?? use;
+}
+
+function TeaserCard({ land }: { land: LandDto }) {
+  const price = land.priceRule?.pricePerMonth;
+  return (
+    <Link to={`/lands/${land.id}`} style={{ textDecoration: "none", color: "inherit" }}>
+      <Card interactive>
+        <Badge tone="green">{formatUse(land.allowedUses?.[0])}</Badge>
+        <h3 className="ts-title lp-landcard__title">{land.title}</h3>
+        <div className="lp-landcard__meta">
+          <PinIcon />
+          <span>
+            {land.location?.province} · {land.area} ha
+          </span>
+        </div>
+        <div className="lp-landcard__price">
+          {typeof price === "number" ? (
+            <>
+              ${price.toLocaleString("es-PA")}
+              <span>/mes</span>
+            </>
+          ) : (
+            <span>Precio a consultar</span>
+          )}
+        </div>
+      </Card>
+    </Link>
+  );
+}
 
 export default function LandingPage() {
   const { isSignedIn, user } = useUser();
   const admin = isAdminUser(user);
-  const [activeTab, setActiveTab] = useState("benefits");
-  const [featuredLands, setFeaturedLands] = useState<FeaturedLand[]>([]);
-  const [landsLoading, setLandsLoading] = useState(true);
+  const [lands, setLands] = useState<LandDto[]>([]);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 
   useEffect(() => {
-    const fetchFeaturedLands = async () => {
-      try {
-        const lands = await listLands({ sort: "createdAt", order: "desc", pageSize: 3 });
-        setFeaturedLands(lands.slice(0, 3));
-      } catch (err) {
-        console.error("Error fetching featured lands:", err);
-      } finally {
-        setLandsLoading(false);
-      }
+    let active = true;
+    listLands({ sort: "createdAt", order: "desc", pageSize: 2 })
+      .then((data) => {
+        if (!active) return;
+        setLands(data.slice(0, 2));
+        setStatus("ready");
+      })
+      .catch((err) => {
+        console.error("Error cargando terrenos destacados:", err);
+        if (active) setStatus("error");
+      });
+    return () => {
+      active = false;
     };
-    fetchFeaturedLands();
   }, []);
 
-  const primaryAction = isSignedIn
-    ? { to: admin ? "/dashboard/admin" : "/catalog", label: admin ? "Ir al dashboard admin" : "Explorar catálogo" }
-    : { to: "/register", label: "Publicar mi terreno" };
+  const dashboardTo = admin ? "/dashboard/admin" : "/dashboard";
+  const lockedTo = isSignedIn ? "/catalog" : "/register";
+  const lockedCta = isSignedIn ? "Ver catálogo" : "Crear cuenta";
 
-  const secondaryAction = isSignedIn
-    ? { to: "/catalog", label: "Ver catálogo" }
-    : { to: "/login", label: "Iniciar sesión" };
+  const scrollToHow = () => {
+    document.getElementById("como-funciona")?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   return (
-    <div className="page-shell">
-      <div className="ambient ambient-left" aria-hidden="true" />
-      <div className="ambient ambient-right" aria-hidden="true" />
-      <div className="ambient ambient-bottom" aria-hidden="true" />
-
-      <PublicHeader />
-
-      <main>
-        <section className="hero-section">
-          <div className="hero-wrapper">
-            <div className="landing-hero-copy">
-              <span className="landing-hero-tag">Plataforma #1 en Panamá</span>
-              <h1 className="landing-hero-title">
-                Encuentra el terreno perfecto
-                <br />
-                <span className="landing-hero-title-accent">para producir</span>
-              </h1>
-              <p className="landing-hero-subtitle">
-                Conectamos propietarios y productores de forma clara y segura. 
-                Explora el catálogo sin registrarte. Solicita cuando estés seguro.
-              </p>
-              <div className="landing-hero-actions">
-                <Link to={primaryAction.to} className="btn btn-primary btn-lg">
-                  {primaryAction.label}
-                </Link>
-                <Link to={secondaryAction.to} className="btn btn-ghost btn-lg">
-                  {secondaryAction.label}
-                </Link>
-              </div>
-              <div className="landing-hero-metrics">
-                {metrics.map((m) => (
-                  <div key={m.label} className="landing-metric-card">
-                    <span className="landing-metric-value">{m.value}</span>
-                    <span className="landing-metric-label">{m.label}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div className="hero-visual" aria-hidden="true">
-              <div className="visual-card visual-main">
-                <div className="visual-badge">Destacado</div>
-                <h3>Finca El Tamarindo</h3>
-                <p className="visual-location">Los Santos • Agricultura</p>
-                <div className="visual-details">
-                  <span>5.2 Ha</span>
-                  <span>Pozo + Río</span>
-                  <span>Carroable</span>
-                </div>
-                <div className="visual-price">$420/mes</div>
-              </div>
-              <div className="visual-card visual-secondary">
-                <div className="visual-badge secondary">Disponible</div>
-                <p>Lote Vista Caisan</p>
-                <span className="visual-price-sm">$560/mes</span>
-              </div>
-              <div className="visual-card visual-tertiary">
-                <div className="visual-badge tertiary">Mixto</div>
-                <p>Parcela Río Indio</p>
-                <span className="visual-price-sm">$390/mes</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-<section className="features-section">
-          <div className="section-header">
-            <span className="kicker">Todo lo que necesitas</span>
-            <h2>Explora, publica y conecta</h2>
-            <p>Una plataforma diseñada para que alquilar tierras sea simple y seguro.</p>
-          </div>
-          
-          <div className="features-tabs">
-            <button 
-              className={`tab-btn ${activeTab === 'benefits' ? 'active' : ''}`}
-              onClick={() => setActiveTab('benefits')}
-            >
-              Beneficios
-            </button>
-            <button 
-              className={`tab-btn ${activeTab === 'how' ? 'active' : ''}`}
-              onClick={() => setActiveTab('how')}
-            >
-              Cómo funciona
-            </button>
-          </div>
-
-          <div className="features-grid">
-            {activeTab === 'benefits' ? (
-              benefits.map((b, i) => (
-                <div key={b.title} className="feature-card" style={{ animationDelay: `${i * 80}ms` }}>
-                  <span className="feature-icon">{b.icon}</span>
-                  <h3>{b.title}</h3>
-                  <p>{b.desc}</p>
-                </div>
-              ))
-            ) : (
-              steps.map((step, i) => (
-                <div key={step.number} className="feature-card" style={{ animationDelay: `${i * 80}ms` }}>
-                  <span className="step-badge">{step.number}</span>
-                  <h3>{step.title}</h3>
-                  <p>{step.desc}</p>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
-
-        <section className="preview-section">
-          <div className="section-header">
-            <h2>Terrenos disponibles ahora</h2>
-            <p>Explora las mejores opciones en las zonas agrícolas de Panamá.</p>
-          </div>
-          <div className="cards-grid lands-grid">
-            {landsLoading ? (
-              <p style={{ gridColumn: "1/-1", textAlign: "center", opacity: 0.6 }}>Cargando terrenos...</p>
-            ) : featuredLands.length === 0 ? (
-              <p style={{ gridColumn: "1/-1", textAlign: "center", opacity: 0.6 }}>No hay terrenos disponibles aún.</p>
-            ) : (
-              featuredLands.map((land) => (
-                <Link key={land.id} to={`/lands/${land.id}`} className="land-card-full">
-                  <div className="land-card-header">
-                    <span className="card-badge">{land.allowedUses?.[0] || land.type}</span>
-                    <span className="card-size">{land.areaHectares || land.area} ha</span>
-                  </div>
-                  <h3>{land.title}</h3>
-                  <p className="land-location">{land.location?.province}</p>
-                  <div className="land-features">
-                    <span>💧 {land.water}</span>
-                    <span>🚜 {land.access}</span>
-                  </div>
-                  <div className="card-footer">
-                    <span className="card-price">${land.priceRule?.pricePerMonth || land.monthlyPrice}<span>/mes</span></span>
-                  </div>
-                </Link>
-              ))
-            )}
-          </div>
-          <div className="preview-cta">
-            <Link to="/catalog" className="btn btn-ghost">
-              Ver todos los terrenos →
+    <div className="lp">
+      {/* Header público minimal */}
+      <header className="lp-header">
+        <Link to="/" className="lp-brand" aria-label="TerraShare, inicio">
+          <LeafIcon size={28} />
+          TerraShare
+        </Link>
+        <div className="lp-header-actions">
+          {isSignedIn ? (
+            <Link to={dashboardTo} className="ds-btn ds-btn--primary">
+              {admin ? "Panel de admin" : "Mi panel"}
             </Link>
-          </div>
-        </section>
+          ) : (
+            <>
+              <Link to="/login" className="ds-btn ds-btn--ghost">
+                Iniciar sesión
+              </Link>
+              <Link to="/register" className="ds-btn ds-btn--primary">
+                Crear cuenta
+              </Link>
+            </>
+          )}
+        </div>
+      </header>
 
-        <section className="cta-section">
-          <div className="cta-box">
-            <div className="cta-content">
-              <h2>¿Listo para empezar?</h2>
+      {/* Hero */}
+      <section className="lp-hero ts-fade-up">
+        <span className="lp-hero__badge">Alquiler y venta de tierra en Panamá</span>
+        <h1 className="ts-display lp-hero__title">Encuentra, publica y alquila tierra productiva</h1>
+        <p className="lp-hero__subtitle">
+          Conectamos a quien tiene tierra con quien la necesita. Claro, seguro y sin intermediarios.
+        </p>
+        <div className="lp-hero__actions">
+          {isSignedIn ? (
+            <Link to="/catalog" className="ds-btn ds-btn--primary ds-btn--lg">
+              Explorar catálogo
+            </Link>
+          ) : (
+            <Link to="/register" className="ds-btn ds-btn--primary ds-btn--lg">
+              Crear cuenta gratis
+            </Link>
+          )}
+          <Button variant="secondary" size="lg" onClick={scrollToHow}>
+            Ver cómo funciona
+          </Button>
+        </div>
+      </section>
+
+      {/* Cómo funciona */}
+      <section className="lp-section" id="como-funciona">
+        <div className="lp-how">
+          {HOW.map((item) => (
+            <Card key={item.title}>
+              <div className="lp-how__icon">{item.icon}</div>
+              <h3 className="ts-title">{item.title}</h3>
+              <p>{item.desc}</p>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* Para quien ofrece */}
+      <section className="lp-split">
+        <div>
+          <span className="lp-eyebrow">Para quien ofrece tierra</span>
+          <h2 className="ts-title lp-split__title">Tu terreno, trabajando por ti</h2>
+          <p className="lp-split__text">
+            Publícalo una vez y recibe solicitudes de productores verificados. Tú decides a quién y cuándo.
+          </p>
+          <ul className="lp-checklist">
+            <li>
+              <CheckIcon /> Solicitudes ordenadas por estado
+            </li>
+            <li>
+              <CheckIcon /> Pagos y contrato integrados
+            </li>
+          </ul>
+        </div>
+        <Card className="lp-split__media">
+          <div className="lp-minilist__label">Solicitudes recibidas</div>
+          <div className="lp-minirow">
+            <span>Finca El Tamarindo</span>
+            <Badge tone="beige">Pendiente</Badge>
+          </div>
+          <div className="lp-minirow">
+            <span>Lote Vista Caisán</span>
+            <Badge tone="green">Aprobada</Badge>
+          </div>
+          <div className="lp-minirow">
+            <span>Parcela Río Indio</span>
+            <Badge tone="neutral">Pagada</Badge>
+          </div>
+        </Card>
+      </section>
+
+      {/* Para quien busca */}
+      <section className="lp-split lp-split--reverse">
+        <Card className="lp-split__media">
+          <div className="lp-minilist__label">Explora en el mapa</div>
+          <div className="lp-minirow">
+            <span>
+              <PinIcon /> Hacienda Las Lomas
+            </span>
+            <span className="lp-teaser__note">$390/mes</span>
+          </div>
+          <div className="lp-minirow">
+            <span>
+              <PinIcon /> Solar El Roble
+            </span>
+            <span className="lp-teaser__note">$420/mes</span>
+          </div>
+        </Card>
+        <div>
+          <span className="lp-eyebrow">Para quien busca tierra</span>
+          <h2 className="ts-title lp-split__title">El terreno ideal, sin dar vueltas</h2>
+          <p className="lp-split__text">
+            Explora en el mapa, compara condiciones reales y solicita cuando estés seguro.
+          </p>
+          <ul className="lp-checklist">
+            <li>
+              <CheckIcon /> Ubicación y área a la vista
+            </li>
+            <li>
+              <CheckIcon /> Contacto directo con el dueño
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="lp-stats ts-fade-up">
+        <div className="lp-stats__caption">Productores y propietarios ya confían en TerraShare</div>
+        <div className="lp-stats__grid">
+          <div>
+            <div className="lp-stat__value">120+</div>
+            <div className="lp-stat__label">Terrenos publicados</div>
+          </div>
+          <div>
+            <div className="lp-stat__value">9</div>
+            <div className="lp-stat__label">Provincias</div>
+          </div>
+          <div>
+            <div className="lp-stat__value">2 días</div>
+            <div className="lp-stat__label">Respuesta promedio</div>
+          </div>
+        </div>
+      </section>
+
+      {/* Teaser de terrenos */}
+      <section className="lp-section">
+        <div className="lp-teaser__head">
+          <h2 className="ts-title">Terrenos destacados</h2>
+          <span className="lp-teaser__note">Muestra pública</span>
+        </div>
+        <div className="lp-teaser__grid">
+          {status === "loading" ? (
+            <>
+              <div className="lp-skeleton" />
+              <div className="lp-skeleton" />
+              <LockedCard to={lockedTo} cta={lockedCta} />
+            </>
+          ) : status === "error" || lands.length === 0 ? (
+            <div className="lp-teaser__state">
               <p>
-                {isSignedIn 
-                  ? "Explora más terrenos disponibles o gestiona los tuyos desde el dashboard." 
-                  : "Únete a propietarios y productores de todo Panamá. Es gratis."}
+                {status === "error"
+                  ? "No pudimos cargar los terrenos ahora mismo. Vuelve a intentarlo en un momento."
+                  : "Aún no hay terrenos publicados. Sé el primero en publicar el tuyo."}
               </p>
-              <div className="cta-actions">
-                <Link to="/catalog" className="btn btn-ghost btn-lg">Ver terrenos</Link>
-                {isSignedIn ? (
-                  <Link to={admin ? "/dashboard/admin" : "/dashboard"} className="btn btn-primary btn-lg">
-                    {admin ? "Panel de Admin" : "Mi Dashboard"}
-                  </Link>
-                ) : (
-                  <Link to="/register" className="btn btn-primary btn-lg">Crear cuenta gratis</Link>
-                )}
-              </div>
             </div>
-          </div>
-        </section>
+          ) : (
+            <>
+              {lands.map((land) => (
+                <TeaserCard key={land.id} land={land} />
+              ))}
+              <LockedCard to={lockedTo} cta={lockedCta} />
+            </>
+          )}
+        </div>
+      </section>
 
-        <footer className="landing-footer">
-          <div className="footer-grid">
-            <div className="footer-brand">
-              <span className="brand">TerraShare</span>
-              <p>La plataforma #1 para alquilar tierras productivas en Panamá.</p>
+      {/* Misión / Visión */}
+      <section className="lp-section">
+        <div className="lp-mv">
+          <Card>
+            <div className="lp-mv__icon">
+              <TargetIcon />
             </div>
-            <div className="footer-links">
-              <Link to="/catalog">Catálogo</Link>
-              {isSignedIn ? (
-                <Link to={admin ? "/dashboard/admin" : "/dashboard"} className="text-btn">
-                  {admin ? "Admin" : "Mi cuenta"}
-                </Link>
-              ) : (
-                <>
-                  <Link to="/login" className="text-btn">Entrar</Link>
-                  <Link to="/register" className="text-btn">Registrarse</Link>
-                </>
-              )}
+            <h3 className="ts-title">Misión</h3>
+            <p>Facilitar el acceso a tierra productiva de forma simple, segura y transparente.</p>
+          </Card>
+          <Card>
+            <div className="lp-mv__icon">
+              <EyeIcon />
             </div>
+            <h3 className="ts-title">Visión</h3>
+            <p>Ser la plataforma de referencia para tierra rural en Centroamérica.</p>
+          </Card>
+        </div>
+      </section>
+
+      {/* CTA final */}
+      <section className="lp-cta ts-fade-up">
+        <h2 className="ts-title">¿Listo para empezar?</h2>
+        <p>Únete a propietarios y productores de todo Panamá. Es gratis.</p>
+        {isSignedIn ? (
+          <Link to="/catalog" className="ds-btn ds-btn--primary ds-btn--lg">
+            Explorar catálogo
+          </Link>
+        ) : (
+          <Link to="/register" className="ds-btn ds-btn--primary ds-btn--lg">
+            Crear cuenta gratis
+          </Link>
+        )}
+      </section>
+
+      {/* Footer */}
+      <footer>
+        <div className="lp-footer">
+          <div>
+            <div className="lp-footer__brand">
+              <LeafIcon size={20} />
+              TerraShare
+            </div>
+            <p className="lp-footer__tag">Tierra productiva para Panamá.</p>
           </div>
-          <div className="footer-legal">
-            <p>© {new Date().getFullYear()} TerraShare. Todos los derechos reservados.</p>
-            <div className="footer-legal-links">
-              <a href="#">Términos</a>
-              <a href="#">Privacidad</a>
-            </div>
+          <div className="lp-footer__col">
+            <h4>Producto</h4>
+            <Link to={isSignedIn ? "/catalog" : "/login"}>Catálogo</Link>
+            <Link to={isSignedIn ? "/dashboard/lands" : "/login"}>Publicar</Link>
           </div>
-        </footer>
-      </main>
+          <div className="lp-footer__col">
+            <h4>Empresa</h4>
+            <a href="#como-funciona">Quiénes somos</a>
+            <a href="#como-funciona">Contacto</a>
+          </div>
+          <div className="lp-footer__col">
+            <h4>Legal</h4>
+            <a href="#">Términos</a>
+            <a href="#">Privacidad</a>
+          </div>
+        </div>
+        <div className="lp-copy">TerraShare © {new Date().getFullYear()} · Hecho en Panamá</div>
+      </footer>
+    </div>
+  );
+}
+
+function LockedCard({ to, cta }: { to: string; cta: string }) {
+  return (
+    <div className="lp-locked">
+      <LockIcon />
+      <div className="lp-locked__count">Todo el catálogo</div>
+      <div className="lp-locked__hint">Inicia sesión para ver todos los terrenos</div>
+      <Link to={to} className="ds-btn ds-btn--secondary ds-btn--sm">
+        {cta}
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -1,0 +1,120 @@
+import { useId, useState } from "react";
+import type { FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, Card, Field, Input } from "../components/ui";
+import { PANAMA_PROVINCES } from "../data/panama-provinces";
+import "./auth.css";
+
+type Preference = "busco" | "ofrezco";
+
+function SearchIcon() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+function MapIcon() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M9 18 3 21V6l6-3 6 3 6-3v15l-6 3-6-3Z" />
+      <path d="M9 3v15M15 6v15" />
+    </svg>
+  );
+}
+
+export default function OnboardingPage() {
+  const navigate = useNavigate();
+  const phoneId = useId();
+  const provinceId = useId();
+
+  const [phone, setPhone] = useState("");
+  const [province, setProvince] = useState("");
+  const [preference, setPreference] = useState<Preference>("busco");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // TODO(#137): persistir teléfono, provincia y preferencia inicial (Busco/
+    // Ofrezco) en el perfil del usuario. Hoy no hay endpoint para provincia ni
+    // preferencia; se capturan en el estado de la UI (phone/province/preference)
+    // y solo se usan para elegir la vista inicial.
+    navigate(preference === "ofrezco" ? "/dashboard/lands" : "/catalog");
+  };
+
+  return (
+    <div className="au-shell">
+      <Card className="au-onb">
+        <span className="au-onb__eyebrow">Un paso más</span>
+        <h1 className="ts-title au-onb__title">Cuéntanos de ti</h1>
+        <p className="au-onb__sub">Ya casi está. Con estos datos personalizamos tu experiencia.</p>
+
+        <form className="au-onb__form" onSubmit={handleSubmit}>
+          <Field label="Teléfono / WhatsApp" htmlFor={phoneId} hint="Para coordinar visitas y solicitudes.">
+            <Input
+              id={phoneId}
+              type="tel"
+              inputMode="tel"
+              autoComplete="tel"
+              placeholder="+507 6000-0000"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+            />
+          </Field>
+
+          <Field label="Provincia" htmlFor={provinceId}>
+            <select
+              id={provinceId}
+              className="au-select"
+              value={province}
+              onChange={(e) => setProvince(e.target.value)}
+            >
+              <option value="">Selecciona…</option>
+              {PANAMA_PROVINCES.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <div>
+            <span className="au-fieldlabel" id="pref-label">
+              ¿Qué te trae a TerraShare?
+            </span>
+            <div className="au-pref" role="radiogroup" aria-labelledby="pref-label">
+              <button
+                type="button"
+                role="radio"
+                aria-checked={preference === "busco"}
+                className={`au-pref__opt ${preference === "busco" ? "is-active" : ""}`}
+                onClick={() => setPreference("busco")}
+              >
+                <SearchIcon />
+                Busco tierra
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={preference === "ofrezco"}
+                className={`au-pref__opt ${preference === "ofrezco" ? "is-active" : ""}`}
+                onClick={() => setPreference("ofrezco")}
+              >
+                <MapIcon />
+                Ofrezco tierra
+              </button>
+            </div>
+            <p className="au-onb__hint">
+              Puedes hacer ambas cosas; esto solo define tu vista inicial.
+            </p>
+          </div>
+
+          <Button type="submit" block>
+            Empezar
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/auth.css
+++ b/apps/web/src/pages/auth.css
@@ -1,0 +1,170 @@
+/* Login / registro / onboarding editoriales (issue #134, Grupo 1). Prefijo `au-`. */
+
+.au-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  padding: 2rem 1rem 3rem;
+}
+
+.au-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  text-decoration: none;
+  color: var(--ts-green);
+  font-family: var(--ts-font-serif);
+  font-size: 1.5rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+
+.au-intro {
+  text-align: center;
+  max-width: 40ch;
+}
+
+.au-intro h1 {
+  margin: 0 0 0.35rem;
+}
+
+.au-intro p {
+  margin: 0;
+  color: var(--ts-text-secondary);
+  font-size: 0.95rem;
+}
+
+/* Contenedor del widget de Clerk: centra y limita el ancho. */
+.au-widget {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  justify-content: center;
+}
+
+.au-note {
+  color: var(--ts-text-muted);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.au-back {
+  color: var(--ts-text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.au-back:hover {
+  color: var(--ts-green);
+}
+
+/* ---------- Onboarding ---------- */
+.au-onb {
+  width: min(520px, 92vw);
+}
+
+.au-onb__eyebrow {
+  display: inline-block;
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.3rem 0.8rem;
+  border-radius: var(--ts-radius-pill);
+  margin-bottom: 0.75rem;
+}
+
+.au-onb__title {
+  margin: 0 0 0.25rem;
+}
+
+.au-onb__sub {
+  color: var(--ts-text-secondary);
+  font-size: 0.95rem;
+  margin: 0 0 1.5rem;
+}
+
+.au-onb__form {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.au-select {
+  width: 100%;
+  font-family: var(--ts-font-sans);
+  font-size: 0.95rem;
+  color: var(--ts-text);
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  padding: 0.7rem 0.9rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.au-select:focus {
+  outline: none;
+  border-color: var(--ts-green);
+  box-shadow: var(--ts-ring);
+}
+
+/* Selector Busco / Ofrezco (dos tarjetas) */
+.au-pref {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.au-pref__opt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  text-align: center;
+  padding: 1rem 0.75rem;
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-lg);
+  background: var(--ts-surface);
+  color: var(--ts-text-secondary);
+  font-family: var(--ts-font-sans);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.au-pref__opt:hover {
+  border-color: var(--ts-sage-3);
+}
+
+.au-pref__opt.is-active {
+  border-color: var(--ts-green);
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+}
+
+.au-pref__opt:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}
+
+.au-pref__opt svg {
+  color: currentColor;
+}
+
+.au-onb__hint {
+  color: var(--ts-text-muted);
+  font-size: 0.8rem;
+  margin: 0.1rem 0 0;
+}
+
+.au-fieldlabel {
+  display: block;
+  font-family: var(--ts-font-sans);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ts-text);
+  margin-bottom: 0.4rem;
+}

--- a/apps/web/src/pages/landing.css
+++ b/apps/web/src/pages/landing.css
@@ -1,0 +1,433 @@
+/* Landing público editorial (issue #134, Grupo 1).
+   Solo estilos específicos de esta página; los componentes reutilizan los
+   primitivos `ds-*` y los helpers `.ts-*` de la Fase 1. Prefijo `lp-`. */
+
+.lp {
+  width: min(1080px, 92vw);
+  margin: 0 auto;
+  padding: 1.25rem 0 3rem;
+}
+
+/* ---------- Header ---------- */
+.lp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0 1.5rem;
+}
+
+.lp-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  text-decoration: none;
+  color: var(--ts-green);
+  font-family: var(--ts-font-serif);
+  font-size: 1.6rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+
+.lp-brand svg {
+  color: var(--ts-green);
+}
+
+.lp-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* ---------- Hero ---------- */
+.lp-hero {
+  background: var(--ts-tint-green);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-xl);
+  padding: clamp(2.5rem, 6vw, 4rem) 1.5rem;
+  text-align: center;
+}
+
+.lp-hero__badge {
+  display: inline-block;
+  background: var(--ts-surface);
+  color: var(--ts-green);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--ts-radius-pill);
+  margin-bottom: 1.25rem;
+}
+
+.lp-hero__title {
+  max-width: 16ch;
+  margin: 0 auto 1rem;
+  color: var(--ts-green-ink);
+}
+
+.lp-hero__subtitle {
+  max-width: 46ch;
+  margin: 0 auto 1.75rem;
+  color: var(--ts-text-secondary);
+  font-size: 1.05rem;
+}
+
+.lp-hero__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ---------- Section scaffold ---------- */
+.lp-section {
+  padding: 2.5rem 0;
+}
+
+.lp-section__head {
+  margin-bottom: 1.5rem;
+}
+
+.lp-eyebrow {
+  color: var(--ts-green);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+/* ---------- How it works (3 cards) ---------- */
+.lp-how {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.lp-how__icon {
+  color: var(--ts-green);
+  margin-bottom: 0.75rem;
+}
+
+.lp-how h3 {
+  font-size: 1.05rem;
+  margin: 0 0 0.35rem;
+}
+
+.lp-how p {
+  margin: 0;
+  color: var(--ts-text-secondary);
+  font-size: 0.92rem;
+}
+
+/* ---------- Split sections ---------- */
+.lp-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 2rem 0;
+}
+
+.lp-split__title {
+  font-size: 1.6rem;
+  margin: 0.4rem 0 0.6rem;
+}
+
+.lp-split__text {
+  color: var(--ts-text-secondary);
+  margin: 0 0 1rem;
+}
+
+.lp-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.lp-checklist li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ts-text-secondary);
+  font-size: 0.95rem;
+}
+
+.lp-checklist svg {
+  color: var(--ts-green);
+  flex-shrink: 0;
+}
+
+/* mini panel (mock de solicitudes / listado) */
+.lp-minilist__label {
+  font-size: 0.8rem;
+  color: var(--ts-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.lp-minirow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--ts-border);
+  font-size: 0.92rem;
+}
+
+.lp-minirow:last-child {
+  border-bottom: 0;
+}
+
+/* ---------- Stats band ---------- */
+.lp-stats {
+  background: var(--ts-green-ink);
+  border-radius: var(--ts-radius-lg);
+  padding: 2.25rem 1.5rem;
+  margin: 1rem 0;
+}
+
+.lp-stats__caption {
+  text-align: center;
+  color: var(--ts-sage-3);
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+
+.lp-stats__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  text-align: center;
+}
+
+.lp-stat__value {
+  font-family: var(--ts-font-serif);
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  font-weight: 500;
+  color: var(--ts-on-green);
+  letter-spacing: -0.02em;
+}
+
+.lp-stat__label {
+  color: var(--ts-sage-3);
+  font-size: 0.85rem;
+}
+
+/* ---------- Teaser ---------- */
+.lp-teaser__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.lp-teaser__note {
+  font-size: 0.85rem;
+  color: var(--ts-text-muted);
+}
+
+.lp-teaser__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.lp-landcard__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--ts-text-muted);
+  font-size: 0.85rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.lp-landcard__title {
+  font-size: 1.05rem;
+  margin: 0.6rem 0 0;
+}
+
+.lp-landcard__price {
+  font-family: var(--ts-font-serif);
+  font-size: 1.2rem;
+  color: var(--ts-green-ink);
+}
+
+.lp-landcard__price span {
+  font-family: var(--ts-font-sans);
+  font-size: 0.85rem;
+  color: var(--ts-text-muted);
+}
+
+/* tarjeta con candado */
+.lp-locked {
+  background: var(--ts-green-ink);
+  border: 1px solid var(--ts-green-ink);
+  border-radius: var(--ts-radius-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 0.4rem;
+  padding: 1.5rem;
+  color: var(--ts-on-green);
+}
+
+.lp-locked svg {
+  color: var(--ts-sage-3);
+}
+
+.lp-locked__count {
+  font-weight: 600;
+}
+
+.lp-locked__hint {
+  color: var(--ts-sage-3);
+  font-size: 0.85rem;
+  margin-bottom: 0.6rem;
+}
+
+/* estado carga / vacío del teaser */
+.lp-teaser__state {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--ts-text-muted);
+  padding: 2rem 1rem;
+}
+
+.lp-skeleton {
+  height: 150px;
+  border-radius: var(--ts-radius-lg);
+  border: 1px solid var(--ts-border);
+  background: linear-gradient(
+    100deg,
+    var(--ts-surface-alt) 30%,
+    var(--ts-paper-tint) 50%,
+    var(--ts-surface-alt) 70%
+  );
+  background-size: 200% 100%;
+  animation: lp-shimmer 1.2s ease-in-out infinite;
+}
+
+@keyframes lp-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-skeleton {
+    animation: none;
+  }
+}
+
+/* ---------- Mission / Vision ---------- */
+.lp-mv {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.lp-mv__icon {
+  color: var(--ts-green);
+  margin-bottom: 0.5rem;
+}
+
+.lp-mv h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+}
+
+.lp-mv p {
+  margin: 0;
+  color: var(--ts-text-secondary);
+  font-size: 0.95rem;
+}
+
+/* ---------- CTA final ---------- */
+.lp-cta {
+  background: var(--ts-tint-green);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-xl);
+  padding: clamp(2rem, 5vw, 3rem);
+  text-align: center;
+  margin: 1.5rem 0;
+}
+
+.lp-cta p {
+  color: var(--ts-text-secondary);
+  margin: 0.5rem 0 1.25rem;
+}
+
+/* ---------- Footer ---------- */
+.lp-footer {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr 1fr 1fr;
+  gap: 1.5rem;
+  padding: 2rem 0 1rem;
+  border-top: 1px solid var(--ts-border);
+}
+
+.lp-footer__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--ts-font-serif);
+  font-size: 1.15rem;
+  color: var(--ts-green);
+  margin-bottom: 0.5rem;
+}
+
+.lp-footer__tag {
+  color: var(--ts-text-muted);
+  font-size: 0.88rem;
+  margin: 0;
+}
+
+.lp-footer__col h4 {
+  font-size: 0.88rem;
+  color: var(--ts-text-secondary);
+  margin: 0 0 0.5rem;
+}
+
+.lp-footer__col a {
+  display: block;
+  color: var(--ts-text-muted);
+  text-decoration: none;
+  font-size: 0.88rem;
+  padding: 0.15rem 0;
+}
+
+.lp-footer__col a:hover {
+  color: var(--ts-green);
+}
+
+.lp-copy {
+  text-align: center;
+  color: var(--ts-text-muted);
+  font-size: 0.8rem;
+  padding-top: 1rem;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 820px) {
+  .lp-how,
+  .lp-split,
+  .lp-teaser__grid,
+  .lp-mv,
+  .lp-stats__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lp-split--reverse .lp-split__media {
+    order: -1;
+  }
+
+  .lp-footer {
+    grid-template-columns: 1fr 1fr;
+  }
+}


### PR DESCRIPTION
## Fase 2 · Grupo 1 — Landing y Login/Onboarding editoriales

Porta al estilo editorial (issue #134) el **landing público** y el flujo de **login/registro + onboarding**, reutilizando los primitivos de la Fase 1 (`Button`, `Card`, `Badge`, `Field`, `Input`) y los tokens `--ts-*`.

> ⚠️ **PR apilado** sobre #142 (Fase 1 / sistema de diseño). Base = `feature/134-design-system` para que el diff muestre solo el Grupo 1. **Mergear después de #142.** Refs #134 (no cierra el épico).

### Landing (`/`)
- Escaparate editorial: header minimal, hero (Spectral + crema), "cómo funciona" (3 tarjetas), bloques *Para quien ofrece* / *Para quien busca*, banda de stats sobre verde tinta, misión/visión, CTA final y footer.
- **Teaser de terrenos** desde `listLands()` (2 reales) + **tarjeta con candado** "Inicia sesión para ver todos". Estados de **carga / vacío / error** (patrón `design/25`), sin datos hardcodeados.
- Solo usa campos reales del `LandDto` (`area`, `allowedUses[0]`, `location.province`, `priceRule.pricePerMonth`); agua/acceso llegan con #138.

### Login / Registro (`/login`, `/register`)
- `<SignIn/>` / `<SignUp/>` de Clerk **embebidos y temizados** vía `appearance` mapeado a los tokens (`clerkAppearance.ts`) + **localización `esES`**. Nada de look celeste stock.
- Todo registro pasa por onboarding: `signUpForceRedirectUrl="/onboarding"` (provider) y `forceRedirectUrl` en `<SignUp/>`.

### Onboarding (`/onboarding`)
- **Ruta dedicada** (no secuencial) para que todos los caminos de registro —landing, modal, Google— pasen por el paso. Captura teléfono, provincia (`panama-provinces.ts`, nombres que casan con el seed) y preferencia **Busco/Ofrezco**.
- Sin persistencia todavía: `// TODO(#137)`. El gateo real (forzar onboarding) lo engancha #137.

### Verificación
- `tsc --noEmit` limpio; `vite build` OK. Sin `@ts-nocheck` ni `any`.
- Verificado en dev (Vite :5181 + API :3000): `/` teaser con datos reales y estado de error; `/login` widget en español y temizado; guard de `/onboarding` redirige a `/login` sin sesión; `/styleguide` y rutas legacy (`/catalog`) siguen cargando.
- Accesibilidad: labels en inputs, `aria-label` en enlaces solo-logo, `role="radiogroup"` en la preferencia, `prefers-reduced-motion` respetado.

### Notas
- Añade dependencia `@clerk/localizations` (copy de Clerk en español).
- No toca backend, `styles.css` legacy, ni páginas aún no portadas. `PublicHeader` legacy intacto (lo usa `LandDetailPage`).