### PR TITLE
feat(web): páginas de contratos, privacidad, auditoría y observabilidad (rescate de #240)

### DIFF
--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useClerk } from "@clerk/clerk-react";
-import { LayoutDashboard, Flag, Map, Users, Mail, LogOut, Sprout } from "lucide-react";
+import { LayoutDashboard, Flag, Map, Users, Mail, LogOut, Sprout, ScrollText, Activity } from "lucide-react";
 import "../pages/admin.css";
 
 interface AdminLayoutProps {
@@ -14,6 +14,8 @@ const NAV = [
   { to: "/dashboard/admin/lands", label: "Terrenos", icon: Map },
   { to: "/dashboard/admin/users", label: "Usuarios", icon: Users },
   { to: "/dashboard/admin/leads", label: "Leads", icon: Mail },
+  { to: "/dashboard/admin/audit", label: "Auditoria", icon: ScrollText },
+  { to: "/dashboard/admin/observability", label: "Observabilidad", icon: Activity },
 ];
 
 /** Layout editorial del panel admin: sidebar oscuro + contenido. Sustituye al

--- a/apps/web/src/components/UserDashboardLayout.tsx
+++ b/apps/web/src/components/UserDashboardLayout.tsx
@@ -51,7 +51,9 @@ export default function UserDashboardLayout({ children, onSignOut }: UserDashboa
           { label: "Mi perfil", onClick: () => navigate({ to: "/dashboard/profile" }) },
           { label: "Mis solicitudes", onClick: () => navigate({ to: "/dashboard" }) },
           { label: "Mis terrenos", onClick: () => navigate({ to: "/dashboard/lands" }) },
+          { label: "Contratos", onClick: () => navigate({ to: "/dashboard/contracts" }) },
           { label: "Pagos", onClick: () => navigate({ to: "/dashboard/payments" }) },
+          { label: "Privacidad", onClick: () => navigate({ to: "/dashboard/privacy" }) },
         ]}
         onSignOut={handleSignOut}
       />

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -11,5 +11,16 @@
     "area": "Area",
     "price": "Price/month",
     "search": "Search lands..."
+  },
+  "privacy": {
+    "title": "Privacy & data",
+    "subtitle": "Manage your personal data and account",
+    "export_title": "Export my data",
+    "export_desc": "Download a copy of the personal data stored on the platform (GDPR).",
+    "export_button": "Export data",
+    "delete_title": "Delete my account",
+    "delete_desc": "Permanently delete your account. Your personal data will be anonymized.",
+    "delete_button": "Delete account",
+    "retention_title": "Data retention"
   }
 }

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -11,5 +11,16 @@
     "area": "Area",
     "price": "Precio/mes",
     "search": "Buscar terrenos..."
+  },
+  "privacy": {
+    "title": "Privacidad y datos",
+    "subtitle": "Gestiona tus datos personales y tu cuenta",
+    "export_title": "Exportar mis datos",
+    "export_desc": "Descarga una copia de tus datos personales almacenados en la plataforma (RGPD).",
+    "export_button": "Exportar datos",
+    "delete_title": "Eliminar mi cuenta",
+    "delete_desc": "Elimina tu cuenta de forma permanente. Tus datos personales se anonimizaran.",
+    "delete_button": "Eliminar cuenta",
+    "retention_title": "Retencion de datos"
   }
 }

--- a/apps/web/src/pages/AdminAuditPage.tsx
+++ b/apps/web/src/pages/AdminAuditPage.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+import { useAuth, useUser } from "@clerk/clerk-react";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+
+interface AuditEventItem {
+  id: string;
+  actorId: string;
+  actorRole: string;
+  entity: string;
+  action: string;
+  entityId: string;
+  metadata?: Record<string, any>;
+  createdAt: string;
+}
+
+const entityLabels: Record<string, string> = {
+  auth: "Autenticación",
+  user: "Usuario",
+  land: "Terreno",
+  rental_request: "Solicitud",
+  contract: "Contrato",
+  payment: "Pago",
+  chat: "Chat",
+};
+
+const actionLabels: Record<string, string> = {
+  created: "Creado",
+  updated: "Actualizado",
+  deleted: "Eliminado",
+  approved: "Aprobado",
+  rejected: "Rechazado",
+  cancelled: "Cancelado",
+  paid: "Pagado",
+  status_changed: "Estado cambiado",
+};
+
+export default function AdminAuditPage() {
+  const { user } = useUser();
+  const { getToken } = useAuth();
+  const [events, setEvents] = useState<AuditEventItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [page, setPage] = useState(1);
+  const PAGE_SIZE = 20;
+
+  useEffect(() => {
+    if (!user) return;
+    setLoading(true);
+    const fetchData = async () => {
+      try {
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        const token = await getToken();
+        if (token) headers["Authorization"] = `Bearer ${token}`;
+        else if (import.meta.env.DEV) { headers["x-dev-role"] = "admin"; headers["x-dev-user-id"] = "web_dev_admin"; }
+        const res = await fetch(`${BASE_URL}/api/v1/audit-events`, { headers });
+        const json = await res.json();
+        // El endpoint de main devuelve un array plano en `data`; toleramos también
+        // una eventual forma paginada { items } por si el backend cambia más adelante.
+        const list: AuditEventItem[] = Array.isArray(json?.data)
+          ? json.data
+          : json?.data?.items || [];
+        setEvents(list);
+        setPage(1);
+      } catch {
+        setError("Error loading audit events");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [user]);
+
+  const totalPages = Math.max(1, Math.ceil(events.length / PAGE_SIZE));
+  const pageEvents = events.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Bitácora de Auditoría</h1>
+        <p>Registro de acciones realizadas en la plataforma</p>
+      </div>
+
+      {loading && <div style={{ marginTop: "1.5rem", textAlign: "center", opacity: 0.6 }}>Cargando...</div>}
+      {error && <div style={{ marginTop: "1.5rem", color: "var(--danger)" }}>{error}</div>}
+
+      {!loading && !error && (
+        <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+          {events.length === 0 ? (
+            <p style={{ textAlign: "center", opacity: 0.6, padding: "2rem" }}>No hay eventos de auditoría</p>
+          ) : (
+            <div style={{ overflowX: "auto" }}>
+              <table className="admin-table">
+                <thead>
+                  <tr>
+                    <th>Fecha</th>
+                    <th>Actor</th>
+                    <th>Entidad</th>
+                    <th>Acción</th>
+                    <th>ID</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pageEvents.map((e) => (
+                    <tr key={e.id}>
+                      <td style={{ fontSize: "0.8rem" }}>{new Date(e.createdAt).toLocaleString()}</td>
+                      <td><span className={`role-badge role-${e.actorRole}`}>{e.actorRole}</span></td>
+                      <td>{entityLabels[e.entity] || e.entity}</td>
+                      <td>{actionLabels[e.action] || e.action}</td>
+                      <td style={{ fontSize: "0.75rem", opacity: 0.6 }}>{e.entityId.slice(0, 12)}...</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div style={{ display: "flex", justifyContent: "center", gap: "0.5rem", marginTop: "1rem" }}>
+              <button className="btn btn-ghost" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+                Anterior
+              </button>
+              <span style={{ padding: "0.5rem 1rem", opacity: 0.6 }}>
+                {page} / {totalPages}
+              </span>
+              <button className="btn btn-ghost" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+                Siguiente
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/AdminObservabilityPage.tsx
+++ b/apps/web/src/pages/AdminObservabilityPage.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { useAuth, useUser } from "@clerk/clerk-react";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+
+interface Metrics {
+  requests: { total: number; errors: number };
+  responseTimeP99: number;
+}
+
+interface HealthStatus {
+  status: string;
+  timestamp: string;
+  uptime?: number;
+  checks?: Record<string, boolean>;
+}
+
+interface LiveStatus {
+  status: string;
+}
+
+export default function AdminObservabilityPage() {
+  const { user } = useUser();
+  const { getToken } = useAuth();
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [health, setHealth] = useState<HealthStatus | null>(null);
+  const [live, setLive] = useState<LiveStatus | null>(null);
+  const [ready, setReady] = useState<HealthStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const buildHeaders = async (): Promise<Record<string, string>> => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const token = await getToken();
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    else if (import.meta.env.DEV) { headers["x-dev-role"] = "admin"; headers["x-dev-user-id"] = "web_dev_admin"; }
+    return headers;
+  };
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const headers = await buildHeaders();
+      const [metricsRes, healthRes, liveRes, readyRes] = await Promise.allSettled([
+        fetch(`${BASE_URL}/api/v1/metrics`, { headers }).then((r) => r.json()),
+        fetch(`${BASE_URL}/api/v1/health`, { headers }).then((r) => r.json()),
+        fetch(`${BASE_URL}/api/v1/health/live`, { headers }).then((r) => r.json()),
+        fetch(`${BASE_URL}/api/v1/health/ready`, { headers }).then((r) => r.json()),
+      ]);
+
+      if (metricsRes.status === "fulfilled") {
+        const raw = metricsRes.value?.data || metricsRes.value;
+        setMetrics(raw?.metrics || raw);
+      }
+      if (healthRes.status === "fulfilled") setHealth(healthRes.value?.data || healthRes.value);
+      if (liveRes.status === "fulfilled") setLive(liveRes.value?.data || liveRes.value);
+      if (readyRes.status === "fulfilled") setReady(readyRes.value?.data || readyRes.value);
+    } catch {
+      setError("Error fetching observability data");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const errorRate = metrics
+    ? metrics.requests.total > 0
+      ? ((metrics.requests.errors / metrics.requests.total) * 100).toFixed(1)
+      : "0.0"
+    : "—";
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Observabilidad</h1>
+        <p>Métricas, salud del sistema y estado en tiempo real</p>
+      </div>
+
+      {loading && <div style={{ marginTop: "1.5rem", textAlign: "center", opacity: 0.6 }}>Cargando...</div>}
+      {error && <div style={{ marginTop: "1.5rem", color: "var(--danger)" }}>{error}</div>}
+
+      <div className="stats-grid" style={{ marginTop: "1.5rem" }}>
+        <div className="glass-card">
+          <div className="stat-value" style={{ color: "var(--leaf-700)" }}>{metrics?.requests.total ?? "—"}</div>
+          <div className="stat-label">Requests totales</div>
+        </div>
+        <div className="glass-card">
+          <div className="stat-value" style={{ color: "var(--danger)" }}>{errorRate}%</div>
+          <div className="stat-label">Tasa de errores</div>
+        </div>
+        <div className="glass-card">
+          <div className="stat-value" style={{ color: "var(--river-500)" }}>{metrics?.responseTimeP99 ?? "—"}ms</div>
+          <div className="stat-label">P99 latencia</div>
+        </div>
+        <div className="glass-card">
+          <div className="stat-value" style={{ color: health?.status === "ok" ? "var(--leaf-700)" : "var(--danger)" }}>
+            {health?.status === "ok" ? "✓" : "✗"}
+          </div>
+          <div className="stat-label">Health status</div>
+        </div>
+      </div>
+
+      <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+        <h3 style={{ margin: "0 0 1rem" }}>Sondas de salud</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "1rem" }}>
+          <div className="glass-card" style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "2rem", color: live?.status === "alive" ? "var(--leaf-700)" : "var(--danger)" }}>
+              {live?.status === "alive" ? "●" : "○"}
+            </div>
+            <div style={{ fontWeight: 600 }}>Liveness</div>
+            <div style={{ fontSize: "0.8rem", opacity: 0.6 }}>{live?.status || "Unknown"}</div>
+          </div>
+          <div className="glass-card" style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "2rem", color: ready?.status === "ready" ? "var(--leaf-700)" : "var(--danger)" }}>
+              {ready?.status === "ready" ? "●" : "○"}
+            </div>
+            <div style={{ fontWeight: 600 }}>Readiness</div>
+            <div style={{ fontSize: "0.8rem", opacity: 0.6 }}>{ready?.status || "Unknown"}</div>
+          </div>
+          <div className="glass-card" style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "2rem", color: health?.status === "ok" ? "var(--leaf-700)" : "var(--danger)" }}>
+              {health?.status === "ok" ? "●" : "○"}
+            </div>
+            <div style={{ fontWeight: 600 }}>Health</div>
+            <div style={{ fontSize: "0.8rem", opacity: 0.6 }}>{health?.status || "Unknown"}</div>
+          </div>
+        </div>
+      </div>
+
+      {health?.checks && (
+        <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+          <h3 style={{ margin: "0 0 1rem" }}>Dependencias</h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            {Object.entries(health.checks).map(([key, ok]) => (
+              <div key={key} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <span>{key}</span>
+                <span style={{ color: ok ? "var(--leaf-700)" : "var(--danger)", fontWeight: 600 }}>
+                  {ok ? "✓ OK" : "✗ FAIL"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+        <h3 style={{ margin: "0 0 0.5rem" }}>Información del sistema</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.5rem", fontSize: "0.9rem" }}>
+          <div><strong>Uptime:</strong> {health?.uptime ? `${Math.floor(health.uptime / 60)}m` : "—"}</div>
+          <div><strong>Última actualización:</strong> {health?.timestamp ? new Date(health.timestamp).toLocaleTimeString() : "—"}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { useParams } from "@tanstack/react-router";
+import { useAuth, useUser } from "@clerk/clerk-react";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+
+const statusConfig: Record<string, { label: string; color: string; bg: string }> = {
+  draft: { label: "Borrador", color: "#997a00", bg: "rgba(200, 170, 0, 0.15)" },
+  pending_owner: { label: "Pendiente firma", color: "var(--river-500)", bg: "rgba(13, 111, 147, 0.12)" },
+  active: { label: "Activo", color: "var(--leaf-700)", bg: "rgba(11, 95, 55, 0.12)" },
+  completed: { label: "Completado", color: "var(--success, #059669)", bg: "rgba(11, 95, 55, 0.12)" },
+  cancelled: { label: "Cancelado", color: "var(--danger, #dc2626)", bg: "rgba(180, 40, 40, 0.12)" },
+};
+
+export default function ContractDetailPage() {
+  const { user } = useUser();
+  const { getToken } = useAuth();
+  const params = useParams({ strict: false }) as { id?: string };
+  const contractId = params.id;
+  const [contract, setContract] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!user || !contractId) return;
+    const fetchContract = async () => {
+      try {
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        const token = await getToken();
+        if (token) headers["Authorization"] = `Bearer ${token}`;
+        else if (import.meta.env.DEV) { headers["x-dev-user-id"] = "web_dev_user"; headers["x-dev-role"] = "user"; }
+        const res = await fetch(`${BASE_URL}/api/v1/contracts/${contractId}`, { headers });
+        if (!res.ok) { setError("No se encontró el contrato"); return; }
+        const json = await res.json();
+        setContract(json?.data || null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Error");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchContract();
+  }, [user, contractId]);
+
+  const status = contract ? statusConfig[contract.status] || statusConfig.draft : null;
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Detalle de contrato</h1>
+        <p>Contrato #{contractId?.slice(0, 8)}</p>
+      </div>
+
+      {loading && (
+        <div className="glass-panel" style={{ marginTop: "1.5rem", textAlign: "center", padding: "3rem" }}>
+          Cargando contrato...
+        </div>
+      )}
+
+      {error && (
+        <div className="glass-panel" style={{ marginTop: "1.5rem", background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)" }}>
+          <p style={{ color: "var(--danger, #dc2626)" }}>{error}</p>
+        </div>
+      )}
+
+      {contract && status && (
+        <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start", marginBottom: "1rem" }}>
+            <h3 style={{ margin: 0 }}>Contrato #{contract.id?.slice(0, 8)}</h3>
+            <span style={{
+              padding: "0.25rem 0.75rem",
+              borderRadius: "999px",
+              background: status.bg,
+              color: status.color,
+              fontWeight: 600,
+              fontSize: "0.85rem",
+            }}>
+              {status.label}
+            </span>
+          </div>
+          <div style={{ fontSize: "0.9rem", opacity: 0.75, display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+            <p style={{ margin: 0 }}><strong>Solicitud:</strong> {contract.rentalRequestId?.slice(0, 8) || "—"}</p>
+            <p style={{ margin: 0 }}><strong>Período:</strong> {contract.terms?.startsAt || "—"} → {contract.terms?.endsAt || "—"}</p>
+            <p style={{ margin: 0 }}><strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString() : "—"}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/ContractsPage.tsx
+++ b/apps/web/src/pages/ContractsPage.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { useAuth, useUser } from "@clerk/clerk-react";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+
+const statusConfig: Record<string, { label: string; color: string; bg: string; step: number }> = {
+  draft: { label: "Borrador", color: "#997a00", bg: "rgba(200, 170, 0, 0.15)", step: 1 },
+  pending_owner: { label: "Pendiente firma", color: "var(--river-500)", bg: "rgba(13, 111, 147, 0.12)", step: 2 },
+  active: { label: "Activo", color: "var(--leaf-700)", bg: "rgba(11, 95, 55, 0.12)", step: 3 },
+  completed: { label: "Completado", color: "var(--success, #059669)", bg: "rgba(11, 95, 55, 0.12)", step: 4 },
+  cancelled: { label: "Cancelado", color: "var(--danger, #dc2626)", bg: "rgba(180, 40, 40, 0.12)", step: 0 },
+};
+
+const steps = ["Borrador", "Firma", "Activo", "Completado"];
+
+export default function ContractsPage() {
+  const { user } = useUser();
+  const { getToken } = useAuth();
+  const [contracts, setContracts] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!user) return;
+    const fetchContracts = async () => {
+      try {
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        const token = await getToken();
+        if (token) headers["Authorization"] = `Bearer ${token}`;
+        else if (import.meta.env.DEV) { headers["x-dev-user-id"] = "web_dev_user"; headers["x-dev-role"] = "user"; }
+        const res = await fetch(`${BASE_URL}/api/v1/contracts`, { headers });
+        const json = await res.json();
+        setContracts(json?.data || []);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Error");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchContracts();
+  }, [user]);
+
+  if (loading) {
+    return (
+      <div>
+        <div className="section-header">
+          <h1>Mis Contratos</h1>
+          <p>Seguimiento de contratos de alquiler</p>
+        </div>
+        <div className="glass-panel" style={{ marginTop: "1.5rem", textAlign: "center", padding: "3rem" }}>
+          Cargando contratos...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>Mis Contratos</h1>
+        <p>Seguimiento de contratos de alquiler</p>
+      </div>
+
+      {error && (
+        <div className="glass-panel" style={{ marginTop: "1.5rem", background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)" }}>
+          <p style={{ color: "var(--danger, #dc2626)" }}>{error}</p>
+        </div>
+      )}
+
+      {contracts.length === 0 ? (
+        <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+          <p>No tienes contratos aún.</p>
+          <p style={{ opacity: 0.7, marginTop: "0.5rem" }}>Los contratos se generan cuando una solicitud es aprobada.</p>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem", marginTop: "1.5rem" }}>
+          {contracts.map((contract: any) => {
+            const status = statusConfig[contract.status] || statusConfig.draft;
+            return (
+              <div key={contract.id} className="glass-panel">
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start", marginBottom: "1rem" }}>
+                  <div>
+                    <h3 style={{ margin: 0 }}>Contrato #{contract.id.slice(0, 8)}</h3>
+                    <p style={{ margin: "0.25rem 0", opacity: 0.6, fontSize: "0.85rem" }}>
+                      Solicitud: {contract.rentalRequestId?.slice(0, 8)}
+                    </p>
+                  </div>
+                  <span style={{
+                    padding: "0.25rem 0.75rem",
+                    borderRadius: "999px",
+                    background: status.bg,
+                    color: status.color,
+                    fontWeight: 600,
+                    fontSize: "0.85rem",
+                  }}>
+                    {status.label}
+                  </span>
+                </div>
+
+                <div style={{ display: "flex", alignItems: "center", gap: "0", margin: "1rem 0", position: "relative" }}>
+                  {steps.map((step, i) => {
+                    const isActive = status.step >= i + 1;
+                    const isCurrent = status.step === i + 1;
+                    return (
+                      <div key={step} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", position: "relative" }}>
+                        <div style={{
+                          width: "2rem",
+                          height: "2rem",
+                          borderRadius: "999px",
+                          background: isActive ? "var(--leaf-700, #059669)" : "#e5e7eb",
+                          color: isActive ? "white" : "#9ca3af",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          fontWeight: 700,
+                          fontSize: "0.8rem",
+                          border: isCurrent ? "3px solid var(--leaf-500, #10b981)" : "none",
+                          zIndex: 1,
+                        }}>
+                          {i + 1}
+                        </div>
+                        <span style={{ fontSize: "0.7rem", marginTop: "0.25rem", opacity: isActive ? 1 : 0.5 }}>
+                          {step}
+                        </span>
+                        {i < steps.length - 1 && (
+                          <div style={{
+                            position: "absolute",
+                            top: "1rem",
+                            left: "50%",
+                            width: "100%",
+                            height: "2px",
+                            background: isActive ? "var(--leaf-700, #059669)" : "#e5e7eb",
+                            zIndex: 0,
+                          }} />
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div style={{ fontSize: "0.85rem", opacity: 0.7 }}>
+                  <p style={{ margin: "0.25rem 0" }}>
+                    <strong>Período:</strong> {contract.terms?.startsAt || "—"} → {contract.terms?.endsAt || "—"}
+                  </p>
+                  <p style={{ margin: "0.25rem 0" }}>
+                    <strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString() : "—"}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/PrivacyPage.tsx
+++ b/apps/web/src/pages/PrivacyPage.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { useAuth, useUser } from "@clerk/clerk-react";
+import { useTranslation } from "react-i18next";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+
+export default function PrivacyPage() {
+  const { user } = useUser();
+  const { getToken } = useAuth();
+  const { t } = useTranslation();
+  const [exporting, setExporting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [exportData, setExportData] = useState<any>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  const buildHeaders = async (): Promise<Record<string, string>> => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const token = await getToken();
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    else if (import.meta.env.DEV) { headers["x-dev-user-id"] = "web_dev_user"; headers["x-dev-role"] = "user"; }
+    return headers;
+  };
+
+  const handleExport = async () => {
+    setExporting(true);
+    setMsg("");
+    try {
+      const headers = await buildHeaders();
+      const res = await fetch(`${BASE_URL}/api/v1/me/data-export`, { headers });
+      const data = await res.json();
+      setExportData(data?.data || data);
+      setMsg("Datos exportados correctamente");
+    } catch {
+      setMsg("Error al exportar datos");
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setMsg("");
+    try {
+      const headers = await buildHeaders();
+      const res = await fetch(`${BASE_URL}/api/v1/me`, {
+        method: "DELETE",
+        headers,
+      });
+      if (res.ok) {
+        setMsg("Cuenta anonimizada correctamente");
+        setConfirmDelete(false);
+      } else {
+        setMsg("Error al eliminar cuenta");
+      }
+    } catch {
+      setMsg("Error al eliminar cuenta");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="section-header">
+        <h1>{t("privacy.title")}</h1>
+        <p>{t("privacy.subtitle")}</p>
+      </div>
+
+      <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+        <h3 style={{ margin: "0 0 0.5rem" }}>{t("privacy.export_title")}</h3>
+        <p style={{ margin: "0 0 1rem", opacity: 0.7, fontSize: "0.9rem" }}>
+          {t("privacy.export_desc")}
+        </p>
+        <button className="btn btn-primary" onClick={handleExport} disabled={exporting}>
+          {exporting ? "Exportando..." : t("privacy.export_button")}
+        </button>
+        {exportData && (
+          <div style={{ marginTop: "1rem" }}>
+            <details>
+              <summary style={{ cursor: "pointer", fontWeight: 600 }}>Ver datos exportados</summary>
+              <pre style={{
+                marginTop: "0.5rem",
+                padding: "1rem",
+                background: "rgba(0,0,0,0.05)",
+                borderRadius: "0.5rem",
+                fontSize: "0.8rem",
+                overflow: "auto",
+                maxHeight: "300px",
+              }}>
+                {JSON.stringify(exportData, null, 2)}
+              </pre>
+            </details>
+          </div>
+        )}
+      </div>
+
+      <div className="glass-panel" style={{ marginTop: "1.5rem", border: "1px solid rgba(239,68,68,0.3)" }}>
+        <h3 style={{ margin: "0 0 0.5rem", color: "var(--danger)" }}>{t("privacy.delete_title")}</h3>
+        <p style={{ margin: "0 0 1rem", opacity: 0.7, fontSize: "0.9rem" }}>
+          {t("privacy.delete_desc")}
+        </p>
+        {!confirmDelete ? (
+          <button className="btn btn-ghost" style={{ borderColor: "var(--danger)", color: "var(--danger)" }} onClick={() => setConfirmDelete(true)}>
+            {t("privacy.delete_button")}
+          </button>
+        ) : (
+          <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+            <span style={{ fontWeight: 600 }}>¿Estás seguro?</span>
+            <button className="btn btn-ghost" onClick={() => setConfirmDelete(false)} disabled={deleting}>
+              Cancelar
+            </button>
+            <button className="btn btn-primary" style={{ background: "var(--danger)" }} onClick={handleDelete} disabled={deleting}>
+              {deleting ? "Eliminando..." : "Sí, eliminar"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {msg && (
+        <div className="glass-panel" style={{ marginTop: "1rem" }}>
+          <p>{msg}</p>
+        </div>
+      )}
+
+      <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
+        <h3 style={{ margin: "0 0 0.5rem" }}>{t("privacy.retention_title")}</h3>
+        <ul style={{ margin: 0, paddingLeft: "1.5rem", opacity: 0.8 }}>
+          <li>Tus datos de perfil se mantienen mientras tu cuenta esté activa.</li>
+          <li>Los terrenos publicados se conservan según su estado.</li>
+          <li>Las solicitudes y pagos se mantienen por razones legales (5 años).</li>
+          <li>Al eliminar tu cuenta, tus datos personales se anonimizan.</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/dashboard.admin.audit.tsx
+++ b/apps/web/src/routes/dashboard.admin.audit.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AdminRoute } from "../components/route-guards";
+import AdminLayout from "../components/AdminLayout";
+import AdminAuditPage from "../pages/AdminAuditPage";
+
+export const Route = createFileRoute("/dashboard/admin/audit")({
+  component: () => (
+    <AdminRoute><AdminLayout><AdminAuditPage /></AdminLayout></AdminRoute>
+  ),
+});

--- a/apps/web/src/routes/dashboard.admin.observability.tsx
+++ b/apps/web/src/routes/dashboard.admin.observability.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AdminRoute } from "../components/route-guards";
+import AdminLayout from "../components/AdminLayout";
+import AdminObservabilityPage from "../pages/AdminObservabilityPage";
+
+export const Route = createFileRoute("/dashboard/admin/observability")({
+  component: () => (
+    <AdminRoute><AdminLayout><AdminObservabilityPage /></AdminLayout></AdminRoute>
+  ),
+});

--- a/apps/web/src/routes/dashboard.contracts.$id.tsx
+++ b/apps/web/src/routes/dashboard.contracts.$id.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "../components/route-guards";
+import UserDashboardLayout from "../components/UserDashboardLayout";
+import ContractDetailPage from "../pages/ContractDetailPage";
+
+export const Route = createFileRoute("/dashboard/contracts/$id")({
+  component: () => (
+    <ProtectedRoute><UserDashboardLayout><ContractDetailPage /></UserDashboardLayout></ProtectedRoute>
+  ),
+});

--- a/apps/web/src/routes/dashboard.contracts.tsx
+++ b/apps/web/src/routes/dashboard.contracts.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "../components/route-guards";
+import UserDashboardLayout from "../components/UserDashboardLayout";
+import ContractsPage from "../pages/ContractsPage";
+
+export const Route = createFileRoute("/dashboard/contracts")({
+  component: () => (
+    <ProtectedRoute><UserDashboardLayout><ContractsPage /></UserDashboardLayout></ProtectedRoute>
+  ),
+});

--- a/apps/web/src/routes/dashboard.privacy.tsx
+++ b/apps/web/src/routes/dashboard.privacy.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "../components/route-guards";
+import UserDashboardLayout from "../components/UserDashboardLayout";
+import PrivacyPage from "../pages/PrivacyPage";
+
+export const Route = createFileRoute("/dashboard/privacy")({
+  component: () => (
+    <ProtectedRoute><UserDashboardLayout><PrivacyPage /></UserDashboardLayout></ProtectedRoute>
+  ),
+});


### PR DESCRIPTION
## Resumen

Rescata el frontend **útil** del PR #240 sobre el `main` actual (que iba muy por delante del branch original `feature/all-changes-consolidated`, ~40 commits atrás y con CI en rojo). **Solo frontend**: el backend ya sirve todos los endpoints necesarios en main.

Closes #247

## Páginas nuevas (rutas protegidas)

| Ruta | Guard | Contenido |
|------|-------|-----------|
| `/dashboard/contracts` | ProtectedRoute | Lista de contratos con wizard de estados (Borrador→Firma→Activo→Completado) |
| `/dashboard/privacy` | ProtectedRoute | Exportación de datos (RGPD) + borrado de cuenta + retención |
| `/dashboard/admin/audit` | AdminRoute | Bitácora de auditoría (paginación en cliente) |
| `/dashboard/admin/observability` | AdminRoute | Métricas, health y sondas live/ready |

Se añadieron enlaces de navegación en `AdminLayout` (auditoría, observabilidad) y `UserDashboardLayout` (contratos, privacidad) — el PR original las dejaba huérfanas.

## Correcciones sobre el código original de #240

1. **Import de Clerk** `@clerk/tanstack-react-start` → `@clerk/clerk-react` — el paquete no está instalado en main, **rompía el build** (era la causa del check *Web Build* rojo en #240).
2. **PrivacyPage**: endpoints `/api/v1/privacy/me/*` → `/api/v1/me/*` (ruta real que sirve `privacyRoutes` en main).
3. **AdminAuditPage**: leía `data.items`/`data.pagination` pero el endpoint de main devuelve **array plano** → parseo corregido + paginación en cliente.
4. **i18n**: añadidas claves namespace `privacy.*` en `es.json` y `en.json` (no existían → se veían en crudo).

## Descartado de #240 (innecesario o regresivo)

- Cambios en `apps/web/src/services/api.ts` — versión vieja que **revertiría** #137/#138.
- Backend `audit.ts` + cambios en `app.ts`/`contracts.ts` — main **ya sirve** `/audit-events` y ya tiene privacy/metrics/health. No se toca backend → **sin riesgo de romper tests**.
- `docs/GUIA-EJECUCION.md` — omitido para no duplicar docs.

## Verificación

- ✅ `bun run build` (web) OK — routeTree generado con las 4 rutas.
- ✅ Las 4 rutas redirigen invitados a `/login` (verificado en navegador).
- ✅ Backend intacto → tests iguales que main.
- ✅ **Desbloquea el PR #245**: su test E2E `contracts.smoke.spec.js` esperaba que `/dashboard/contracts` redirija a `/login`, lo que ahora ocurre.

## Relación con otros PRs

- **Reemplaza al PR #240** (obsoleto y roto) — se puede cerrar.
- **Desbloquea el PR #245 / issue #170** — una vez mergeado, el E2E de contratos pasa.
