### PR TITLE
feat(auth): cuenta única (Busco/Ofrezco) + onboarding persistente (#137)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -15,7 +15,7 @@ export interface IUser extends Document {
   email: string;
   role: AppRole;
   status: UserStatus;
-  profile: { fullName: string; phone?: string };
+  profile: { fullName: string; phone?: string; province?: string; marketPreference?: "busco" | "ofrezco" };
   deletedAt?: Date;
   createdAt: Date;
   updatedAt: Date;
@@ -144,6 +144,8 @@ const UserSchema = new Schema<IUser>({
   profile: {
     fullName: { type: String, required: true },
     phone: String,
+    province: String,
+    marketPreference: { type: String, enum: ["busco", "ofrezco"] },
   },
   deletedAt: { type: Date, default: null },
 }, { timestamps: true });

--- a/apps/backend-api/src/middleware/require-auth.test.ts
+++ b/apps/backend-api/src/middleware/require-auth.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { ensureUserInMongo, __resetMongoUserSync } from "./require-auth";
+import { User } from "../db/schemas";
+import type { AuthContextUser } from "../types";
+
+function makeUser(id: string): AuthContextUser {
+  return {
+    id,
+    clerkUserId: id,
+    email: `${id}@example.com`,
+    role: "user",
+    status: "active",
+    profile: { fullName: "Test User", phone: "+50760000000" },
+  };
+}
+
+describe("ensureUserInMongo (#137 D-4)", () => {
+  afterEach(() => {
+    __resetMongoUserSync();
+  });
+
+  it("upserts the authenticated user into the Mongo users collection", async () => {
+    await ensureUserInMongo(makeUser("user_clerk_real"));
+
+    const doc = await User.findOne({ clerkUserId: "user_clerk_real" }).lean();
+    expect(doc).not.toBeNull();
+    expect(doc?.email).toBe("user_clerk_real@example.com");
+    expect(doc?.profile.fullName).toBe("Test User");
+  });
+
+  it("is idempotent: a second call does not duplicate the user", async () => {
+    await ensureUserInMongo(makeUser("user_dupe"));
+    __resetMongoUserSync(); // fuerza reintento de escritura, no cache
+    await ensureUserInMongo(makeUser("user_dupe"));
+
+    const count = await User.countDocuments({ clerkUserId: "user_dupe" });
+    expect(count).toBe(1);
+  });
+
+  it("does not overwrite onboarding data on later logins ($setOnInsert)", async () => {
+    // El usuario ya existe con datos de onboarding (provincia/preferencia).
+    await User.create({
+      clerkUserId: "user_onb",
+      email: "user_onb@example.com",
+      role: "user",
+      status: "active",
+      profile: { fullName: "Onb User", province: "Chiriquí", marketPreference: "ofrezco" },
+    });
+
+    await ensureUserInMongo(makeUser("user_onb"));
+
+    const doc = await User.findOne({ clerkUserId: "user_onb" }).lean();
+    expect(doc?.profile.province).toBe("Chiriquí");
+    expect(doc?.profile.marketPreference).toBe("ofrezco");
+  });
+});

--- a/apps/backend-api/src/middleware/require-auth.ts
+++ b/apps/backend-api/src/middleware/require-auth.ts
@@ -6,9 +6,46 @@ import { failure } from "../lib/api-response";
 import type { AuthContextUser } from "../types";
 import { resolveClerkAuthUser } from "../lib/clerk-user";
 import { getStore } from "../store/in-memory-db";
+import { User } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 let jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
+
+// Usuarios ya sincronizados a Mongo en este proceso: evita un write por request.
+const mongoSyncedUsers = new Set<string>();
+
+/**
+ * Asegura que el usuario autenticado por Clerk exista en la colección `users`
+ * de Mongo para que aparezca en el panel admin (#137, D-4). Usa $setOnInsert
+ * para no pisar datos de onboarding (provincia/preferencia) en logins futuros.
+ */
+export async function ensureUserInMongo(user: AuthContextUser): Promise<void> {
+  if (mongoSyncedUsers.has(user.clerkUserId)) return;
+  mongoSyncedUsers.add(user.clerkUserId);
+  try {
+    await User.updateOne(
+      { clerkUserId: user.clerkUserId },
+      {
+        $setOnInsert: {
+          clerkUserId: user.clerkUserId,
+          email: user.email,
+          role: user.role,
+          status: user.status,
+          profile: { fullName: user.profile.fullName, phone: user.profile.phone },
+        },
+      },
+      { upsert: true },
+    );
+  } catch {
+    // No romper la auth si Mongo falla; se reintenta en el próximo proceso.
+    mongoSyncedUsers.delete(user.clerkUserId);
+  }
+}
+
+/** Limpia la caché de sincronización a Mongo (solo para tests). */
+export function __resetMongoUserSync(): void {
+  mongoSyncedUsers.clear();
+}
 
 function getJwks() {
   if (!jwks) {
@@ -92,6 +129,9 @@ export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
     if (persistedUser.status !== "active") {
       return failure(c, 403, "FORBIDDEN", "User is blocked");
     }
+
+    // D-4: registrar al usuario real de Clerk en Mongo (aparece en admin).
+    await ensureUserInMongo(persistedUser);
 
     c.set("authUser", persistedUser);
     await next();

--- a/apps/backend-api/src/routes/auth-extra.test.ts
+++ b/apps/backend-api/src/routes/auth-extra.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { requestJson } from "../lib/http-test-utils";
+import { User } from "../db/schemas";
 
 describe("auth routes - extended coverage", () => {
   it("GET /auth/me returns user profile", async () => {
@@ -20,6 +21,41 @@ describe("auth routes - extended coverage", () => {
     expect(response.status).toBe(200);
     expect(payload.ok).toBe(true);
     expect(payload.data.profile.phone).toBe("+50761234567");
+  });
+
+  // #137: el onboarding persiste provincia y preferencia (Busco/Ofrezco).
+  it("PATCH /auth/profile persists province + marketPreference (onboarding)", async () => {
+    const { response, payload } = await requestJson("/api/v1/auth/profile", {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_onboarding" },
+      body: { phone: "+50769998888", province: "Veraguas", marketPreference: "ofrezco" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(payload.data.profile.province).toBe("Veraguas");
+    expect(payload.data.profile.marketPreference).toBe("ofrezco");
+
+    // Se refleja en /auth/me.
+    const me = await requestJson("/api/v1/auth/me", {
+      headers: { "x-dev-user-id": "user_onboarding" },
+    });
+    expect(me.payload.data.profile.province).toBe("Veraguas");
+    expect(me.payload.data.profile.marketPreference).toBe("ofrezco");
+
+    // Persistido en Mongo (aparece en admin, D-4).
+    const doc = await User.findOne({ clerkUserId: "user_onboarding" }).lean();
+    expect(doc?.profile.province).toBe("Veraguas");
+    expect(doc?.profile.marketPreference).toBe("ofrezco");
+  });
+
+  it("PATCH /auth/profile rejects an invalid marketPreference", async () => {
+    const { response, payload } = await requestJson("/api/v1/auth/profile", {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_bad_pref" },
+      body: { marketPreference: "vendo" },
+    });
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
   });
 
   it("admin can access admin routes", async () => {

--- a/apps/backend-api/src/routes/auth.ts
+++ b/apps/backend-api/src/routes/auth.ts
@@ -16,11 +16,27 @@ authRoutes.get("/auth/me", requireAuth, (c) => {
 authRoutes.patch("/auth/profile", requireAuth, async (c) => {
   const authUser = c.get("authUser");
   const body = (await c.req.json().catch(() => null)) as
-    | { fullName?: string; phone?: string }
+    | { fullName?: string; phone?: string; province?: string; marketPreference?: "busco" | "ofrezco" }
     | null;
 
-  if (!body || (body.fullName === undefined && body.phone === undefined)) {
-    return failure(c, 400, "VALIDATION_ERROR", "Provide fullName and/or phone");
+  const hasAnyField =
+    body &&
+    (body.fullName !== undefined ||
+      body.phone !== undefined ||
+      body.province !== undefined ||
+      body.marketPreference !== undefined);
+
+  if (!hasAnyField) {
+    return failure(
+      c,
+      400,
+      "VALIDATION_ERROR",
+      "Provide fullName, phone, province and/or marketPreference",
+    );
+  }
+
+  if (body.marketPreference !== undefined && !["busco", "ofrezco"].includes(body.marketPreference)) {
+    return failure(c, 400, "VALIDATION_ERROR", "marketPreference must be 'busco' or 'ofrezco'");
   }
 
   const store = getStore();
@@ -29,14 +45,29 @@ authRoutes.patch("/auth/profile", requireAuth, async (c) => {
     ...existing.profile,
     ...(body.fullName !== undefined ? { fullName: body.fullName } : {}),
     ...(body.phone !== undefined ? { phone: body.phone } : {}),
+    ...(body.province !== undefined ? { province: body.province } : {}),
+    ...(body.marketPreference !== undefined ? { marketPreference: body.marketPreference } : {}),
   };
 
   // Update the in-memory store (the source require-auth reads from).
   const updatedUser = { ...existing, profile: nextProfile };
   store.users.set(authUser.id, updatedUser);
 
-  // Persist to Mongo if the user exists there (no-op for dev-bypass users).
-  await User.updateOne({ clerkUserId: authUser.id }, { profile: nextProfile });
+  // Persist to Mongo. Upsert so el onboarding funciona aunque el usuario aún no
+  // exista en Mongo; $setOnInsert cubre los campos requeridos del schema (#137).
+  await User.updateOne(
+    { clerkUserId: authUser.id },
+    {
+      $set: { profile: nextProfile },
+      $setOnInsert: {
+        clerkUserId: authUser.id,
+        email: authUser.email,
+        role: authUser.role,
+        status: authUser.status,
+      },
+    },
+    { upsert: true },
+  );
 
   return success(c, updatedUser);
 });

--- a/apps/backend-api/src/types.ts
+++ b/apps/backend-api/src/types.ts
@@ -2,6 +2,9 @@ export type AppRole = "user" | "admin";
 
 export type UserStatus = "active" | "blocked";
 
+/** Preferencia de lado del mercado en el modelo de cuenta única (#137). */
+export type MarketPreference = "busco" | "ofrezco";
+
 export interface AuthContextUser {
   id: string;
   clerkUserId: string;
@@ -12,6 +15,8 @@ export interface AuthContextUser {
   profile: {
     fullName: string;
     phone?: string;
+    province?: string;
+    marketPreference?: MarketPreference;
   };
 }
 

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button, Card, Field, Input } from "../components/ui";
 import { PANAMA_PROVINCES } from "../data/panama-provinces";
+import { updateMyProfile } from "../services/api";
 import "./auth.css";
 
 type Preference = "busco" | "ofrezco";
@@ -33,14 +34,27 @@ export default function OnboardingPage() {
   const [phone, setPhone] = useState("");
   const [province, setProvince] = useState("");
   const [preference, setPreference] = useState<Preference>("busco");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // TODO(#137): persistir teléfono, provincia y preferencia inicial (Busco/
-    // Ofrezco) en el perfil del usuario. Hoy no hay endpoint para provincia ni
-    // preferencia; se capturan en el estado de la UI (phone/province/preference)
-    // y solo se usan para elegir la vista inicial.
-    navigate({ to: preference === "ofrezco" ? "/dashboard/lands" : "/catalog" });
+    setSaving(true);
+    setError("");
+    try {
+      // Persiste teléfono, provincia y preferencia inicial (Busco/Ofrezco) en el
+      // perfil del usuario vía PATCH /auth/profile (#137).
+      await updateMyProfile({
+        phone: phone || undefined,
+        province: province || undefined,
+        marketPreference: preference,
+      });
+      navigate({ to: preference === "ofrezco" ? "/dashboard/lands" : "/catalog" });
+    } catch {
+      setError("No se pudo guardar tu información. Intenta de nuevo.");
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -110,8 +124,14 @@ export default function OnboardingPage() {
             </p>
           </div>
 
-          <Button type="submit" block>
-            Empezar
+          {error ? (
+            <p className="au-onb__error" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <Button type="submit" block disabled={saving}>
+            {saving ? "Guardando…" : "Empezar"}
           </Button>
         </form>
       </Card>

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -281,6 +281,8 @@ export const getExternalContact = async (chatId: string): Promise<ExternalContac
 export interface UserProfile {
   fullName?: string;
   phone?: string;
+  province?: string;
+  marketPreference?: "busco" | "ofrezco";
 }
 
 interface MeResponse {

--- a/docs/SETUP_AND_COMMANDS.md
+++ b/docs/SETUP_AND_COMMANDS.md
@@ -70,6 +70,30 @@ Nota:
 - El contrato para backend esta en `docs/MODULE_INTEGRATION_CONTRACTS.md`.
 - Setup detallado de Stripe en dev: `docs/STRIPE_DEV_SETUP.md`.
 
+## 4.2 Autenticacion en desarrollo (#137)
+
+El backend admite dos modos de autenticacion en dev, conmutables por entorno:
+
+- **Dev-bypass** (`ALLOW_DEV_AUTH_BYPASS=true`, valor por defecto fuera de
+  produccion): enviando las cabeceras `x-dev-user-id` y opcionalmente
+  `x-dev-role: admin` se sintetiza un usuario sin pasar por Clerk. Util para
+  probar rutas sin tokens. **Los usuarios dev viven en el store en memoria**, no
+  se sincronizan a Mongo.
+- **Token real de Clerk**: enviando `Authorization: Bearer <jwt>` con un token de
+  sesion real, el backend lo valida contra el JWKS (`CLERK_JWKS_URL` /
+  `CLERK_ISSUER`). Este camino **hace upsert del usuario en la coleccion `users`
+  de Mongo** (aparece en el panel admin, D-4) y enriquece email/nombre via la
+  Clerk Backend API cuando el token no los trae (requiere `CLERK_SECRET_KEY`, ver
+  #132). El bypass sigue disponible aunque haya token real, segun la cabecera.
+
+Para forzar solo tokens reales en un entorno (o en produccion), poner
+`ALLOW_DEV_AUTH_BYPASS=false`.
+
+**Rol admin (D-5):** el rol `admin` se asigna automaticamente al usuario cuyo
+email coincide con `ADMIN_SEED_EMAIL`. Antes de produccion, revisar/rotar ese
+valor y preferir asignar el rol via `public_metadata` de Clerk en vez del email
+semilla.
+
 ## 5. Arranque sugerido en equipo
 1. Clonar repo.
 2. Configurar variables de entorno en cada modulo.


### PR DESCRIPTION
## Qué

Completa el **modelo de cuenta única** (Busco/Ofrezco): persiste el onboarding y registra a los usuarios reales de Clerk en Mongo. La UI de onboarding y el switch ya existían (del rediseño #134); este cambio los **conecta con el backend**.

## Estado por hallazgo

| # | Antes | Ahora |
|---|-------|-------|
| **D-1** permisos por ownership | ✅ ya (auth-helpers) | Sin cambios |
| **D-2** onboarding persiste | ❌ `TODO` en UI, sin campos ni endpoint | `province` + `marketPreference` en el perfil; `PATCH /auth/profile` los persiste; OnboardingPage los envía |
| **D-3** token real en dev | ✅ parcial (#132 + bypass) | Documentado en `SETUP_AND_COMMANDS.md` |
| **D-4** usuario en Mongo | ❌ solo store en memoria | `require-auth` hace **upsert a la colección `users`** en el camino de token real |
| **D-5** admin por email semilla | ✅ existe | Nota de revisión pre-producción |

## Cambios

- **`types.ts` + `schemas.ts`**: perfil admite `province` y `marketPreference` (`busco`|`ofrezco`).
- **`routes/auth.ts`**: `PATCH /auth/profile` acepta/valida/persiste los campos nuevos (upsert a Mongo).
- **`middleware/require-auth.ts`**: `ensureUserInMongo` con caché por proceso y `$setOnInsert` (no pisa datos de onboarding en logins futuros).
- **`OnboardingPage.tsx`**: el submit persiste vía `updateMyProfile` antes de navegar; estado de guardado + error.
- **`docs/SETUP_AND_COMMANDS.md`**: modos de auth en dev (bypass vs token real) + nota de rol admin.

## Verificación

- ✅ **199 tests pass / 0 fail**. Nuevos: `ensureUserInMongo` (upsert idempotente + `$setOnInsert` preserva onboarding), persistencia de `province`/`marketPreference` reflejada en la respuesta, en `/auth/me` y en **Mongo**, y rechazo de preferencia inválida.
- ✅ `tsc --noEmit` limpio en backend y web.
- ✅ El route guard de `/onboarding` redirige a login sin sesión (flujo correcto), sin errores de consola.

Closes #137