### PR TITLE
[web] Acceso visible al panel admin desde el shell autenticado (#251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,19 @@ Plataforma para alquiler de terrenos (agricultura, ganaderia y otros usos produc
 | `/register` | Registro | Publico |
 | `/dashboard` | Dashboard usuario | Auth |
 | `/dashboard/admin` | Panel admin | Admin |
+
+## Acceso admin
+
+El panel `/dashboard/admin` esta protegido por rol. Un usuario se considera admin cuando (`isAdminUser`):
+
+- su email es `terradmin@gmail.com`, **o**
+- su `publicMetadata.role` en Clerk es `"admin"`.
+
+Un admin logueado ve la entrada **"Panel admin"** en el menu de usuario de la Navbar (solo visible para admins); un usuario normal no la ve.
+
+### Conceder rol admin real
+
+1. **Cuenta semilla:** inicia sesion con `terradmin@gmail.com` (coincide con `ADMIN_SEED_EMAIL` del backend).
+2. **Cualquier cuenta:** en el [Dashboard de Clerk](https://dashboard.clerk.com) → Users → (usuario) → **Metadata → Public**, agrega `{ "role": "admin" }` y guarda. Al re-loguear, el usuario tendra acceso al panel.
+
+> Nota: los usuarios `role:"admin"` creados por `apps/backend-api/src/db/seed.ts` (emails `@terrashare.test`) son datos de relleno para poblar las vistas; **no permiten iniciar sesion** porque no existen como identidades en Clerk.

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -4,7 +4,8 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import { Navbar } from "./ui";
 import type { BuscoOfrezcoMode } from "./ui";
-import { getDisplayName } from "./authDisplay";
+import { getDisplayName, isAdminUser } from "./authDisplay";
+import type { UserMenuItem } from "./ui";
 import "../pages/app-shell.css";
 
 const MODE_STORAGE_KEY = "terrashare-mode";
@@ -72,6 +73,16 @@ export default function AppLayout({ children }: { children?: ReactNode }) {
 
   const context: AppLayoutContext = { mode, setMode };
 
+  const userMenuItems: UserMenuItem[] = [
+    { label: "Mi perfil", onClick: () => navigate({ to: "/dashboard/profile" }) },
+    { label: "Mis terrenos", onClick: () => navigate({ to: "/dashboard/lands" }) },
+    { label: "Pagos", onClick: () => navigate({ to: "/dashboard/payments" }) },
+  ];
+  // El acceso al panel admin solo se ofrece a cuentas admin (issue #251).
+  if (isAdminUser(user)) {
+    userMenuItems.push({ label: "Panel admin", onClick: () => navigate({ to: "/dashboard/admin" }) });
+  }
+
   const actions = (
     <>
       <Link to="/dashboard/notifications" className="ds-navbar__icon" aria-label="Notificaciones">
@@ -91,11 +102,7 @@ export default function AppLayout({ children }: { children?: ReactNode }) {
         onModeChange={setMode}
         userName={getDisplayName(user)}
         actions={actions}
-        userMenuItems={[
-          { label: "Mi perfil", onClick: () => navigate({ to: "/dashboard/profile" }) },
-          { label: "Mis terrenos", onClick: () => navigate({ to: "/dashboard/lands" }) },
-          { label: "Pagos", onClick: () => navigate({ to: "/dashboard/payments" }) },
-        ]}
+        userMenuItems={userMenuItems}
         onSignOut={() => signOut({ redirectUrl: "/" })}
       />
       <main className="app-main">

--- a/apps/web/src/components/UserDashboardLayout.tsx
+++ b/apps/web/src/components/UserDashboardLayout.tsx
@@ -3,7 +3,8 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import { Bell, MessageCircle, Sprout } from "lucide-react";
 import { Navbar } from "./ui";
-import { getDisplayName } from "./authDisplay";
+import type { UserMenuItem } from "./ui";
+import { getDisplayName, isAdminUser } from "./authDisplay";
 import "../pages/app-shell.css";
 
 interface UserDashboardLayoutProps {
@@ -30,6 +31,19 @@ export default function UserDashboardLayout({ children, onSignOut }: UserDashboa
 
   const handleSignOut = onSignOut ?? (() => signOut({ redirectUrl: "/" }));
 
+  const userMenuItems: UserMenuItem[] = [
+    { label: "Mi perfil", onClick: () => navigate({ to: "/dashboard/profile" }) },
+    { label: "Mis solicitudes", onClick: () => navigate({ to: "/dashboard" }) },
+    { label: "Mis terrenos", onClick: () => navigate({ to: "/dashboard/lands" }) },
+    { label: "Contratos", onClick: () => navigate({ to: "/dashboard/contracts" }) },
+    { label: "Pagos", onClick: () => navigate({ to: "/dashboard/payments" }) },
+    { label: "Privacidad", onClick: () => navigate({ to: "/dashboard/privacy" }) },
+  ];
+  // El acceso al panel admin solo se ofrece a cuentas admin (issue #251).
+  if (isAdminUser(user)) {
+    userMenuItems.push({ label: "Panel admin", onClick: () => navigate({ to: "/dashboard/admin" }) });
+  }
+
   const actions = (
     <>
       <Link to="/dashboard/notifications" className="ds-navbar__icon" aria-label="Notificaciones">
@@ -47,14 +61,7 @@ export default function UserDashboardLayout({ children, onSignOut }: UserDashboa
         brand={<BrandMark />}
         userName={getDisplayName(user)}
         actions={actions}
-        userMenuItems={[
-          { label: "Mi perfil", onClick: () => navigate({ to: "/dashboard/profile" }) },
-          { label: "Mis solicitudes", onClick: () => navigate({ to: "/dashboard" }) },
-          { label: "Mis terrenos", onClick: () => navigate({ to: "/dashboard/lands" }) },
-          { label: "Contratos", onClick: () => navigate({ to: "/dashboard/contracts" }) },
-          { label: "Pagos", onClick: () => navigate({ to: "/dashboard/payments" }) },
-          { label: "Privacidad", onClick: () => navigate({ to: "/dashboard/privacy" }) },
-        ]}
+        userMenuItems={userMenuItems}
         onSignOut={handleSignOut}
       />
       <main className="app-main">{children}</main>


### PR DESCRIPTION
## Objetivo
Dar un punto de entrada visible al panel admin desde el shell autenticado (sub-tarea de #134). Cierra #251.

## Cambios
- Enlace **"Panel admin"** en el menú de usuario de `AppLayout` y `UserDashboardLayout`, **solo visible si `isAdminUser(user)`**.
- README: sección de acceso admin (login `terradmin@gmail.com` o `publicMetadata.role="admin"` en Clerk); se aclara que los admins del seed `@terrashare.test` son relleno y no permiten login.

## Verificación
- `tsc --noEmit` limpio; dev server compila sin errores.
- El enlace está tras el gate de Clerk (no navegable en preview sin login admin real); sigue el patrón existente del menú.

Closes #251
