### PR TITLE
feat(web): catálogo tras login + detalle editorial (Fase 2, Grupo 2b) — Refs #134

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -364,7 +364,6 @@ export default function App() {
     <Routes>
       <Route path="/" element={<LandingPage />} />
       <Route path="/styleguide" element={<StyleguidePage />} />
-      <Route path="/catalog" element={<UserDashboardLayout><CatalogPage /></UserDashboardLayout>} />
       <Route path="/lands/:id" element={<LandDetailPage />} />
       <Route path="/reserve/:landId" element={<ProtectedRoute><ReservePage /></ProtectedRoute>} />
       <Route path="/login" element={<Login />} />
@@ -374,6 +373,7 @@ export default function App() {
       <Route path="/checkout/cancel" element={<PaymentCancelPage />} />
       <Route element={<ProtectedRoute><AppLayout /></ProtectedRoute>}>
         <Route path="/dashboard" element={<HomePage />} />
+        <Route path="/catalog" element={<CatalogPage />} />
       </Route>
       <Route path="/dashboard/lands" element={<ProtectedRoute><UserDashboardLayout><MyLandsPage /></UserDashboardLayout></ProtectedRoute>} />
       <Route path="/dashboard/chats" element={<ProtectedRoute><UserDashboardLayout><ChatsPage /></UserDashboardLayout></ProtectedRoute>} />

--- a/apps/web/src/data/lands.ts
+++ b/apps/web/src/data/lands.ts
@@ -133,33 +133,6 @@ const LANDS = [
   },
 ];
 
-const DEFAULT_CHAT_MESSAGES: Record<string, { id: string; role: string; text: string; createdAt: string }[]> = {
-  1: [
-    {
-      id: "1-seed-1",
-      role: "owner",
-      text: "Hola, soy Manuel. El terreno está disponible de inmediato y puedo compartir más fotos si las necesitas.",
-      createdAt: "2026-04-22T09:00:00.000Z",
-    },
-  ],
-  2: [
-    {
-      id: "2-seed-1",
-      role: "owner",
-      text: "Hola, Rosa por aquí. El lote tiene agua permanente y cercas recientes.",
-      createdAt: "2026-04-22T09:10:00.000Z",
-    },
-  ],
-  3: [
-    {
-      id: "3-seed-1",
-      role: "owner",
-      text: "Te puedo confirmar disponibilidad para este mes y coordinar una visita.",
-      createdAt: "2026-04-22T09:20:00.000Z",
-    },
-  ],
-};
-
 // Mock/legacy land shape — these helpers handle both the seed data below and
 // API-shaped objects, so the structural type stays intentionally permissive.
 type LandLike = Record<string, any>;
@@ -228,10 +201,6 @@ export function filterLands(lands: LandLike[], filters: LandFilterOptions = {}) 
 
     return matchesType && matchesProvince && matchesPrice && matchesQuery;
   });
-}
-
-export function getChatSeedMessages(landId: string) {
-  return DEFAULT_CHAT_MESSAGES[landId] ?? [];
 }
 
 export function normalizeReserveLand(land: LandLike | null | undefined) {

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -1,151 +1,255 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { LandDto } from "@terrashare/shared";
+import { Input } from "../components/ui";
 import { listLands } from "../services/api";
 import PanamaMap from "../components/PanamaMap";
+import "./catalog.css";
 
-type CatalogLand = LandDto & { type?: string; water?: string; access?: string };
+type LoadState = "loading" | "ready" | "error";
 
+const USE_LABELS: Record<string, string> = {
+  agricultura: "Agricultura",
+  ganaderia: "Ganadería",
+  forestal: "Forestal",
+  acuicultura: "Acuicultura",
+  mixto: "Mixto",
+  otro: "Otro",
+};
 
+function formatUse(use?: string): string {
+  if (!use) return "Terreno";
+  return USE_LABELS[use] ?? use;
+}
+
+function PinIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
+function PhotoIcon() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.5-3.5L9 20" />
+    </svg>
+  );
+}
 
 export default function CatalogPage() {
   const navigate = useNavigate();
-  const [type, setType] = useState("Todos");
-  const [province, setProvince] = useState("Todas");
-  const [maxPrice, setMaxPrice] = useState(1500);
+  const searchId = useId();
+  const useId_ = useId();
+  const provinceId = useId();
+  const priceId = useId();
+
+  const [lands, setLands] = useState<LandDto[]>([]);
+  const [status, setStatus] = useState<LoadState>("loading");
+
   const [query, setQuery] = useState("");
+  const [use, setUse] = useState("todos");
+  const [province, setProvince] = useState("todas");
+  const [maxPrice, setMaxPrice] = useState(3000);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [lands, setLands] = useState<CatalogLand[]>([]);
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const fetchLands = async () => {
-      try {
-        const data = await listLands();
-        setLands(data || []);
-      } catch (err) {
-        console.error("Error fetching lands:", err);
-      }
-      setLoading(false);
+    let active = true;
+    listLands()
+      .then((data) => {
+        if (!active) return;
+        setLands(data);
+        setStatus("ready");
+      })
+      .catch((err) => {
+        console.error("Error cargando catálogo:", err);
+        if (active) setStatus("error");
+      });
+    return () => {
+      active = false;
     };
-    fetchLands();
   }, []);
 
