### PR TITLE
feat(web): app shell + home Busco/Ofrezco (Fase 2, Grupo 2a) — Refs #134

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
-import { useAuth, useClerk, useUser } from "@clerk/clerk-react";
-import type { RentalRequestDto } from "@terrashare/shared";
+import { useClerk, useUser } from "@clerk/clerk-react";
 import LandingPage from "./pages/LandingPage";
 import CatalogPage from "./pages/CatalogPage";
 import LandDetailPage from "./pages/LandDetailPage";
@@ -10,7 +9,6 @@ import ReservePage from "./pages/ReservePage";
 import PaymentSuccessPage from "./pages/PaymentSuccessPage";
 import PaymentCancelPage from "./pages/PaymentCancelPage";
 import PaymentPage from "./pages/PaymentPage";
-import PaymentButton from "./components/PaymentButton";
 import AdminLandsPage from "./pages/AdminLandsPage";
 import AdminLeadsPage from "./pages/AdminLeadsPage";
 import MyLandsPage from "./pages/MyLandsPage";
@@ -22,6 +20,8 @@ import PaymentsPage from "./pages/PaymentsPage";
 import Login from "./components/Login";
 import Register from "./components/Register";
 import OnboardingPage from "./pages/OnboardingPage";
+import AppLayout from "./components/AppLayout";
+import HomePage from "./pages/HomePage";
 import UserDashboardLayout from "./components/UserDashboardLayout";
 import PublicHeader from "./components/PublicHeader";
 import StyleguidePage from "./pages/StyleguidePage";
@@ -228,144 +228,6 @@ function AdminLayout({ children, onSignOut }: LayoutProps) {
   );
 }
 
