### PR TITLE
docs: actualizar stack a TanStack Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Plataforma para alquiler de terrenos (agricultura, ganaderia y otros usos produc
 - Notas historicas: [docs/CLERK_TOKENS_REMOVAL.md](docs/CLERK_TOKENS_REMOVAL.md)
 
 ## Stack tecnologico
-- Frontend: React + Vite + Clerk (unificado en `apps/web`)
-- Backend: Bun + Hono (`apps/backend-api`)
+- Frontend: TanStack Start (React, modo SPA) sobre Vite 7 + Clerk (unificado en `apps/web`). Routing por archivos en `apps/web/src/routes/`.
+- Backend: Bun + Hono + Zod (`apps/backend-api`)
 - Base de datos: MongoDB + Mongoose
 - Testing E2E: Playwright
 - CI/CD: GitHub Actions
+- MCP server propio: planeado (epico #234)
+- Docker: planeado (issue #233)
 
 ## Estado actual
 - `apps/web`: frontend unificado (landing + dashboard + admin)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Arquitectura tecnica - TerraShare
 
 ## 1. Stack acordado
-- Frontend: React + Vite + Clerk (unificado en `apps/web`)
-- Backend: Bun + Hono (`apps/backend-api`)
+- Frontend: TanStack Start (React, modo SPA) sobre Vite 7 + Clerk (unificado en `apps/web`). Routing por archivos en `apps/web/src/routes/`.
+- Backend: Bun + Hono + Zod (`apps/backend-api`)
 - Base de datos: MongoDB + Mongoose
 - Runtime y package manager: Bun
 - Testing E2E: Playwright
@@ -21,7 +21,7 @@ packages/
 ## 3. Diagrama de arquitectura
 ```mermaid
 flowchart LR
-    U[Usuario Web] --> FE[Frontend React + Vite + Tailwind]
+    U[Usuario Web] --> FE[Frontend TanStack Start React SPA sobre Vite]
     FE --> API[Backend API Hono sobre Bun]
     API --> AUTH[Auth y RBAC]
     API --> DB[(MongoDB + Mongoose)]

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -219,5 +219,5 @@ chore/<slug>                     # Chore
 
 - MongoDB requiere estar instalado y corriendo localmente
 - El backend usa Bun como runtime
-- Frontend usa Vite + React 18
+- Frontend usa TanStack Start (React, modo SPA) sobre Vite 7
 - Autenticación via Clerk

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -189,9 +189,10 @@ Dolores principales:
 
 | Tecnología | Versión | Uso |
 |------------|---------|-----|
-| React | 18.3.1 | Framework UI |
-| Vite | 5.4.10 | Build tool |
-| React Router DOM | 6.30.1 | Enrutamiento |
+| React | 18.3.1 | Librería UI |
+| TanStack Start | 1.168 | Framework frontend full-stack (modo SPA) |
+| TanStack Router | 1.170 | Enrutamiento por archivos (`src/routes/`) |
+| Vite | 7.3.6 | Build tool / dev server |
 | @clerk/clerk-react | 5.0.0 | Autenticación |
 | Leaflet + react-leaflet | 1.9.4 / 4.2.1 | Mapas |
 | @stripe/react-stripe-js | 6.3.0 | Pagos frontend |
@@ -569,7 +570,7 @@ metadata?: Record<string, any>;
 | D-05 | Base de datos: MongoDB |
 | D-06 | Runtime backend: Bun |
 | D-07 | Framework API: Hono |
-| D-08 | Framework frontend: React |
+| D-08 | Framework frontend: TanStack Start (React, modo SPA sobre Vite 7) |
 | D-09 | Mapa: Leaflet + react-leaflet |
 | D-10 | Descubrimiento: listado + mapa con filtros |
 | D-11 | Chat: mixto (interno + WhatsApp con teléfono) |
@@ -606,10 +607,10 @@ TerraShare-v1/
 │   │   │   ├── pages/
 │   │   │   ├── hooks/
 │   │   │   ├── services/
-│   │   │   └── App.jsx
-│   │   ├── public/
+│   │   │   ├── routes/                  # Rutas file-based (TanStack Start)
+│   │   │   └── router.tsx
 │   │   ├── tests/
-│   │   ├── vite.config.js
+│   │   ├── vite.config.ts
 │   │   └── package.json
 │   │
 │   ├── backend-api/                  # Backend Bun + Hono


### PR DESCRIPTION
Actualiza la documentación para reflejar el stack actual del frontend tras la migración (PR #236):

- **README.md** · **ARCHITECTURE.md** · **MIGRATION.md** · **PRD.md**: `apps/web` ahora es **TanStack Start (React, modo SPA) sobre Vite 7** con routing por archivos (`src/routes/`), en vez de Vite 5 + react-router-dom.
- Tabla de stack del PRD: Vite 5.4.10 → 7.3.6, se reemplaza React Router DOM por TanStack Start/Router.
- Se añaden como planeados: MCP server (épico #234) y Docker (#233).

Solo documentación, sin cambios de código.