-  const filteredLands = useMemo(() => {
+  const useOptions = useMemo(
+    () => [...new Set(lands.map((l) => l.allowedUses?.[0]).filter((v): v is NonNullable<typeof v> => Boolean(v)))],
+    [lands],
+  );
+  const provinceOptions = useMemo(
+    () => [...new Set(lands.map((l) => l.location?.province).filter((v): v is string => Boolean(v)))],
+    [lands],
+  );
+
+  const filtered = useMemo(() => {
     return lands.filter((land) => {
-      const landType = land.allowedUses?.[0] || land.type || "otro";
-      const price = land.priceRule?.pricePerMonth || 0;
-      const matchesType = type === "Todos" || landType === type;
-      const matchesProvince = province === "Todas" || land.location?.province === province;
+      const landUse = land.allowedUses?.[0] ?? "otro";
+      const price = land.priceRule?.pricePerMonth ?? 0;
+      const matchesUse = use === "todos" || landUse === use;
+      const matchesProvince = province === "todas" || land.location?.province === province;
       const matchesPrice = price <= maxPrice;
       const haystack = [land.title, land.location?.province, land.location?.district, land.description]
         .filter(Boolean)
         .join(" ")
         .toLowerCase();
       const matchesQuery = !query || haystack.includes(query.toLowerCase());
-      return matchesType && matchesProvince && matchesPrice && matchesQuery;
+      return matchesUse && matchesProvince && matchesPrice && matchesQuery;
     });
-  }, [lands, type, province, maxPrice, query]);
+  }, [lands, use, province, maxPrice, query]);
 