-function DashboardPage() {
-  const { user } = useUser();
-  const { getToken } = useAuth();
-  const [requests, setRequests] = useState<RentalRequestDto[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchRequests = async () => {
-      try {
-        const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
-        const headers: Record<string, string> = { "Content-Type": "application/json" };
-        if (import.meta.env.DEV) {
-          headers["x-dev-user-id"] = "web_dev_user";
-          headers["x-dev-role"] = "user";
-        } else {
-          const token = await getToken();
-          if (token) headers["Authorization"] = `Bearer ${token}`;
-        }
-        const res = await fetch(`${BASE_URL}/api/v1/rental-requests`, { headers });
-        const data = await res.json();
-        console.log("API response:", data);
-        if (data?.data) {
-          setRequests(data.data);
-        } else if (Array.isArray(data)) {
-          setRequests(data);
-        }
-      } catch (err) {
-        console.error("Error fetching requests:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchRequests();
-  }, [user]);
-
-  const statusConfig: Record<string, { label: string; color: string; bg: string; icon: string }> = {
-    draft: { label: "Borrador", color: "#997a00", bg: "rgba(200, 170, 0, 0.15)", icon: "📝" },
-    pending_owner: { label: "Pendiente", color: "var(--river-500)", bg: "rgba(13, 111, 147, 0.12)", icon: "⏳" },
-    approved: { label: "Aprobada", color: "var(--leaf-700)", bg: "rgba(11, 95, 55, 0.12)", icon: "✅" },
-    rejected: { label: "Rechazada", color: "var(--danger)", bg: "rgba(180, 40, 40, 0.12)", icon: "❌" },
-    pending_payment: { label: "Pago pendiente", color: "var(--soil-500)", bg: "rgba(157, 106, 59, 0.15)", icon: "💳" },
-    paid: { label: "Pagada", color: "var(--success)", bg: "rgba(11, 95, 55, 0.12)", icon: "🎉" },
-  };
-
-  if (loading) {
-    return (
-      <div>
-        <div className="section-header">
-          <h1>Mis Solicitudes</h1>
-          <p>Gestiona tus solicitudes de alquiler</p>
-        </div>
-        <div className="panel" style={{ marginTop: "1.5rem", textAlign: "center", padding: "3rem" }}>
-          <div className="dashboard-spinner" />
-          <p style={{ marginTop: "1rem", opacity: 0.7 }}>Cargando solicitudes...</p>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      <div className="section-header">
-        <h1>Mis Solicitudes</h1>
-        <p>Gestiona tus solicitudes de alquiler</p>
-      </div>
-
-      {requests.length === 0 ? (
-        <div className="glass-panel dashboard-empty">
-          <div className="dashboard-empty-icon">📋</div>
-          <h2>Sin solicitudes aún</h2>
-          <p>Cuando envíes una solicitud de alquiler, aparecerá aquí.</p>
-          <Link to="/catalog" className="btn btn-primary" style={{ marginTop: "1.5rem" }}>
-            Explorar terrenos
-          </Link>
-        </div>
-      ) : (
-        <div className="dashboard-requests">
-          {requests.map((req) => {
-            const status = statusConfig[req.status] || statusConfig.draft;
-            return (
-              <div key={req.id} className="request-card">
-                <div className="request-header">
-                  <div className="request-id">
-                    <span className="request-icon">{status.icon}</span>
-                    <span>Solicitud #{req.id.slice(0, 8)}</span>
-                  </div>
-                  <span
-                    className="request-status"
-                    style={{ background: status.bg, color: status.color }}
-                  >
-                    {status.label}
-                  </span>
-                </div>
-
-                <div className="request-body">
-                  <div className="request-detail">
-                    <span className="request-detail-label">Terreno</span>
-                    <span className="request-detail-value">{req.landId}</span>
-                  </div>
-                  <div className="request-detail">
-                    <span className="request-detail-label">Uso</span>
-                    <span className="request-detail-value">{req.intendedUse}</span>
-                  </div>
-                  <div className="request-detail">
-                    <span className="request-detail-label">Período</span>
-                    <span className="request-detail-value">
-                      {req.period?.startDate} → {req.period?.endDate}
-                    </span>
-                  </div>
-                </div>
-
-                {req.status === "approved" && (
-                  <div className="request-action">
-                    <p>Tu solicitud fue aprobada. Completa el pago para confirmar el alquiler.</p>
-                    <PaymentButton rentalRequest={req} />
-                  </div>
-                )}
-                {req.status === "pending_payment" && (
-                  <div className="request-action">
-                    <p>Procesando pago...</p>
-                    <PaymentButton rentalRequest={req} />
-                  </div>
-                )}
-                {req.status === "paid" && (
-                  <div className="request-action request-success">
-                    <span className="request-success-icon">✓</span>
-                    <span>Pago confirmado - ¡Alquiler activo!</span>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
 function AdminDashboardPage() {
   const { user } = useUser();
   const [summary, setSummary] = useState<AdminSummary | null>(null);
@@ -510,7 +372,9 @@ export default function App() {
       <Route path="/onboarding" element={<ProtectedRoute><OnboardingPage /></ProtectedRoute>} />
       <Route path="/checkout/success" element={<PaymentSuccessPage />} />
       <Route path="/checkout/cancel" element={<PaymentCancelPage />} />
-      <Route path="/dashboard" element={<ProtectedRoute><UserDashboardLayout><DashboardPage /></UserDashboardLayout></ProtectedRoute>} />
+      <Route element={<ProtectedRoute><AppLayout /></ProtectedRoute>}>
+        <Route path="/dashboard" element={<HomePage />} />
+      </Route>
       <Route path="/dashboard/lands" element={<ProtectedRoute><UserDashboardLayout><MyLandsPage /></UserDashboardLayout></ProtectedRoute>} />
       <Route path="/dashboard/chats" element={<ProtectedRoute><UserDashboardLayout><ChatsPage /></UserDashboardLayout></ProtectedRoute>} />
       <Route path="/dashboard/notifications" element={<ProtectedRoute><UserDashboardLayout><NotificationsPage /></UserDashboardLayout></ProtectedRoute>} />

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { Link, Outlet, useNavigate, useOutletContext } from "react-router-dom";
+import { useClerk, useUser } from "@clerk/clerk-react";
+import { Navbar } from "./ui";
+import type { BuscoOfrezcoMode } from "./ui";
+import { getDisplayName } from "./authDisplay";
+import "../pages/app-shell.css";
+
+const MODE_STORAGE_KEY = "terrashare-mode";
+
+export interface AppLayoutContext {
+  mode: BuscoOfrezcoMode;
+  setMode: (mode: BuscoOfrezcoMode) => void;
+}
+
+/** Modo Busco/Ofrezco compartido por la Navbar y las páginas hijas. */
+export function useAppMode(): AppLayoutContext {
+  return useOutletContext<AppLayoutContext>();
+}
+
+function readStoredMode(): BuscoOfrezcoMode {
+  const stored = typeof window !== "undefined" ? window.localStorage.getItem(MODE_STORAGE_KEY) : null;
+  return stored === "ofrezco" ? "ofrezco" : "busco";
+}
+
+function BrandMark() {
+  return (
+    <Link to="/dashboard" className="ds-navbar__brand" aria-label="TerraShare, inicio">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z" />
+        <path d="M2 21c0-3 1.85-5.36 5.08-6" />
+      </svg>
+      TerraShare
+    </Link>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  );
+}
+
+function ChatIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}
+
+export default function AppLayout() {
+  const navigate = useNavigate();
+  const { user } = useUser();
+  const { signOut } = useClerk();
+  const [mode, setModeState] = useState<BuscoOfrezcoMode>(readStoredMode);
+
+  const setMode = (next: BuscoOfrezcoMode) => {
+    setModeState(next);
+    // TODO(#137): persistir el modo (Busco/Ofrezco) en el perfil del usuario.
+    // Por ahora se guarda localmente para que sobreviva a recargas.
+    window.localStorage.setItem(MODE_STORAGE_KEY, next);
+  };
+
+  const context: AppLayoutContext = { mode, setMode };
+
+  const actions = (
+    <>
+      <Link to="/dashboard/notifications" className="ds-navbar__icon" aria-label="Notificaciones">
+        <BellIcon />
+      </Link>
+      <Link to="/dashboard/chats" className="ds-navbar__icon" aria-label="Chats">
+        <ChatIcon />
+      </Link>
+    </>
+  );
+
+  return (
+    <div className="app-shell">
+      <Navbar
+        brand={<BrandMark />}
+        mode={mode}
+        onModeChange={setMode}
+        userName={getDisplayName(user)}
+        actions={actions}
+        userMenuItems={[
+          { label: "Mi perfil", onClick: () => navigate("/dashboard/profile") },
+          { label: "Mis terrenos", onClick: () => navigate("/dashboard/lands") },
+          { label: "Pagos", onClick: () => navigate("/dashboard/payments") },
+        ]}
+        onSignOut={() => signOut({ redirectUrl: "/" })}
+      />
+      <main className="app-main">
+        <Outlet context={context} />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/Navbar.tsx
+++ b/apps/web/src/components/ui/Navbar.tsx
@@ -22,6 +22,8 @@ export interface NavbarProps {
   userMenuItems?: UserMenuItem[];
   /** Acción de cerrar sesión (se añade al final del menú de usuario). */
   onSignOut?: () => void;
+  /** Contenido opcional (p.ej. íconos de notificaciones/chats) antes del menú de usuario. */
+  actions?: ReactNode;
   className?: string;
 }
 
@@ -37,6 +39,7 @@ export default function Navbar({
   userName,
   userMenuItems = [],
   onSignOut,
+  actions,
   className,
 }: NavbarProps) {
   const [open, setOpen] = useState(false);
@@ -102,6 +105,7 @@ export default function Navbar({
       ) : null}
 
       <div className="ds-navbar__actions">
+        {actions}
         {userName ? (
           <div className="ds-usermenu" ref={menuRef}>
             <button

--- a/apps/web/src/components/ui/ui.css
+++ b/apps/web/src/components/ui/ui.css
@@ -255,6 +255,43 @@
   gap: 0.6rem;
 }
 
+/* botón de ícono para el slot `actions` (notificaciones, chats) */
+.ds-navbar__icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid transparent;
+  border-radius: var(--ts-radius);
+  background: transparent;
+  color: var(--ts-text-secondary);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ds-navbar__icon:hover {
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+}
+
+.ds-navbar__icon:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}
+
+.ds-navbar__icon-dot {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.45rem;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--ts-clay);
+}
+
 /* switch Busco / Ofrezco (segmented control) */
 .ds-segment {
   display: inline-flex;

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,0 +1,300 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useUser } from "@clerk/clerk-react";
+import type { ChatDto, LandDto, RentalRequestDto, RentalRequestStatus } from "@terrashare/shared";
+import { Badge, Button, Card } from "../components/ui";
+import type { BadgeTone } from "../components/ui";
+import { getChats, getMyLands, listRentalRequests } from "../services/api";
+import { getDisplayName } from "../components/authDisplay";
+import { useAppMode } from "../components/AppLayout";
+import "./home.css";
+
+type LoadState = "loading" | "ready" | "error";
+
+const REQUEST_STATUS: Record<RentalRequestStatus, { label: string; tone: BadgeTone }> = {
+  draft: { label: "Borrador", tone: "neutral" },
+  pending_owner: { label: "Pendiente", tone: "beige" },
+  approved: { label: "Aprobada", tone: "green" },
+  rejected: { label: "Rechazada", tone: "clay" },
+  cancelled: { label: "Cancelada", tone: "neutral" },
+  pending_payment: { label: "Pago pendiente", tone: "beige" },
+  paid: { label: "Pagada", tone: "green" },
+};
+
+const USE_LABELS: Record<string, string> = {
+  agricultura: "Agricultura",
+  ganaderia: "Ganadería",
+  forestal: "Forestal",
+  acuicultura: "Acuicultura",
+  mixto: "Mixto",
+  otro: "Otro",
+};
+
+function formatMonth(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("es-PA", { month: "short", year: "numeric" });
+}
+
+function formatPeriod(startDate?: string, endDate?: string): string {
+  return `${formatMonth(startDate)} – ${formatMonth(endDate)}`;
+}
+
+// ─── Modo Busco ───────────────────────────────────────────────────────────────
+function BuscoHome({ name }: { name: string }) {
+  const [requests, setRequests] = useState<RentalRequestDto[]>([]);
+  const [reqState, setReqState] = useState<LoadState>("loading");
+  const [chats, setChats] = useState<ChatDto[]>([]);
+  const [chatsState, setChatsState] = useState<LoadState>("loading");
+
+  useEffect(() => {
+    let active = true;
+    listRentalRequests()
+      .then((data) => {
+        if (!active) return;
+        setRequests(data);
+        setReqState("ready");
+      })
+      .catch(() => active && setReqState("error"));
+    getChats()
+      .then((data) => {
+        if (!active) return;
+        setChats(data);
+        setChatsState("ready");
+      })
+      .catch(() => active && setChatsState("error"));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="hm-head">
+        <div>
+          <h1 className="ts-title">Hola, {name}</h1>
+          <p>Encuentra el terreno ideal para tu proyecto.</p>
+        </div>
+      </div>
+
+      <Link to="/catalog" className="hm-search">
+        <span className="hm-search__box">Buscar por provincia, uso o palabra clave…</span>
+        <Button variant="primary">Ver mapa</Button>
+      </Link>
+
+      <section className="hm-section">
+        <div className="hm-section__head">
+          <h2 className="ts-title">Mis solicitudes</h2>
+        </div>
+        {reqState === "loading" ? (
+          <div className="hm-grid-3">
+            <div className="hm-skeleton" />
+            <div className="hm-skeleton" />
+            <div className="hm-skeleton" />
+          </div>
+        ) : reqState === "error" ? (
+          <Card>
+            <p className="hm-state hm-state--error">
+              No pudimos cargar tus solicitudes. Inténtalo de nuevo en un momento.
+            </p>
+          </Card>
+        ) : requests.length === 0 ? (
+          <Card>
+            <p className="hm-state">
+              Aún no tienes solicitudes. Explora el catálogo y solicita tu primer terreno.
+            </p>
+          </Card>
+        ) : (
+          <div className="hm-grid-3">
+            {requests.slice(0, 6).map((req) => {
+              const status = REQUEST_STATUS[req.status];
+              return (
+                <Card key={req.id}>
+                  <div className="hm-item__top">
+                    <span className="hm-item__title">{USE_LABELS[req.intendedUse] ?? req.intendedUse}</span>
+                    <Badge tone={status.tone}>{status.label}</Badge>
+                  </div>
+                  <div className="hm-item__meta">{formatPeriod(req.period?.startDate, req.period?.endDate)}</div>
+                  <p className="hm-item__note">Solicitud #{req.id.slice(0, 8)}</p>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <div className="hm-split">
+        <section className="hm-section">
+          <div className="hm-section__head">
+            <h2 className="ts-title">Guardados</h2>
+          </div>
+          {/* TODO(#137): no existe endpoint de favoritos/guardados todavía. */}
+          <Card>
+            <p className="hm-state">Todavía no guardas terrenos. Toca el corazón en un terreno para guardarlo aquí.</p>
+          </Card>
+        </section>
+
+        <section className="hm-section">
+          <div className="hm-section__head">
+            <h2 className="ts-title">Chats</h2>
+            <Link to="/dashboard/chats" className="hm-link">
+              Ver todos
+            </Link>
+          </div>
+          <Card flat>
+            {chatsState === "loading" ? (
+              <p className="hm-state">Cargando conversaciones…</p>
+            ) : chatsState === "error" ? (
+              <p className="hm-state hm-state--error">No pudimos cargar tus chats.</p>
+            ) : chats.length === 0 ? (
+              <p className="hm-state">Aún no tienes conversaciones.</p>
+            ) : (
+              <div className="hm-rows">
+                {chats.slice(0, 4).map((chat) => (
+                  <Link key={chat.id} to="/dashboard/chats" className="hm-row">
+                    <span className="hm-avatar" aria-hidden="true">
+                      TS
+                    </span>
+                    <div className="hm-row__body">
+                      <div className="hm-row__title">Conversación</div>
+                      {/* ChatDto no incluye el último mensaje; mostramos la fecha real. */}
+                      <div className="hm-row__sub">Actualizado {formatMonth(chat.updatedAt)}</div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </Card>
+        </section>
+      </div>
+    </>
+  );
+}
+
+// ─── Modo Ofrezco ───────────────────────────────────────────────────────────────
+function OfrezcoHome() {
+  const navigate = useNavigate();
+  const [lands, setLands] = useState<LandDto[]>([]);
+  const [landsState, setLandsState] = useState<LoadState>("loading");
+
+  useEffect(() => {
+    let active = true;
+    // Nota(#136): getMyLands() (GET /lands/me) está roto en el backend; se
+    // maneja el error con estado vacío/error, sin datos falsos.
+    getMyLands()
+      .then((data) => {
+        if (!active) return;
+        setLands(data);
+        setLandsState("ready");
+      })
+      .catch(() => active && setLandsState("error"));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const activeCount = landsState === "ready" ? String(lands.length) : "—";
+
+  return (
+    <>
+      <div className="hm-head">
+        <div>
+          <h1 className="ts-title">Tu tierra, trabajando por ti</h1>
+          <p>Gestiona tus publicaciones y las solicitudes que recibes.</p>
+        </div>
+        <Button variant="primary" onClick={() => navigate("/dashboard/lands")}>
+          Publicar terreno
+        </Button>
+      </div>
+
+      <div className="hm-stats">
+        <Card>
+          <div className="hm-stat__value">{activeCount}</div>
+          <div className="hm-stat__label">Publicaciones activas</div>
+        </Card>
+        <Card>
+          {/* TODO(#136): sin endpoint de solicitudes-por-dueño todavía. */}
+          <div className="hm-stat__value">—</div>
+          <div className="hm-stat__label">Solicitudes nuevas</div>
+        </Card>
+        <Card>
+          {/* TODO(#136): analítica de ingresos pendiente en backend. */}
+          <div className="hm-stat__value hm-stat__value--accent">—</div>
+          <div className="hm-stat__label">Ingresos del mes</div>
+        </Card>
+      </div>
+
+      <section className="hm-section">
+        <div className="hm-section__head">
+          <h2 className="ts-title">Solicitudes recibidas</h2>
+        </div>
+        {/* TODO(#136): no existe endpoint de solicitudes recibidas por el dueño. */}
+        <Card>
+          <p className="hm-state">
+            Cuando alguien solicite uno de tus terrenos, aparecerá aquí. (Pendiente de backend, #136.)
+          </p>
+        </Card>
+      </section>
+
+      <section className="hm-section">
+        <div className="hm-section__head">
+          <h2 className="ts-title">Mis publicaciones</h2>
+          <Link to="/dashboard/lands" className="hm-link">
+            Ver todas
+          </Link>
+        </div>
+        {landsState === "loading" ? (
+          <div className="hm-grid-3">
+            <div className="hm-skeleton" />
+            <div className="hm-skeleton" />
+            <div className="hm-skeleton" />
+          </div>
+        ) : landsState === "error" ? (
+          <Card>
+            <p className="hm-state hm-state--error">
+              No pudimos cargar tus terrenos ahora mismo. (Pendiente de backend, #136.)
+            </p>
+          </Card>
+        ) : lands.length === 0 ? (
+          <div className="hm-grid-3">
+            <Link to="/dashboard/lands" className="hm-add">
+              <span style={{ fontSize: "1.5rem", lineHeight: 1 }}>+</span>
+              Publicar tu primer terreno
+            </Link>
+          </div>
+        ) : (
+          <div className="hm-grid-3">
+            {lands.slice(0, 5).map((land) => (
+              <Card key={land.id} interactive onClick={() => navigate(`/lands/${land.id}`)}>
+                <div className="hm-item__top">
+                  <Badge tone={land.status === "active" ? "green" : "beige"}>
+                    {land.status === "active" ? "Publicada" : land.status === "draft" ? "Borrador" : "Inactiva"}
+                  </Badge>
+                </div>
+                <div className="hm-item__title" style={{ marginTop: "0.6rem" }}>
+                  {land.title}
+                </div>
+                <div className="hm-item__meta">
+                  {USE_LABELS[land.allowedUses?.[0]] ?? "Terreno"} · ${land.priceRule?.pricePerMonth?.toLocaleString("es-PA")}/mes
+                </div>
+              </Card>
+            ))}
+            <Link to="/dashboard/lands" className="hm-add">
+              <span style={{ fontSize: "1.5rem", lineHeight: 1 }}>+</span>
+              Publicar otro terreno
+            </Link>
+          </div>
+        )}
+      </section>
+    </>
+  );
+}
+
+export default function HomePage() {
+  const { mode } = useAppMode();
+  const { user } = useUser();
+  const name = getDisplayName(user).split(" ")[0];
+
+  return mode === "ofrezco" ? <OfrezcoHome /> : <BuscoHome name={name} />;
+}

--- a/apps/web/src/pages/app-shell.css
+++ b/apps/web/src/pages/app-shell.css
@@ -1,0 +1,11 @@
+/* Shell autenticado editorial (issue #134, Grupo 2). Navbar + contenido. */
+
+.app-shell {
+  width: min(1120px, 94vw);
+  margin: 0 auto;
+  padding: 1rem 0 3rem;
+}
+
+.app-main {
+  margin-top: 1.25rem;
+}

--- a/apps/web/src/pages/home.css
+++ b/apps/web/src/pages/home.css
@@ -1,0 +1,301 @@
+/* Home autenticada Busco/Ofrezco (issue #134, Grupo 2). Prefijo `hm-`. */
+
+.hm-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.hm-head h1 {
+  margin: 0 0 0.25rem;
+}
+
+.hm-head p {
+  margin: 0;
+  color: var(--ts-text-secondary);
+}
+
+/* Secciones */
+.hm-section {
+  margin-bottom: 2rem;
+}
+
+.hm-section__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.85rem;
+}
+
+.hm-section__head h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.hm-link {
+  color: var(--ts-green);
+  font-size: 0.88rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hm-link:hover {
+  text-decoration: underline;
+}
+
+/* Buscador (modo Busco) */
+.hm-search {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.hm-search__box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  padding: 0.7rem 0.9rem;
+  color: var(--ts-text-muted);
+  font-size: 0.95rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.15s ease;
+}
+
+.hm-search__box:hover {
+  border-color: var(--ts-sage-3);
+}
+
+/* Grillas */
+.hm-grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.hm-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.hm-split {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 1.5rem;
+}
+
+/* Tarjeta de solicitud / item */
+.hm-item__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.hm-item__title {
+  font-weight: 600;
+  font-size: 0.98rem;
+}
+
+.hm-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--ts-text-muted);
+  font-size: 0.82rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.hm-item__note {
+  color: var(--ts-text-secondary);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+/* Stats (modo Ofrezco) */
+.hm-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.hm-stat__value {
+  font-family: var(--ts-font-serif);
+  font-size: 1.9rem;
+  font-weight: 500;
+  color: var(--ts-green-ink);
+}
+
+.hm-stat__value--accent {
+  color: var(--ts-green);
+}
+
+.hm-stat__label {
+  color: var(--ts-text-muted);
+  font-size: 0.85rem;
+}
+
+/* Lista de filas (chats, solicitudes recibidas, publicaciones) */
+.hm-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.hm-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--ts-border);
+  text-decoration: none;
+  color: inherit;
+}
+
+.hm-row:last-child {
+  border-bottom: 0;
+}
+
+.hm-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.hm-row__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.hm-row__title {
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.hm-row__sub {
+  font-size: 0.82rem;
+  color: var(--ts-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hm-row__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.hm-unread {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--ts-green);
+  flex-shrink: 0;
+}
+
+/* Publicaciones (grid con métricas) */
+.hm-pub__meta {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.6rem;
+  color: var(--ts-text-secondary);
+  font-size: 0.82rem;
+}
+
+.hm-pub__meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+/* Tarjeta "añadir" con borde discontinuo */
+.hm-add {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  text-align: center;
+  border: 1px dashed var(--ts-beige-2);
+  border-radius: var(--ts-radius-lg);
+  background: var(--ts-surface-alt);
+  color: var(--ts-text-muted);
+  text-decoration: none;
+  padding: 1.25rem;
+  min-height: 120px;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.hm-add:hover {
+  border-color: var(--ts-green);
+  color: var(--ts-green);
+}
+
+/* Estados vacío/carga/error */
+.hm-state {
+  color: var(--ts-text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.hm-state--error {
+  color: var(--ts-clay);
+}
+
+.hm-skeleton {
+  height: 96px;
+  border-radius: var(--ts-radius-lg);
+  border: 1px solid var(--ts-border);
+  background: linear-gradient(
+    100deg,
+    var(--ts-surface-alt) 30%,
+    var(--ts-paper-tint) 50%,
+    var(--ts-surface-alt) 70%
+  );
+  background-size: 200% 100%;
+  animation: hm-shimmer 1.2s ease-in-out infinite;
+}
+
+@keyframes hm-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hm-skeleton {
+    animation: none;
+  }
+}
+
+@media (max-width: 820px) {
+  .hm-grid-3,
+  .hm-grid-2,
+  .hm-stats,
+  .hm-split {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Fase 2 · Grupo 2a — App shell autenticado + Home

Shell editorial (issue #134) para las páginas autenticadas, reutilizando el primitivo **Navbar** de la Fase 1, con la **home de dos modos** (Busco / Ofrezco).

> ⚠️ **PR apilado**. Base = `feature/134-web-landing` (#143). Orden de merge: **#142 → #143 → 2a → 2b**. Refs #134 (no cierra el épico).

### Cambios
- **Navbar** (primitivo): nuevo slot **aditivo** `actions` para íconos (notificaciones/chats) + estilos `ds-navbar__icon`. No cambia usos existentes.
- **AppLayout** (`components/AppLayout.tsx`): layout con Navbar (switch Busco/Ofrezco, menú usuario, cerrar sesión) y `<Outlet/>`. El **modo se comparte** con las páginas hijas vía `useOutletContext` (misma fuente que el switch, no se desincronizan) y se persiste en `localStorage` (backend → `// TODO(#137)`).
- **HomePage** (`pages/HomePage.tsx`):
  - **Busco**: saludo, buscador → `/catalog`, **Mis solicitudes** (`listRentalRequests`), **Guardados** (sin endpoint → vacío + `// TODO(#137)`), **Chats** (`getChats`).
  - **Ofrezco**: "Publicar terreno", stats, **Solicitudes recibidas** y **Mis publicaciones** (`getMyLands`). Como `getMyLands`/analítica están rotos (#136) y no hay endpoint de solicitudes-por-dueño, se muestran con **estado vacío/error + `// TODO(#136)`**, sin datos falsos.
  - Estados **loading / empty / error** en cada bloque.
- **App.tsx**: `/dashboard` pasa a rutas anidadas bajo `AppLayout`; se elimina el `DashboardPage` inline legacy (glass) y sus imports (`PaymentButton`, `useAuth`, `RentalRequestDto`).

### Verificación
- `tsc --noEmit` limpio; `vite build` OK. Sin `@ts-nocheck` ni `any`.
- Verificado en dev (Vite :5181 + API :3000) vía ruta temporal (ya retirada): **Busco** muestra solicitudes reales con estado/periodo; **Ofrezco** degrada con estados vacío/error #136; el switch persiste y comparte modo con la Navbar. Grids responsivos (3→1 col a ≤820px). `/dashboard` sin sesión redirige a `/login`.
- Accesibilidad: `aria-label` en íconos solo-glyph, `role=tab` en el switch (primitivo), `prefers-reduced-motion` en skeletons.

### Notas
- La home **Ofrezco** queda "hueca" en dev por #136 (backend en paralelo); es intencional (estados + TODO), no hardcodeo.
- No toca backend, `styles.css` legacy, `UserDashboardLayout` (lo siguen usando chats/notifs/pagos/perfil/mis-terrenos legacy) ni admin.
- **2b** (catálogo + detalle, incl. gateo de `/catalog` tras login) irá apilado sobre esta rama.