-  const USE_FILTERS = useMemo(() => ["Todos", ...new Set(lands.map((l) => l.allowedUses?.[0] || l.type).filter(Boolean))], [lands]);
-  const PROVINCE_FILTERS = useMemo(() => ["Todas", ...new Set(lands.map((l) => l.location?.province).filter(Boolean))], [lands]);
-
-  const selectedLand = filteredLands.find((l) => l.id === selectedId) || filteredLands[0];
-
-  const handlePinClick = (land: CatalogLand) => setSelectedId(land.id);
+  const selectedLand = filtered.find((l) => l.id === selectedId) ?? filtered[0] ?? null;
 
   return (
-    <div className="page-shell">
-      <main>
-        <div className="section-header">
-          <p className="kicker">Catálogo</p>
-          <h1>Terrenos Disponibles</h1>
-          <p>Explora y encuentra el terreno perfecto en Panama.</p>
+    <>
+      <div className="cat-head">
+        <h1 className="ts-title">Terrenos disponibles</h1>
+        <p>Explora en el mapa y encuentra el terreno ideal en Panamá.</p>
+      </div>
+
+      <div className="cat-filters">
+        <div className="cat-filter">
+          <label htmlFor={searchId}>Buscar</label>
+          <Input
+            id={searchId}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Provincia, uso o palabra clave…"
+          />
         </div>
+        <div className="cat-filter">
+          <label htmlFor={useId_}>Uso</label>
+          <select id={useId_} value={use} onChange={(e) => setUse(e.target.value)}>
+            <option value="todos">Todos</option>
+            {useOptions.map((opt) => (
+              <option key={opt} value={opt}>
+                {formatUse(opt)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="cat-filter">
+          <label htmlFor={provinceId}>Provincia</label>
+          <select id={provinceId} value={province} onChange={(e) => setProvince(e.target.value)}>
+            <option value="todas">Todas</option>
+            {provinceOptions.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="cat-filter">
+          <label htmlFor={priceId}>Precio máx.</label>
+          <input
+            id={priceId}
+            type="range"
+            min={300}
+            max={3000}
+            step={50}
+            value={maxPrice}
+            onChange={(e) => setMaxPrice(Number(e.target.value))}
+          />
+          <span className="cat-range__value">${maxPrice.toLocaleString("es-PA")}/mes</span>
+        </div>
+        {/* TODO(#140): el tipo de operación (alquiler/venta) aún no existe en el
+            backend; el filtro se muestra deshabilitado para no simular que filtra. */}
+        <div className="cat-filter">
+          <label aria-hidden="true">&nbsp;</label>
+          <span className="cat-soon" role="note" title="Disponible próximamente">
+            Alquiler / Venta
+            <span className="cat-soon__tag">Próximamente</span>
+          </span>
+        </div>
+      </div>
 
-        <section className="catalog-workspace glass-panel">
-          <aside className="catalog-map-panel">
-            <div className="section-header compact">
-              <h1>Mapa</h1>
-              <p>Vista geográfica</p>
+      <div className="cat-meta">
+        {status === "ready" ? `${filtered.length} terreno${filtered.length === 1 ? "" : "s"}` : " "}
+      </div>
+
+      <div className="cat-workspace">
+        <div>
+          {status === "loading" ? (
+            <div className="cat-list">
+              <div className="cat-skeleton" />
+              <div className="cat-skeleton" />
+              <div className="cat-skeleton" />
             </div>
-            <PanamaMap
-              lands={filteredLands}
-              selectedLand={selectedLand}
-              onSelectLand={(land) => setSelectedId(land.id)}
-            />
-          </aside>
-
-          <section className="catalog-list-panel">
-            <div className="catalog-filters glass-card">
-              <div className="filters-grid">
-                <label>
-                  Buscar
-                  <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Provincia, uso..." />
-                </label>
-                <label>
-                  Uso
-                  <select value={type} onChange={(e) => setType(e.target.value)}>
-                    {USE_FILTERS.map((opt) => <option key={opt} value={opt}>{opt}</option>)}
-                  </select>
-                </label>
-                <label>
-                  Provincia
-                  <select value={province} onChange={(e) => setProvince(e.target.value)}>
-                    {PROVINCE_FILTERS.map((opt) => <option key={opt} value={opt}>{opt}</option>)}
-                  </select>
-                </label>
-                <label>
-                  Precio máximo
-                  <input type="range" min="300" max="1500" step="50" value={maxPrice} onChange={(e) => setMaxPrice(Number(e.target.value))} />
-                  <span className="range-value">${maxPrice}</span>
-                </label>
-              </div>
-            </div>
-
-            <div className="catalog-meta">
-              <span>{filteredLands.length} resultados</span>
-              {selectedLand && <span>Seleccionado: {selectedLand.title}</span>}
-            </div>
-
-            <div className="cards-grid catalog-results-grid">
-              {filteredLands.map((land) => {
-                const active = selectedLand?.id === land.id;
+          ) : status === "error" ? (
+            <p className="cat-state cat-state--error">
+              No pudimos cargar el catálogo ahora mismo. Vuelve a intentarlo en un momento.
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="cat-state">No hay terrenos que coincidan con estos filtros.</p>
+          ) : (
+            <div className="cat-list">
+              {filtered.map((land) => {
+                const price = land.priceRule?.pricePerMonth;
                 return (
-                  <article
+                  <div
                     key={land.id}
-                    className={`land-card ${active ? "active" : ""}`}
-                    onClick={() => setSelectedId(land.id)}
+                    className={`cat-card ${selectedLand?.id === land.id ? "is-active" : ""}`}
                     role="button"
                     tabIndex={0}
+                    onClick={() => setSelectedId(land.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedId(land.id);
+                      }
+                    }}
+                    onDoubleClick={() => navigate(`/lands/${land.id}`)}
                   >
-                    <div className="land-card-top">
-                      <span className="card-badge">{land.allowedUses?.[0]}</span>
-                      <span className="land-pill">{land.area} ha</span>
+                    <div className="cat-card__thumb" aria-hidden="true">
+                      <PhotoIcon />
                     </div>
-                    <h2>{land.title}</h2>
-                    <p>{land.location?.province} · {land.location?.district}</p>
-                    <p className="land-muted">Agua: {land.water || "No especificado"}</p>
-                    <p className="land-muted">Acceso: {land.access || "No especificado"}</p>
-                    <p className="card-price">${land.priceRule?.pricePerMonth}/mes</p>
-                    <div className="card-actions">
-                      <button className="btn btn-ghost" onClick={(e) => { e.stopPropagation(); navigate(`/lands/${land.id}`); }}>
+                    <div className="cat-card__body">
+                      <div className="cat-card__top">
+                        <span className="cat-card__title">{land.title}</span>
+                        <span className="ds-badge ds-badge--green">{formatUse(land.allowedUses?.[0])}</span>
+                      </div>
+                      <div className="cat-card__meta">
+                        <PinIcon />
+                        {land.location?.province} · {land.area} ha
+                      </div>
+                      <div className="cat-card__price">
+                        {typeof price === "number" ? (
+                          <>
+                            ${price.toLocaleString("es-PA")}
+                            <span>/mes</span>
+                          </>
+                        ) : (
+                          <span>Precio a consultar</span>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        className="ds-btn ds-btn--ghost ds-btn--sm"
+                        style={{ marginTop: "0.5rem" }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          navigate(`/lands/${land.id}`);
+                        }}
+                      >
                         Ver detalle
                       </button>
                     </div>
-                  </article>
+                  </div>
                 );
               })}
             </div>
+          )}
+        </div>
 
-            {loading ? (
-              <div className="glass-panel empty-state"><p>Cargando...</p></div>
-            ) : filteredLands.length === 0 ? (
-              <div className="glass-panel empty-state"><p>No hay terrenos para esos filtros.</p></div>
-            ) : null}
-          </section>
-        </section>
-      </main>
-    </div>
+        <div className="cat-map">
+          <PanamaMap
+            lands={filtered}
+            selectedLand={selectedLand}
+            onSelectLand={(land) => setSelectedId(land.id)}
+          />
+        </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/src/pages/LandDetailPage.tsx
+++ b/apps/web/src/pages/LandDetailPage.tsx
@@ -1,144 +1,130 @@
 import { useEffect, useState } from "react";
-import type { FormEvent } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { useAuth, useClerk, useUser } from "@clerk/clerk-react";
-import type { ChatDto, LandDto } from "@terrashare/shared";
-import { getLandPrimaryUse, formatLandUse, getChatSeedMessages } from "../data/lands";
-import { getLandById, getChats, createChat, getMessages, sendMessage, getExternalContact } from "../services/api";
-import PublicHeader from "../components/PublicHeader";
+import { useClerk, useUser } from "@clerk/clerk-react";
+import type { LandDto } from "@terrashare/shared";
+import { Badge, Button, Card } from "../components/ui";
+import { createChat, getLandById } from "../services/api";
+import PanamaMap from "../components/PanamaMap";
+import "./detail.css";
 
-interface ChatMessageVM {
-  id: string;
-  role: string;
-  text: string;
-  createdAt: string;
-}
+type Operation = "alquiler" | "venta" | "ambas";
 
+// Campos que llegarán con #138 (agua/acceso/características/título) y #140
+// (operación y precio de venta). Aún no existen en LandDto; se leen de forma
+// opcional para dejar lista la variante de venta.
 type DetailLand = LandDto & {
-  features?: string[];
-  areaHectares?: number;
+  operation?: Operation;
+  salePrice?: number;
   water?: string;
   access?: string;
+  titleStatus?: string;
+  features?: string[];
 };
 
-interface ExternalContactVM {
-  phone: string;
+const USE_LABELS: Record<string, string> = {
+  agricultura: "Agricultura",
+  ganaderia: "Ganadería",
+  forestal: "Forestal",
+  acuicultura: "Acuicultura",
+  mixto: "Mixto",
+  otro: "Otro",
+};
+
+function formatUse(use?: string): string {
+  if (!use) return "Terreno";
+  return USE_LABELS[use] ?? use;
 }
 
-function useChat(
-  landId: string | undefined,
-  isSignedIn: boolean | undefined,
-  user: { id: string } | null | undefined,
-) {
-  const { getToken } = useAuth();
-  const [messages, setMessages] = useState<ChatMessageVM[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [chatId, setChatId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [externalContact, setExternalContact] = useState<ExternalContactVM | null>(null);
+function formatMonth(iso?: string): string {
+  if (!iso) return "Ahora";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "Ahora";
+  return `Desde ${d.toLocaleDateString("es-PA", { month: "short", year: "numeric" })}`;
+}
 
-  useEffect(() => {
-    if (!isSignedIn || !user) {
-      const stored = sessionStorage.getItem(`terrashare-chat:${landId}`);
-      const seed = getChatSeedMessages(landId!);
-      setMessages(stored ? JSON.parse(stored) : seed);
-      setLoading(false);
-      return;
-    }
+// TODO(#140): sin campo de operación en el backend, el detalle es de alquiler
+// por defecto. La rama de venta queda lista para cuando #140 lo aporte.
+function getOperation(land: DetailLand): Operation {
+  return land.operation ?? "alquiler";
+}
 
-    const initChat = async () => {
-      try {
-        const token = await getToken();
-        if (!token) throw new Error("No token");
+function PinIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
 
-        const chats = await getChats();
-        let chat: ChatDto | null | undefined = chats.find((c) => c.landId === landId && c.participants.some((p) => p.userId === user.id));
+function PhotoIcon({ size = 40 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.5-3.5L9 20" />
+    </svg>
+  );
+}
 
-        if (!chat) {
-          chat = await createChat({
-            landId,
-            participants: [{ userId: user.id, role: "tenant" }],
-          });
-        }
+function RulerIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M3 9l6-6 12 12-6 6z" />
+      <path d="M7 9l1.5 1.5M10 6l1.5 1.5M13 9l1.5 1.5M9 13l1.5 1.5" />
+    </svg>
+  );
+}
 
-        if (chat) {
-          setChatId(chat.id);
-          const msgs = await getMessages(chat.id);
-          setMessages(msgs.map((m) => ({
-            id: m.id,
-            role: m.senderId === user.id ? "tenant" : "owner",
-            text: m.text,
-            createdAt: m.createdAt,
-          })));
+function CalendarIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M16 2v4M8 2v4M3 10h18" />
+    </svg>
+  );
+}
 
-          try {
-            const contact = await getExternalContact(chat.id);
-            if (contact?.whatsappEnabled && contact?.contact?.phone) {
-              setExternalContact(contact.contact);
-            }
-          } catch (contactErr) {
-            console.error("Could not fetch WhatsApp contact:", contactErr);
-          }
-        }
-      } catch (err) {
-        console.error("Error initializing chat:", err);
-        const stored = sessionStorage.getItem(`terrashare-chat:${landId}`);
-        const seed = getChatSeedMessages(landId!);
-        setMessages(stored ? JSON.parse(stored) : seed);
-      } finally {
-        setLoading(false);
-      }
-    };
+function DropletIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 2.7 6.3 8.4a8 8 0 1 0 11.4 0Z" />
+    </svg>
+  );
+}
 
-    initChat();
-  }, [landId, isSignedIn, user]);
+function RoadIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M4 22 8 2M20 22 16 2M12 6v3M12 13v3M12 20v1" />
+    </svg>
+  );
+}
 
-  useEffect(() => {
-    if (!isSignedIn && messages.length > 0) {
-      sessionStorage.setItem(`terrashare-chat:${landId}`, JSON.stringify(messages));
-    }
-  }, [messages, landId, isSignedIn]);
+function CertificateIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="9" r="6" />
+      <path d="m9 14-1 8 4-2 4 2-1-8" />
+    </svg>
+  );
+}
 
-  const addMessage = async (text: string) => {
-    if (!isSignedIn || !chatId) {
-      const newMsg: ChatMessageVM = {
-        id: crypto.randomUUID(),
-        role: "tenant",
-        text,
-        createdAt: new Date().toISOString(),
-      };
-      setMessages((prev) => [...prev, newMsg]);
-      return;
-    }
+function CheckIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
 
-    try {
-      const msg = await sendMessage(chatId, text);
-      setMessages((prev) => [...prev, {
-        id: msg!.id,
-        role: "tenant",
-        text: msg!.text,
-        createdAt: msg!.createdAt,
-      }]);
-    } catch (err) {
-      console.error("Error sending message:", err);
-      const newMsg = {
-        id: crypto.randomUUID(),
-        role: "tenant",
-        text,
-        createdAt: new Date().toISOString(),
-      };
-      setMessages((prev) => [...prev, newMsg]);
-    }
-  };
-
-  const clearMessages = () => {
-    setMessages([]);
-    if (!isSignedIn) {
-      sessionStorage.removeItem(`terrashare-chat:${landId}`);
-    }
-  };
-
-  return { messages, loading, addMessage, clearMessages, externalContact };
+function UserIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  );
 }
 
 export default function LandDetailPage() {
@@ -146,29 +132,28 @@ export default function LandDetailPage() {
   const navigate = useNavigate();
   const { openSignIn } = useClerk();
   const { isSignedIn, user } = useUser();
-  const [message, setMessage] = useState("");
-  const [land, setLand] = useState<DetailLand | null>(null);
-  const [landLoading, setLandLoading] = useState(true);
-  const [landError, setLandError] = useState<string | null>(null);
 
-  const { messages, loading: chatLoading, addMessage, clearMessages, externalContact } = useChat(id, isSignedIn, user);
+  const [land, setLand] = useState<DetailLand | null>(null);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 
   useEffect(() => {
-    const fetchLand = async () => {
-      try {
-        const data = await getLandById(id!);
+    let active = true;
+    getLandById(id!)
+      .then((data) => {
+        if (!active) return;
         setLand(data);
-      } catch (err) {
-        console.error("Error fetching land:", err);
-        setLandError(err instanceof Error ? err.message : "Error al cargar terreno");
-      } finally {
-        setLandLoading(false);
-      }
+        setStatus(data ? "ready" : "error");
+      })
+      .catch((err) => {
+        console.error("Error cargando terreno:", err);
+        if (active) setStatus("error");
+      });
+    return () => {
+      active = false;
     };
-    fetchLand();
   }, [id]);
 
-  const handleRequest = async () => {
+  const handleRent = () => {
     if (!isSignedIn) {
       openSignIn({ redirectUrl: `/reserve/${id}` });
       return;
@@ -176,130 +161,197 @@ export default function LandDetailPage() {
     navigate(`/reserve/${id}`, { state: { land } });
   };
 
-  const handleSend = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const text = message.trim();
-    if (!text) return;
-    setMessage("");
-    await addMessage(text);
+  const handleContact = async () => {
+    if (!isSignedIn || !user) {
+      openSignIn({ redirectUrl: `/lands/${id}` });
+      return;
+    }
+    try {
+      await createChat({ landId: id, participants: [{ userId: user.id, role: "tenant" }] });
+    } catch (err) {
+      console.error("No se pudo iniciar el chat:", err);
+    }
+    navigate("/dashboard/chats");
   };
 
-  if (landLoading) {
+  if (status === "loading") {
     return (
-      <div className="page-shell">
-        <div className="glass-panel empty-state">
-          <p>Cargando terreno...</p>
+      <div className="det">
+        <p className="det-state">Cargando terreno…</p>
+      </div>
+    );
+  }
+
+  if (status === "error" || !land) {
+    return (
+      <div className="det">
+        <div className="det-state">
+          <h1 className="ts-title">Terreno no encontrado</h1>
+          <p>El terreno que buscas no existe o no está disponible.</p>
+          <Link to="/catalog" className="ds-btn ds-btn--primary" style={{ marginTop: "1rem" }}>
+            Volver al catálogo
+          </Link>
         </div>
       </div>
     );
   }
 
-  if (landError || !land) {
-    return (
-      <div className="page-shell">
-        <div className="glass-panel empty-state">
-          <h1>Terreno no encontrado</h1>
-          <p>{landError || "El terreno que buscas no existe."}</p>
-          <Link to="/catalog" className="btn btn-primary">Volver al catálogo</Link>
-        </div>
-      </div>
-    );
-  }
-
-  const primaryUse = formatLandUse(getLandPrimaryUse(land));
+  const operation = getOperation(land);
+  const isSale = operation === "venta" || operation === "ambas";
+  const monthly = land.priceRule?.pricePerMonth;
+  const locationParts = [land.location?.province, land.location?.district, land.location?.corregimiento ?? land.location?.addressLine].filter(Boolean);
 
   return (
-    <div className="page-shell">
-      <PublicHeader />
+    <div className="det">
+      <Link to="/catalog" className="det-back">
+        ← Volver al catálogo
+      </Link>
 
-      <main>
-        <Link to="/catalog" className="back-link-text">← Volver al catálogo</Link>
-
-        <section className="detail-hero glass-panel">
-          <div>
-            <span className="card-badge">{primaryUse}</span>
-            <h1>{land.title}</h1>
-            <p>{land.location?.province} · {land.location?.district}</p>
-            <p className="detail-summary">{land.description}</p>
+      <div className="det-gallery" aria-hidden="true">
+        <div className="det-gallery__main">
+          <PhotoIcon size={44} />
+        </div>
+        <div className="det-gallery__side">
+          <div className="det-gallery__tile">
+            <PhotoIcon size={24} />
           </div>
-          <div className="detail-price-box">
-            <strong>${land.priceRule?.pricePerMonth}</strong>
-            <span>/ mes</span>
+          <div className="det-gallery__tile">
+            <PhotoIcon size={24} />
           </div>
-        </section>
+        </div>
+      </div>
 
-        <section className="detail-grid">
-          <div className="glass-panel detail-main-panel">
-            <h2>Características</h2>
-            <div className="feature-grid">
-              {(land.features || []).map((feature) => (
-                <div key={feature} className="feature-chip">{feature}</div>
-              ))}
+      <div className="det-body">
+        <div>
+          <div className="det-badges">
+            <Badge tone="green">{formatUse(land.allowedUses?.[0])}</Badge>
+            <Badge tone={isSale ? "clay" : "beige"}>{isSale ? "En venta" : "Alquiler"}</Badge>
+          </div>
+          <h1 className="ts-title det-title">{land.title}</h1>
+          <p className="det-loc">
+            <PinIcon />
+            {locationParts.join(" · ")}
+          </p>
+
+          <div className="det-specs">
+            <div className="det-spec">
+              <RulerIcon />
+              <div className="det-spec__label">Área</div>
+              <div className="det-spec__value">{land.area} hectáreas</div>
             </div>
-
-            <div className="detail-specs">
-              <div><span>Área</span><strong>{land.areaHectares} ha</strong></div>
-              <div><span>Agua</span><strong>{land.water}</strong></div>
-              <div><span>Acceso</span><strong>{land.access}</strong></div>
-              <div><span>Disponible desde</span><strong>{land.availability?.availableFrom ?? "Ahora"}</strong></div>
+            <div className="det-spec">
+              <CalendarIcon />
+              <div className="det-spec__label">Disponible</div>
+              <div className="det-spec__value">{formatMonth(land.availability?.availableFrom)}</div>
             </div>
-
-            <button className="btn btn-primary btn-full" onClick={handleRequest}>
-              Solicitar alquiler
-            </button>
-          </div>
-
-          <div className="glass-panel chat-panel">
-            <div className="chat-header">
-              <div>
-                <h2>Chat interno</h2>
-                <p>{isSignedIn ? "Mensajes guardados en el servidor" : "Inicia sesión para chatear con el propietario"}</p>
+            {/* Agua/Acceso/Título llegan con #138; se muestran solo si existen. */}
+            {land.water ? (
+              <div className="det-spec">
+                <DropletIcon />
+                <div className="det-spec__label">Agua</div>
+                <div className="det-spec__value">{land.water}</div>
               </div>
-              <div style={{ display: "flex", gap: "0.5rem" }}>
-                {externalContact && (
-                  <a
-                    href={`https://wa.me/${externalContact.phone.replace(/[^0-9]/g, "")}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn-ghost"
-                    style={{ background: "#25D366", color: "white", borderColor: "#25D366" }}
-                  >
-                    WhatsApp
-                  </a>
+            ) : null}
+            {land.access ? (
+              <div className="det-spec">
+                <RoadIcon />
+                <div className="det-spec__label">Acceso</div>
+                <div className="det-spec__value">{land.access}</div>
+              </div>
+            ) : null}
+            {isSale && land.titleStatus ? (
+              <div className="det-spec">
+                <CertificateIcon />
+                <div className="det-spec__label">Título</div>
+                <div className="det-spec__value">{land.titleStatus}</div>
+              </div>
+            ) : null}
+          </div>
+
+          {land.description ? (
+            <>
+              <h2 className="det-section-title">Descripción</h2>
+              <p className="det-desc">{land.description}</p>
+            </>
+          ) : null}
+
+          {land.features && land.features.length > 0 ? (
+            <>
+              <h2 className="det-section-title">Características</h2>
+              <div className="det-features">
+                {land.features.map((f) => (
+                  <span key={f} className="det-feature">
+                    <CheckIcon />
+                    {f}
+                  </span>
+                ))}
+              </div>
+            </>
+          ) : null}
+        </div>
+
+        <aside className="det-aside">
+          <Card>
+            {isSale ? (
+              <>
+                <div className="det-price__label">Precio de venta</div>
+                <div className="det-price">
+                  {typeof land.salePrice === "number" ? `$${land.salePrice.toLocaleString("es-PA")}` : "A consultar"}
+                </div>
+              </>
+            ) : (
+              <div className="det-price">
+                {typeof monthly === "number" ? (
+                  <>
+                    ${monthly.toLocaleString("es-PA")}
+                    <span> /mes</span>
+                  </>
+                ) : (
+                  "A consultar"
                 )}
-                <button className="btn btn-ghost" onClick={clearMessages}>Limpiar</button>
+              </div>
+            )}
+
+            <div className="det-actions">
+              {isSale ? (
+                // TODO(#140): flujo de oferta de compra pendiente; por ahora
+                // deriva al contacto con el propietario.
+                <Button variant="primary" block onClick={handleContact}>
+                  Hacer oferta
+                </Button>
+              ) : (
+                <Button variant="primary" block onClick={handleRent}>
+                  Solicitar alquiler
+                </Button>
+              )}
+              <Button variant="secondary" block onClick={handleContact}>
+                Contactar al dueño
+              </Button>
+            </div>
+
+            <div className="det-owner">
+              <span className="det-owner__avatar" aria-hidden="true">
+                <UserIcon />
+              </span>
+              <div>
+                <div className="det-owner__name">Propietario</div>
+                {/* TODO(#138): perfil del propietario (nombre, tiempo de respuesta). */}
+                <div className="det-owner__role">Publica en TerraShare</div>
               </div>
             </div>
 
-            <div className="chat-thread">
-              {chatLoading ? (
-                <div className="chat-empty">Cargando mensajes...</div>
-              ) : messages.length === 0 ? (
-                <div className="chat-empty">Aún no hay mensajes.</div>
-              ) : (
-                messages.map((item) => (
-                  <div key={item.id} className={`chat-bubble ${item.role === "tenant" ? "chat-bubble-user" : "chat-bubble-owner"}`}>
-                    <span>{item.text}</span>
-                  </div>
-                ))
-              )}
+            <div className="det-map">
+              <PanamaMap lands={[land]} selectedLand={land} onSelectLand={() => {}} />
             </div>
 
-            <form className="chat-form" onSubmit={handleSend}>
-              <textarea
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                placeholder={isSignedIn ? "Escribe tu mensaje..." : "Inicia sesión para enviar mensajes"}
-                rows={3}
-                disabled={!isSignedIn}
-              />
-              <button className="btn btn-primary" type="submit" disabled={!message.trim() || !isSignedIn}>
-                Enviar
-              </button>
-            </form>
-          </div>
-        </section>
-      </main>
+            {isSale ? (
+              <p className="det-note">
+                La compra se cierra ante notaría. TerraShare conecta a las partes y gestiona la reserva.
+              </p>
+            ) : null}
+          </Card>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -1,0 +1,254 @@
+/* Catálogo editorial (issue #134, Grupo 2b). Prefijo `cat-`. */
+
+.cat-head {
+  margin-bottom: 1.25rem;
+}
+
+.cat-head h1 {
+  margin: 0 0 0.25rem;
+}
+
+.cat-head p {
+  margin: 0;
+  color: var(--ts-text-secondary);
+}
+
+/* Barra de filtros */
+.cat-filters {
+  display: grid;
+  grid-template-columns: 1.4fr repeat(3, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+  margin-bottom: 1.25rem;
+}
+
+.cat-filter label {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--ts-text);
+  margin-bottom: 0.35rem;
+}
+
+.cat-range__value {
+  display: inline-block;
+  margin-top: 0.3rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ts-green);
+}
+
+.cat-filter select {
+  width: 100%;
+  font-family: var(--ts-font-sans);
+  font-size: 0.95rem;
+  color: var(--ts-text);
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  padding: 0.7rem 0.9rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.cat-filter select:focus {
+  outline: none;
+  border-color: var(--ts-green);
+  box-shadow: var(--ts-ring);
+}
+
+.cat-filter input[type="range"] {
+  width: 100%;
+  accent-color: var(--ts-green);
+}
+
+/* control deshabilitado "Próximamente" (operación alquiler/venta, #140) */
+.cat-soon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--ts-surface);
+  border: 1px dashed var(--ts-beige-2);
+  border-radius: var(--ts-radius);
+  padding: 0.6rem 0.8rem;
+  color: var(--ts-text-muted);
+  font-size: 0.9rem;
+  cursor: not-allowed;
+}
+
+.cat-soon__tag {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--ts-beige);
+  color: var(--ts-green-soft);
+  border-radius: var(--ts-radius-pill);
+  padding: 0.12rem 0.5rem;
+}
+
+/* Workspace lista + mapa */
+.cat-workspace {
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.cat-meta {
+  font-size: 0.85rem;
+  color: var(--ts-text-muted);
+  margin-bottom: 0.85rem;
+}
+
+.cat-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+/* Tarjeta de terreno (horizontal) */
+.cat-card {
+  display: flex;
+  gap: 0.9rem;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-lg);
+  padding: 0.85rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.cat-card:hover {
+  border-color: var(--ts-sage-3);
+  box-shadow: var(--ts-shadow);
+  transform: translateY(-2px);
+}
+
+.cat-card.is-active {
+  border-color: var(--ts-green);
+  box-shadow: var(--ts-ring);
+}
+
+.cat-card:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}
+
+.cat-card__thumb {
+  flex-shrink: 0;
+  width: 92px;
+  height: 74px;
+  border-radius: var(--ts-radius);
+  background: var(--ts-tint-green-2);
+  color: var(--ts-green);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cat-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.cat-card__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.cat-card__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.cat-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--ts-text-muted);
+  font-size: 0.82rem;
+  margin: 0.3rem 0;
+}
+
+.cat-card__price {
+  font-family: var(--ts-font-serif);
+  font-size: 1.1rem;
+  color: var(--ts-green-ink);
+}
+
+.cat-card__price span {
+  font-family: var(--ts-font-sans);
+  font-size: 0.82rem;
+  color: var(--ts-text-muted);
+}
+
+/* Mapa enmarcado */
+.cat-map {
+  position: relative;
+  height: 560px;
+  border-radius: var(--ts-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--ts-border);
+  position: sticky;
+  top: 1rem;
+}
+
+/* Estados */
+.cat-state {
+  text-align: center;
+  color: var(--ts-text-muted);
+  padding: 2.5rem 1rem;
+}
+
+.cat-state--error {
+  color: var(--ts-clay);
+}
+
+.cat-skeleton {
+  height: 92px;
+  border-radius: var(--ts-radius-lg);
+  border: 1px solid var(--ts-border);
+  background: linear-gradient(
+    100deg,
+    var(--ts-surface-alt) 30%,
+    var(--ts-paper-tint) 50%,
+    var(--ts-surface-alt) 70%
+  );
+  background-size: 200% 100%;
+  animation: cat-shimmer 1.2s ease-in-out infinite;
+}
+
+@keyframes cat-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cat-skeleton {
+    animation: none;
+  }
+}
+
+@media (max-width: 940px) {
+  .cat-filters {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .cat-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .cat-map {
+    height: 360px;
+    position: relative;
+    top: auto;
+    order: -1;
+  }
+}

--- a/apps/web/src/pages/detail.css
+++ b/apps/web/src/pages/detail.css
@@ -1,0 +1,252 @@
+/* Detalle de terreno editorial (issue #134, Grupo 2b). Prefijo `det-`.
+   Página pública (compartible); las acciones exigen login. */
+
+.det {
+  width: min(1080px, 94vw);
+  margin: 0 auto;
+  padding: 1rem 0 3rem;
+}
+
+.det-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--ts-text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  padding: 0.5rem 0;
+}
+
+.det-back:hover {
+  color: var(--ts-green);
+}
+
+/* Galería (placeholders neutros: aún no hay imágenes reales, #138) */
+.det-gallery {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 0.6rem;
+  margin: 0.75rem 0 1.5rem;
+}
+
+.det-gallery__main {
+  height: 260px;
+  border-radius: var(--ts-radius-lg);
+  background: var(--ts-tint-green-2);
+  color: var(--ts-green);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.det-gallery__side {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.det-gallery__tile {
+  border-radius: var(--ts-radius-lg);
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Cuerpo */
+.det-body {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.det-badges {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.det-title {
+  margin: 0 0 0.35rem;
+}
+
+.det-loc {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--ts-text-secondary);
+  font-size: 0.95rem;
+  margin: 0 0 1.25rem;
+}
+
+.det-loc svg {
+  color: var(--ts-green);
+  flex-shrink: 0;
+}
+
+.det-specs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.6rem;
+  margin-bottom: 1.5rem;
+}
+
+.det-spec {
+  background: var(--ts-surface-alt);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  padding: 0.85rem;
+}
+
+.det-spec svg {
+  color: var(--ts-green);
+}
+
+.det-spec__label {
+  font-size: 0.8rem;
+  color: var(--ts-text-muted);
+  margin-top: 0.3rem;
+}
+
+.det-spec__value {
+  font-weight: 600;
+}
+
+.det-section-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.det-desc {
+  color: var(--ts-text-secondary);
+  font-size: 0.95rem;
+  margin: 0 0 1.5rem;
+  line-height: 1.65;
+}
+
+.det-features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.det-feature {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--ts-text-secondary);
+  background: var(--ts-surface-alt);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-pill);
+  padding: 0.35rem 0.75rem;
+}
+
+.det-feature svg {
+  color: var(--ts-green);
+}
+
+/* Panel lateral (precio + acciones) */
+.det-aside {
+  position: sticky;
+  top: 1rem;
+}
+
+.det-price__label {
+  font-size: 0.82rem;
+  color: var(--ts-text-muted);
+}
+
+.det-price {
+  font-family: var(--ts-font-serif);
+  font-size: 1.9rem;
+  font-weight: 500;
+  color: var(--ts-green-ink);
+  margin-bottom: 0.85rem;
+}
+
+.det-price span {
+  font-family: var(--ts-font-sans);
+  font-size: 0.95rem;
+  color: var(--ts-text-muted);
+}
+
+.det-actions {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.det-owner {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ts-border);
+}
+
+.det-owner__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+  flex-shrink: 0;
+}
+
+.det-owner__name {
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.det-owner__role {
+  font-size: 0.8rem;
+  color: var(--ts-text-muted);
+}
+
+.det-map {
+  position: relative;
+  height: 150px;
+  border-radius: var(--ts-radius);
+  overflow: hidden;
+  margin-top: 1rem;
+  border: 1px solid var(--ts-border);
+}
+
+.det-note {
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  color: var(--ts-text-secondary);
+  background: var(--ts-surface-alt);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  padding: 0.7rem 0.8rem;
+}
+
+/* Estados */
+.det-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--ts-text-muted);
+}
+
+@media (max-width: 820px) {
+  .det-body {
+    grid-template-columns: 1fr;
+  }
+
+  .det-aside {
+    position: relative;
+    top: auto;
+  }
+
+  .det-specs {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Fase 2 · Grupo 2b — Catálogo (tras login) + Detalle

Porta al estilo editorial (issue #134) el **catálogo** y el **detalle de terreno**, reutilizando `AppLayout`/`Navbar` y los primitivos de la Fase 1.

> ⚠️ **PR apilado**. Base = `feature/134-web-home` (#144). Orden de merge: **#142 → #143 → #144(2a) → 2b**. Refs #134 (no cierra el épico).

### Catálogo (`/catalog`)
- **Gateado**: `ProtectedRoute` + `AppLayout` (catálogo tras login; sin sesión → `/login`). Verificado.
- Filtros **uso / provincia / precio** + buscador. **Filtro Alquiler/Venta DESHABILITADO "Próximamente"** (`// TODO(#140)`) — no se muestra activo-inerte.
- Lista de tarjetas editoriales + **`PanamaMap` enmarcado** (reutilizado, sin tocar su interior; pines desde `lat/lng` reales).
- Estados **loading / empty / error**; datos reales vía `listLands`.

### Detalle (`/lands/:id`)
- Reescrito editorial; **sigue público** (compartible). Las acciones exigen login.
- **Variante alquiler/venta lista en código**, default alquiler (`getOperation` → `// TODO(#140)`; la rama de venta lee `operation`/`salePrice`/`titleStatus` futuros).
- **Quita el chat inline con seed** → CTA **"Contactar al dueño"** (sin sesión → `openSignIn`; con sesión → `createChat` → `/dashboard/chats`). Verificado que sin sesión abre el sign-in.
- Specs **solo con campos reales** (área, disponibilidad); **agua/acceso/características/título condicionales** (`// TODO(#138)`, no se inventan). Propietario mínimo desde `ownerId` (sin nombre/tiempo de respuesta falsos).
- Mini-mapa con `PanamaMap` enmarcado.

### Limpieza
- `data/lands.ts`: eliminados `getChatSeedMessages` + `DEFAULT_CHAT_MESSAGES` (seed de chat). Se conservan `normalizeReserveLand`/`formatLandUse` (los usa `ReservePage` legacy).

### Verificación
- `tsc --noEmit` limpio; `vite build` OK. Sin `@ts-nocheck` ni `any`.
- En dev (Vite :5181 + API :3000, vía ruta temporal `/__preview/catalog` ya retirada): catálogo con 20 terrenos reales + mapa + filtro "Próximamente"; `/catalog` sin sesión → `/login`; detalle con badges alquiler, specs reales (Área/Disponible), precio $/mes y CTAs; "Contactar al dueño" abre el sign-in de Clerk. `/styleguide` y páginas legacy siguen cargando.
- Accesibilidad: labels en filtros, `aria-label`/roles, `prefers-reduced-motion` en skeletons, copy en español.

### Notas
- No toca backend, `styles.css` legacy, `UserDashboardLayout` (chats/notifs/pagos/perfil/mis-terrenos siguen legacy) ni admin.
- La operación alquiler/venta real y agua/acceso/características llegan con #140/#138; aquí quedan como TODO condicionales, sin datos falsos.