### PR TITLE
[web+backend] Moderación por reportes: panel admin (09/26) + modelo/endpoints (#250)

### DIFF
--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -22,6 +22,7 @@ import { analyticsRoutes } from "./routes/analytics";
 import { notificationRoutes } from "./routes/notifications";
 import { metricsRoutes } from "./routes/metrics";
 import { privacyRoutes } from "./routes/privacy";
+import { reportRoutes } from "./routes/reports";
 import type { AppEnv } from "./types";
 import { corsAllowHeaders, resolveCorsOrigin } from "./config/env";
 
@@ -52,6 +53,7 @@ export function createApp() {
   app.use("/api/v1/chats*", requireAuth, rateLimitByUser(200));
   app.use("/api/v1/admin*", requireAuth, rateLimitByUser(200));
   app.use("/api/v1/analytics*", requireAuth, rateLimitByUser(200));
+  app.use("/api/v1/reports*", requireAuth, rateLimitByUser(200));
 
   app.get("/", (c) => {
     return c.json({
@@ -74,6 +76,7 @@ export function createApp() {
   app.route("/api/v1", notificationRoutes);
   app.route("/api/v1", metricsRoutes);
   app.route("/api/v1", privacyRoutes);
+  app.route("/api/v1", reportRoutes);
 
   app.notFound((c) => failure(c, 404, "NOT_FOUND", "Route not found"));
 

--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -10,6 +10,9 @@ export type ChatStatus = "active" | "archived";
 export type LeadSource = "landing" | "app-web" | "admin-dashboard";
 export type UserStatus = "active" | "blocked";
 export type AppRole = "user" | "admin";
+export type ReportTargetType = "land" | "user" | "chat";
+export type ReportReason = "spam" | "fraude" | "contenido_inapropiado" | "informacion_falsa" | "otro";
+export type ReportStatus = "open" | "reviewing" | "resolved" | "dismissed";
 
 export interface IUser extends Document {
   clerkUserId: string;
@@ -128,7 +131,7 @@ export interface IAuditEvent extends Document {
   id: string;
   actorId: string;
   actorRole: AppRole;
-  entity: "auth" | "user" | "land" | "rental_request" | "contract" | "payment" | "chat";
+  entity: "auth" | "user" | "land" | "rental_request" | "contract" | "payment" | "chat" | "report";
   action: "created" | "updated" | "deleted" | "approved" | "rejected" | "cancelled" | "paid" | "status_changed";
   entityId: string;
   metadata?: Record<string, unknown>;
@@ -140,6 +143,20 @@ export interface ILead extends Document {
   email: string;
   source: LeadSource;
   createdAt: Date;
+}
+
+export interface IReport extends Document {
+  id: string;
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  description?: string;
+  reporterId: string;
+  status: ReportStatus;
+  resolutionNote?: string;
+  resolvedBy?: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 const UserSchema = new Schema<IUser>({
@@ -253,7 +270,7 @@ const AuditEventSchema = new Schema<IAuditEvent>({
   id: { type: String, required: true, unique: true },
   actorId: { type: String, required: true },
   actorRole: { type: String, enum: ["user", "admin"], required: true },
-  entity: { type: String, enum: ["auth", "user", "land", "rental_request", "contract", "payment", "chat"], required: true },
+  entity: { type: String, enum: ["auth", "user", "land", "rental_request", "contract", "payment", "chat", "report"], required: true },
   action: { type: String, enum: ["created", "updated", "deleted", "approved", "rejected", "cancelled", "paid", "status_changed"], required: true },
   entityId: { type: String, required: true },
   metadata: Schema.Types.Mixed,
@@ -263,6 +280,18 @@ const LeadSchema = new Schema<ILead>({
   id: { type: String, required: true, unique: true },
   email: { type: String, required: true },
   source: { type: String, enum: ["landing", "app-web", "admin-dashboard"], required: true },
+}, { timestamps: true });
+
+const ReportSchema = new Schema<IReport>({
+  id: { type: String, required: true, unique: true },
+  targetType: { type: String, enum: ["land", "user", "chat"], required: true },
+  targetId: { type: String, required: true },
+  reason: { type: String, enum: ["spam", "fraude", "contenido_inapropiado", "informacion_falsa", "otro"], required: true },
+  description: String,
+  reporterId: { type: String, required: true },
+  status: { type: String, enum: ["open", "reviewing", "resolved", "dismissed"], default: "open" },
+  resolutionNote: String,
+  resolvedBy: String,
 }, { timestamps: true });
 
 // Índices secundarios (antes vivían en el driver nativo config/database.ts; se
@@ -279,6 +308,9 @@ ChatSchema.index({ landId: 1 });
 ChatMessageSchema.index({ chatId: 1, createdAt: 1 });
 AuditEventSchema.index({ entity: 1, entityId: 1 });
 LeadSchema.index({ email: 1 });
+ReportSchema.index({ status: 1 });
+ReportSchema.index({ targetType: 1, targetId: 1 });
+ReportSchema.index({ reporterId: 1 });
 
 export const User = mongoose.model<IUser>("User", UserSchema);
 export const Land = mongoose.model<ILand>("Land", LandSchema);
@@ -289,3 +321,4 @@ export const Chat = mongoose.model<IChat>("Chat", ChatSchema);
 export const ChatMessage = mongoose.model<IChatMessage>("ChatMessage", ChatMessageSchema);
 export const AuditEvent = mongoose.model<IAuditEvent>("AuditEvent", AuditEventSchema);
 export const Lead = mongoose.model<ILead>("Lead", LeadSchema);
+export const Report = mongoose.model<IReport>("Report", ReportSchema);

--- a/apps/backend-api/src/db/seed.ts
+++ b/apps/backend-api/src/db/seed.ts
@@ -1,7 +1,7 @@
 import mongoose from "mongoose";
 
 import {
-  User, Land, RentalRequest, Contract, Payment, Chat, ChatMessage, AuditEvent, Lead,
+  User, Land, RentalRequest, Contract, Payment, Chat, ChatMessage, AuditEvent, Lead, Report,
 } from "./schemas";
 
 const PROVINCES = [
@@ -318,6 +318,47 @@ function generateLeads(count: number) {
   return leads;
 }
 
+function generateReports(count: number, landIds: string[], userIds: string[], chatIds: string[]) {
+  const reports = [];
+  const reasons = ["spam", "fraude", "contenido_inapropiado", "informacion_falsa", "otro"] as const;
+  const statuses = ["open", "open", "reviewing", "resolved", "dismissed"] as const;
+  const descriptions = [
+    "El anuncio parece falso o engañoso.",
+    "Precio sospechosamente bajo para la zona.",
+    "El usuario pide pagos por fuera de la plataforma.",
+    "Contenido inapropiado en la descripción.",
+    "Fotos que no corresponden al terreno.",
+    "",
+  ];
+
+  for (let i = 0; i < count; i++) {
+    const targetType = randomItem(["land", "land", "user", "chat"] as const);
+    const targetId =
+      targetType === "land"
+        ? randomItem(landIds)
+        : targetType === "user"
+          ? randomItem(userIds)
+          : randomItem(chatIds);
+    const createdAt = randomDate(45);
+    const status = randomItem(statuses);
+    const isClosing = status === "resolved" || status === "dismissed";
+    reports.push({
+      id: `report_${String(i + 1).padStart(4, "0")}`,
+      targetType,
+      targetId,
+      reason: randomItem(reasons),
+      description: randomItem(descriptions) || undefined,
+      reporterId: randomItem(userIds),
+      status,
+      resolutionNote: isClosing ? "Revisado por el equipo de moderación." : undefined,
+      resolvedBy: isClosing ? randomItem(userIds.slice(0, 3)) : undefined,
+      createdAt,
+      updatedAt: createdAt,
+    });
+  }
+  return reports;
+}
+
 export async function seedDatabase() {
   if (mongoose.connection.readyState !== 1) {
     console.error("[seed] Database not connected");
@@ -357,6 +398,8 @@ export async function seedDatabase() {
   
   const leads = generateLeads(100);
 
+  const reports = generateReports(30, landIds, userIds, chatIds);
+
   // Se inserta vía `Model.collection` (handle nativo de la conexión Mongoose):
   // usa el nombre de colección real del modelo — corrige el desajuste
   // rentalRequests/chatMessages/auditEvents del driver nativo (#135 A-2) — y
@@ -388,6 +431,9 @@ export async function seedDatabase() {
   console.log(`[seed] Inserting ${leads.length} leads...`);
   await Lead.collection.insertMany(leads);
 
+  console.log(`[seed] Inserting ${reports.length} reports...`);
+  await Report.collection.insertMany(reports);
+
   console.log("[seed] Database seeded successfully!");
-  console.log(`[seed] Total: ${users.length} users, ${lands.length} lands, ${requests.length} requests, ${contracts.length} contracts, ${payments.length} payments, ${chats.length} chats, ${messages.length} messages, ${auditEvents.length} events, ${leads.length} leads`);
+  console.log(`[seed] Total: ${users.length} users, ${lands.length} lands, ${requests.length} requests, ${contracts.length} contracts, ${payments.length} payments, ${chats.length} chats, ${messages.length} messages, ${auditEvents.length} events, ${leads.length} leads, ${reports.length} reports`);
 }

--- a/apps/backend-api/src/routes/reports.test.ts
+++ b/apps/backend-api/src/routes/reports.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+
+import { requestJson } from "../lib/http-test-utils";
+
+const asUser = { "x-dev-user-id": "user_reporter_01" };
+const asAdmin = { "x-dev-user-id": "admin_reports", "x-dev-role": "admin" };
+
+async function createReport(overrides: Record<string, unknown> = {}) {
+  return requestJson("/api/v1/reports", {
+    method: "POST",
+    headers: asUser,
+    body: { targetType: "land", targetId: "land_001", reason: "spam", ...overrides },
+  });
+}
+
+describe("reports routes", () => {
+  it("lets an authenticated user create a report", async () => {
+    const { response, payload } = await createReport({ description: "Anuncio sospechoso" });
+
+    expect(response.status).toBe(201);
+    expect(payload.ok).toBe(true);
+    expect(payload.data.id).toBeDefined();
+    expect(payload.data.status).toBe("open");
+  });
+
+  it("rejects a report with an invalid targetType", async () => {
+    const { response, payload } = await createReport({ targetType: "planet" });
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+  });
+
+  it("rejects a report with an invalid reason", async () => {
+    const { response, payload } = await createReport({ reason: "no-me-gusta" });
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+  });
+
+  it("requires authentication to create a report", async () => {
+    const { response } = await requestJson("/api/v1/reports", {
+      method: "POST",
+      body: { targetType: "land", targetId: "land_001", reason: "spam" },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("lists reports for an admin", async () => {
+    await createReport();
+    const { response, payload } = await requestJson("/api/v1/admin/reports", { headers: asAdmin });
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(Array.isArray(payload.data.items)).toBe(true);
+    expect(payload.data.items.length).toBeGreaterThan(0);
+  });
+
+  it("forbids listing reports for a non-admin user", async () => {
+    const { response, payload } = await requestJson("/api/v1/admin/reports", { headers: asUser });
+
+    expect(response.status).toBe(403);
+    expect(payload.ok).toBe(false);
+  });
+
+  it("returns a report detail for an admin", async () => {
+    const { payload: created } = await createReport();
+    const { response, payload } = await requestJson(`/api/v1/admin/reports/${created.data.id}`, {
+      headers: asAdmin,
+    });
+
+    expect(response.status).toBe(200);
+    expect(payload.data.id).toBe(created.data.id);
+    expect(payload.data.targetLabel).toBeDefined();
+  });
+
+  it("returns 404 for a missing report", async () => {
+    const { response } = await requestJson("/api/v1/admin/reports/report_missing", { headers: asAdmin });
+    expect(response.status).toBe(404);
+  });
+
+  it("lets an admin transition a report to resolved", async () => {
+    const { payload: created } = await createReport();
+    const { response, payload } = await requestJson(`/api/v1/admin/reports/${created.data.id}`, {
+      method: "PATCH",
+      headers: asAdmin,
+      body: { status: "resolved", resolutionNote: "Sin fundamento" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(payload.data.status).toBe("resolved");
+    expect(payload.data.resolvedBy).toBeDefined();
+  });
+
+  it("rejects an invalid status transition", async () => {
+    const { payload: created } = await createReport();
+    const { response } = await requestJson(`/api/v1/admin/reports/${created.data.id}`, {
+      method: "PATCH",
+      headers: asAdmin,
+      body: { status: "banana" },
+    });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/backend-api/src/routes/reports.ts
+++ b/apps/backend-api/src/routes/reports.ts
@@ -1,0 +1,183 @@
+import { Hono } from "hono";
+
+import { failure, success } from "../lib/api-response";
+import { requireAdmin, requireAuth } from "../middleware/require-auth";
+import { createAuditEvent } from "../store/audit";
+import { Report, User, Land } from "../db/schemas";
+import type { ReportReason, ReportStatus, ReportTargetType } from "../db/schemas";
+import type { AppEnv } from "../types";
+
+export const reportRoutes = new Hono<AppEnv>();
+
+const TARGET_TYPES: ReportTargetType[] = ["land", "user", "chat"];
+const REASONS: ReportReason[] = ["spam", "fraude", "contenido_inapropiado", "informacion_falsa", "otro"];
+const STATUSES: ReportStatus[] = ["open", "reviewing", "resolved", "dismissed"];
+
+/**
+ * Etiqueta legible del elemento reportado para el panel admin. Para terrenos
+ * usamos el título; para usuarios, el email; para chats, el propio id.
+ */
+async function describeTarget(targetType: ReportTargetType, targetId: string): Promise<string> {
+  if (targetType === "land") {
+    const land = await Land.findOne({ id: targetId }).lean();
+    return land?.title ?? targetId;
+  }
+  if (targetType === "user") {
+    const user = await User.findOne({ clerkUserId: targetId }).lean();
+    return user?.email ?? targetId;
+  }
+  return targetId;
+}
+
+// ─── Crear reporte (cualquier usuario autenticado) ───────────────────────────
+
+reportRoutes.post("/reports", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const body = (await c.req.json().catch(() => null)) as
+    | { targetType?: string; targetId?: string; reason?: string; description?: string }
+    | null;
+
+  if (!body) {
+    return failure(c, 400, "VALIDATION_ERROR", "Invalid JSON body");
+  }
+  if (!body.targetType || !TARGET_TYPES.includes(body.targetType as ReportTargetType)) {
+    return failure(c, 400, "VALIDATION_ERROR", "targetType must be one of land|user|chat");
+  }
+  if (!body.targetId || typeof body.targetId !== "string") {
+    return failure(c, 400, "VALIDATION_ERROR", "targetId is required");
+  }
+  if (!body.reason || !REASONS.includes(body.reason as ReportReason)) {
+    return failure(c, 400, "VALIDATION_ERROR", "reason is invalid");
+  }
+
+  const report = await Report.create({
+    id: `report_${crypto.randomUUID()}`,
+    targetType: body.targetType as ReportTargetType,
+    targetId: body.targetId,
+    reason: body.reason as ReportReason,
+    description: typeof body.description === "string" ? body.description.trim() : undefined,
+    reporterId: authUser.id,
+    status: "open",
+  });
+
+  await createAuditEvent({
+    actor: authUser,
+    entity: "report",
+    action: "created",
+    entityId: report.id,
+    metadata: { targetType: report.targetType, targetId: report.targetId, reason: report.reason },
+  });
+
+  return success(c, { id: report.id, status: report.status, createdAt: report.createdAt }, 201);
+});
+
+// ─── Listar reportes (solo admin) ────────────────────────────────────────────
+
+reportRoutes.get("/admin/reports", requireAuth, requireAdmin, async (c) => {
+  const status = c.req.query("status");
+  const targetType = c.req.query("targetType");
+  const search = c.req.query("search")?.toLowerCase();
+
+  const query: Record<string, unknown> = {};
+  if (status && STATUSES.includes(status as ReportStatus)) query.status = status;
+  if (targetType && TARGET_TYPES.includes(targetType as ReportTargetType)) query.targetType = targetType;
+
+  const reports = await Report.find(query).sort({ createdAt: -1 }).lean();
+
+  const reporterIds = [...new Set(reports.map((r) => r.reporterId))];
+  const reporters = await User.find({ clerkUserId: { $in: reporterIds } }).lean();
+  const reporterMap = new Map(reporters.map((u) => [u.clerkUserId, u]));
+
+  let items = await Promise.all(
+    reports.map(async (r) => ({
+      id: r.id,
+      targetType: r.targetType,
+      targetId: r.targetId,
+      targetLabel: await describeTarget(r.targetType, r.targetId),
+      reason: r.reason,
+      status: r.status,
+      reporterId: r.reporterId,
+      reporterEmail: reporterMap.get(r.reporterId)?.email ?? r.reporterId,
+      createdAt: r.createdAt,
+    })),
+  );
+
+  if (search) {
+    items = items.filter(
+      (r) =>
+        r.targetLabel.toLowerCase().includes(search) ||
+        r.reporterEmail.toLowerCase().includes(search) ||
+        r.reason.toLowerCase().includes(search),
+    );
+  }
+
+  const page = Math.max(1, Number(c.req.query("page") ?? 1) || 1);
+  const pageSize = Math.min(100, Math.max(1, Number(c.req.query("pageSize") ?? 20) || 20));
+  const total = items.length;
+  const start = (page - 1) * pageSize;
+
+  return success(c, {
+    items: items.slice(start, start + pageSize),
+    total,
+    pagination: { page, pageSize, total, totalPages: Math.max(1, Math.ceil(total / pageSize)) },
+  });
+});
+
+// ─── Ver un reporte (solo admin) ─────────────────────────────────────────────
+
+reportRoutes.get("/admin/reports/:reportId", requireAuth, requireAdmin, async (c) => {
+  const reportId = c.req.param("reportId");
+  const report = await Report.findOne({ id: reportId }).lean();
+  if (!report) {
+    return failure(c, 404, "NOT_FOUND", "Report not found");
+  }
+
+  const reporter = await User.findOne({ clerkUserId: report.reporterId }).lean();
+
+  return success(c, {
+    ...report,
+    targetLabel: await describeTarget(report.targetType, report.targetId),
+    reporterEmail: reporter?.email ?? report.reporterId,
+    reporterName: reporter?.profile?.fullName ?? null,
+  });
+});
+
+// ─── Transicionar estado de un reporte (solo admin) ──────────────────────────
+
+reportRoutes.patch("/admin/reports/:reportId", requireAuth, requireAdmin, async (c) => {
+  const authUser = c.get("authUser");
+  const reportId = c.req.param("reportId");
+
+  const report = await Report.findOne({ id: reportId }).lean();
+  if (!report) {
+    return failure(c, 404, "NOT_FOUND", "Report not found");
+  }
+
+  const body = (await c.req.json().catch(() => null)) as
+    | { status?: string; resolutionNote?: string }
+    | null;
+  const nextStatus = body?.status;
+  if (!nextStatus || !STATUSES.includes(nextStatus as ReportStatus)) {
+    return failure(c, 400, "VALIDATION_ERROR", "status must be one of open|reviewing|resolved|dismissed");
+  }
+
+  const isClosing = nextStatus === "resolved" || nextStatus === "dismissed";
+  const update: Record<string, unknown> = {
+    status: nextStatus,
+    resolutionNote: typeof body?.resolutionNote === "string" ? body.resolutionNote.trim() : report.resolutionNote,
+    resolvedBy: isClosing ? authUser.id : undefined,
+  };
+
+  await Report.updateOne({ id: reportId }, update);
+
+  await createAuditEvent({
+    actor: authUser,
+    entity: "report",
+    action: "status_changed",
+    entityId: reportId,
+    metadata: { from: report.status, to: nextStatus },
+  });
+
+  const updated = await Report.findOne({ id: reportId }).lean();
+  return success(c, updated);
+});

--- a/apps/backend-api/src/store/types.ts
+++ b/apps/backend-api/src/store/types.ts
@@ -148,7 +148,8 @@ export interface AuditEventRecord {
     | "rental_request"
     | "contract"
     | "payment"
-    | "chat";
+    | "chat"
+    | "report";
   action:
     | "created"
     | "updated"

--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -11,6 +11,7 @@ interface AdminLayoutProps {
 
 const NAV = [
   { to: "/dashboard/admin", label: "Resumen", icon: LayoutDashboard },
+  { to: "/dashboard/admin/reports", label: "Reportes", icon: Flag },
   { to: "/dashboard/admin/lands", label: "Terrenos", icon: Map },
   { to: "/dashboard/admin/users", label: "Usuarios", icon: Users },
   { to: "/dashboard/admin/leads", label: "Leads", icon: Mail },
@@ -42,10 +43,6 @@ export default function AdminLayout({ children, onSignOut }: AdminLayoutProps) {
               <Icon size={17} /> {label}
             </Link>
           ))}
-          {/* TODO(#134): moderación de reportes pendiente de backend. */}
-          <span className="adm-side__link" style={{ opacity: 0.55, cursor: "default" }}>
-            <Flag size={17} /> Reportes
-          </span>
           <button
             type="button"
             className="adm-side__link"

--- a/apps/web/src/pages/AdminReportDetailPage.tsx
+++ b/apps/web/src/pages/AdminReportDetailPage.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "@tanstack/react-router";
+import { ArrowLeft, Flag } from "lucide-react";
+import { getAdminReport, updateReportStatus } from "../services/adminApi";
+import type { AdminReportDetail, ReportStatus } from "../services/adminApi";
+import { REASON_LABELS, STATUS_BADGE, STATUS_LABELS, TARGET_LABELS } from "./reportLabels";
+import "./admin.css";
+
+function formatDate(value?: string): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("es-PA", { dateStyle: "medium", timeStyle: "short" });
+}
+
+export default function AdminReportDetailPage() {
+  const { id } = useParams({ strict: false });
+  const [report, setReport] = useState<AdminReportDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [note, setNote] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    setError("");
+    getAdminReport(id)
+      .then((res) => {
+        setReport(res.data);
+        setNote(res.data?.resolutionNote ?? "");
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : "Error"))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const transition = async (next: ReportStatus) => {
+    if (!id) return;
+    setSaving(true);
+    setError("");
+    try {
+      const res = await updateReportStatus(id, next, note.trim() || undefined);
+      setReport(res.data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <>
+        <BackLink />
+        <div className="adm-empty">Cargando…</div>
+      </>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <>
+        <BackLink />
+        <div className="adm-empty adm-empty--error">{error || "No se encontró el reporte."}</div>
+      </>
+    );
+  }
+
+  const isClosed = report.status === "resolved" || report.status === "dismissed";
+
+  return (
+    <>
+      <BackLink />
+
+      <div className="adm-rep__head">
+        <div className="adm-rep__title">
+          <span className="adm-user__avatar" aria-hidden="true">
+            <Flag size={16} />
+          </span>
+          <div>
+            <h1 className="adm-title" style={{ margin: 0 }}>{report.targetLabel}</h1>
+            <p className="adm-sub" style={{ margin: 0 }}>
+              {TARGET_LABELS[report.targetType]} · Reporte #{report.id.slice(-6)}
+            </p>
+          </div>
+        </div>
+        <span className={`adm-badge ${STATUS_BADGE[report.status]}`}>{STATUS_LABELS[report.status]}</span>
+      </div>
+
+      <div className="adm-rep__grid">
+        <section className="adm-panel">
+          <h2 className="adm-panel__title">Detalle del reporte</h2>
+          <dl className="adm-rep__dl">
+            <div>
+              <dt>Motivo</dt>
+              <dd>{REASON_LABELS[report.reason]}</dd>
+            </div>
+            <div>
+              <dt>Descripción</dt>
+              <dd>{report.description || "Sin descripción adicional."}</dd>
+            </div>
+            <div>
+              <dt>Elemento reportado</dt>
+              <dd>{report.targetLabel} <span className="adm-cell--muted">({report.targetId})</span></dd>
+            </div>
+            <div>
+              <dt>Reportado por</dt>
+              <dd>{report.reporterName || report.reporterEmail}</dd>
+            </div>
+            <div>
+              <dt>Fecha</dt>
+              <dd>{formatDate(report.createdAt)}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="adm-panel">
+          <h2 className="adm-panel__title">Moderación</h2>
+          <label className="adm-rep__label" htmlFor="rep-note">Nota de resolución (opcional)</label>
+          <textarea
+            id="rep-note"
+            className="adm-rep__note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Explica la decisión tomada…"
+            rows={4}
+          />
+          <div className="adm-rep__actions">
+            <button
+              type="button"
+              className="adm-act"
+              disabled={saving || report.status === "reviewing"}
+              onClick={() => transition("reviewing")}
+            >
+              En revisión
+            </button>
+            <button
+              type="button"
+              className="adm-act adm-rep__cta"
+              disabled={saving}
+              onClick={() => transition("resolved")}
+            >
+              Resolver
+            </button>
+            <button
+              type="button"
+              className="adm-act adm-act--danger"
+              disabled={saving}
+              onClick={() => transition("dismissed")}
+            >
+              Descartar
+            </button>
+          </div>
+          {isClosed && report.resolutionNote && (
+            <p className="adm-rep__resolved">Resolución: {report.resolutionNote}</p>
+          )}
+        </section>
+      </div>
+    </>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link to="/dashboard/admin/reports" className="adm-act" style={{ display: "inline-flex", alignItems: "center", gap: 6, marginBottom: 16 }}>
+      <ArrowLeft size={15} /> Volver a reportes
+    </Link>
+  );
+}

--- a/apps/web/src/pages/AdminReportsPage.tsx
+++ b/apps/web/src/pages/AdminReportsPage.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Search, ChevronDown, Flag } from "lucide-react";
+import { listAdminReports } from "../services/adminApi";
+import type { AdminReportSummary } from "../services/adminApi";
+import { REASON_LABELS, STATUS_BADGE, STATUS_LABELS, TARGET_LABELS } from "./reportLabels";
+import "./admin.css";
+
+const COLS = "1.6fr 1fr 1.4fr 0.9fr auto";
+
+export default function AdminReportsPage() {
+  const navigate = useNavigate();
+  const [reports, setReports] = useState<AdminReportSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [status, setStatus] = useState("all");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    setLoading(true);
+    setError("");
+    const filters: { status?: string; search?: string } = {};
+    if (status !== "all") filters.status = status;
+    if (search.trim()) filters.search = search.trim();
+
+    listAdminReports(filters)
+      .then((res) => setReports(res.data?.items ?? []))
+      .catch((e) => setError(e instanceof Error ? e.message : "Error"))
+      .finally(() => setLoading(false));
+  }, [status, search]);
+
+  return (
+    <>
+      <h1 className="adm-title">Reportes</h1>
+      <p className="adm-sub">Modera terrenos, usuarios y chats reportados por la comunidad.</p>
+
+      <div className="adm-toolbar">
+        <div className="adm-search">
+          <span className="adm-search__icon">
+            <Search size={17} />
+          </span>
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por elemento, motivo o quien reporta…"
+            aria-label="Buscar reportes"
+          />
+        </div>
+        <label className="adm-pill">
+          <select value={status} onChange={(e) => setStatus(e.target.value)} aria-label="Filtrar por estado">
+            <option value="all">Estado</option>
+            <option value="open">Abiertos</option>
+            <option value="reviewing">En revisión</option>
+            <option value="resolved">Resueltos</option>
+            <option value="dismissed">Descartados</option>
+          </select>
+          <ChevronDown size={14} />
+        </label>
+      </div>
+
+      <div className="adm-table">
+        <div className="adm-trow adm-trow--head" style={{ gridTemplateColumns: COLS }}>
+          <span>Elemento</span>
+          <span>Motivo</span>
+          <span>Reportado por</span>
+          <span>Estado</span>
+          <span />
+        </div>
+        {loading ? (
+          <div className="adm-empty">Cargando…</div>
+        ) : error ? (
+          <div className="adm-empty adm-empty--error">No pudimos cargar los reportes.</div>
+        ) : reports.length === 0 ? (
+          <div className="adm-empty">No hay reportes que coincidan.</div>
+        ) : (
+          reports.map((r) => (
+            <div key={r.id} className="adm-trow" style={{ gridTemplateColumns: COLS }}>
+              <div className="adm-user">
+                <span className="adm-user__avatar" aria-hidden="true">
+                  <Flag size={15} />
+                </span>
+                <div style={{ minWidth: 0 }}>
+                  <div className="adm-user__name">{r.targetLabel}</div>
+                  <div className="adm-user__email">{TARGET_LABELS[r.targetType]}</div>
+                </div>
+              </div>
+              <span>{REASON_LABELS[r.reason]}</span>
+              <span className="adm-cell--muted">{r.reporterEmail}</span>
+              <span>
+                <span className={`adm-badge ${STATUS_BADGE[r.status]}`}>{STATUS_LABELS[r.status]}</span>
+              </span>
+              <span className="adm-cell--right">
+                <button
+                  type="button"
+                  className="adm-act"
+                  onClick={() => navigate({ to: "/dashboard/admin/reports/$id", params: { id: r.id } })}
+                >
+                  Ver
+                </button>
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      {!loading && !error && reports.length > 0 && (
+        <div className="adm-foot">
+          <span>{reports.length} reporte{reports.length !== 1 ? "s" : ""}</span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/pages/LandDetailPage.tsx
+++ b/apps/web/src/pages/LandDetailPage.tsx
@@ -16,9 +16,19 @@ import {
   ImageIcon,
   ShieldCheck,
   User,
+  Flag,
 } from "lucide-react";
-import { createChat, getLandById } from "../services/api";
+import { createChat, getLandById, createReport } from "../services/api";
+import type { ReportReason } from "../services/api";
 import "./detail.css";
+
+const REPORT_REASONS: { value: ReportReason; label: string }[] = [
+  { value: "fraude", label: "Fraude o estafa" },
+  { value: "informacion_falsa", label: "Información falsa" },
+  { value: "contenido_inapropiado", label: "Contenido inapropiado" },
+  { value: "spam", label: "Spam" },
+  { value: "otro", label: "Otro" },
+];
 
 type Operation = "alquiler" | "venta" | "ambas";
 
@@ -71,6 +81,11 @@ export default function LandDetailPage() {
   const [land, setLand] = useState<DetailLand | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reportReason, setReportReason] = useState<ReportReason>("fraude");
+  const [reportDesc, setReportDesc] = useState("");
+  const [reportState, setReportState] = useState<"idle" | "sending" | "done" | "error">("idle");
+
   useEffect(() => {
     let active = true;
     getLandById(id!)
@@ -107,6 +122,33 @@ export default function LandDetailPage() {
       console.error("No se pudo iniciar el chat:", err);
     }
     navigate({ to: "/dashboard/chats" });
+  };
+
+  const openReport = () => {
+    if (!isSignedIn) {
+      openSignIn({ redirectUrl: `/lands/${id}` });
+      return;
+    }
+    setReportState("idle");
+    setReportOpen(true);
+  };
+
+  const submitReport = async () => {
+    if (!id) return;
+    setReportState("sending");
+    try {
+      await createReport({
+        targetType: "land",
+        targetId: id,
+        reason: reportReason,
+        description: reportDesc.trim() || undefined,
+      });
+      setReportState("done");
+      setReportDesc("");
+    } catch (err) {
+      console.error("No se pudo enviar el reporte:", err);
+      setReportState("error");
+    }
   };
 
   if (status === "loading") {
@@ -189,8 +231,87 @@ export default function LandDetailPage() {
           >
             <Share2 size={17} />
           </button>
+          <button
+            type="button"
+            className="det-nav__action"
+            title="Reportar terreno"
+            aria-label="Reportar terreno"
+            onClick={openReport}
+          >
+            <Flag size={17} /> Reportar
+          </button>
         </div>
       </nav>
+
+      {reportOpen && (
+        <div className="det-report" role="dialog" aria-modal="true" aria-label="Reportar terreno">
+          <div className="det-report__box">
+            {reportState === "done" ? (
+              <>
+                <h2 className="det-report__title">Reporte enviado</h2>
+                <p className="det-report__lead">
+                  Gracias. Nuestro equipo de moderación revisará este terreno.
+                </p>
+                <div className="det-report__actions">
+                  <button type="button" className="det-btn det-btn--primary" onClick={() => setReportOpen(false)}>
+                    Cerrar
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h2 className="det-report__title">Reportar «{land.title}»</h2>
+                <p className="det-report__lead">Cuéntanos qué problema tiene esta publicación.</p>
+
+                <label className="det-report__label" htmlFor="report-reason">Motivo</label>
+                <select
+                  id="report-reason"
+                  className="det-report__select"
+                  value={reportReason}
+                  onChange={(e) => setReportReason(e.target.value as ReportReason)}
+                >
+                  {REPORT_REASONS.map((r) => (
+                    <option key={r.value} value={r.value}>{r.label}</option>
+                  ))}
+                </select>
+
+                <label className="det-report__label" htmlFor="report-desc">Descripción (opcional)</label>
+                <textarea
+                  id="report-desc"
+                  className="det-report__textarea"
+                  rows={3}
+                  value={reportDesc}
+                  onChange={(e) => setReportDesc(e.target.value)}
+                  placeholder="Agrega detalles que ayuden a la revisión…"
+                />
+
+                {reportState === "error" && (
+                  <p className="det-report__error">No se pudo enviar el reporte. Inténtalo de nuevo.</p>
+                )}
+
+                <div className="det-report__actions">
+                  <button
+                    type="button"
+                    className="det-btn det-btn--ghost"
+                    onClick={() => setReportOpen(false)}
+                    disabled={reportState === "sending"}
+                  >
+                    Cancelar
+                  </button>
+                  <button
+                    type="button"
+                    className="det-btn det-btn--primary"
+                    onClick={submitReport}
+                    disabled={reportState === "sending"}
+                  >
+                    {reportState === "sending" ? "Enviando…" : "Enviar reporte"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="det-wrap">
         {/* galería */}

--- a/apps/web/src/pages/admin.css
+++ b/apps/web/src/pages/admin.css
@@ -273,6 +273,36 @@
 .adm-empty { padding: 40px 20px; text-align: center; color: var(--ts-sage-2); font-size: 14px; }
 .adm-empty--error { color: #a5573a; }
 
+/* detalle de reporte (maqueta 26) */
+.adm-rep__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.adm-rep__title { display: flex; align-items: center; gap: 12px; }
+.adm-rep__grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 18px; align-items: start; }
+.adm-rep__dl { display: grid; gap: 14px; margin: 0; }
+.adm-rep__dl dt { font-size: 12px; font-weight: 700; color: var(--ts-sage-2); text-transform: uppercase; letter-spacing: 0.03em; }
+.adm-rep__dl dd { margin: 2px 0 0; font-size: 14px; color: var(--ts-text); }
+.adm-rep__label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 6px; color: var(--ts-text-secondary); }
+.adm-rep__note {
+  width: 100%;
+  border: 1px solid #d8cfb8;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font: inherit;
+  font-size: 14px;
+  resize: vertical;
+  background: var(--ts-surface);
+  color: var(--ts-text);
+}
+.adm-rep__actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.adm-rep__cta { color: var(--ts-bg); background: var(--ts-green); border-color: var(--ts-green); }
+.adm-rep__cta:hover:not(:disabled) { background: var(--ts-green-ink); }
+.adm-rep__resolved { margin-top: 14px; font-size: 13px; color: var(--ts-sage); }
+
 @media (max-width: 860px) {
   .adm { grid-template-columns: 1fr; }
   .adm-side { position: static; height: auto; flex-direction: row; align-items: center; flex-wrap: wrap; gap: 8px; }
@@ -282,4 +312,5 @@
   .adm-stats { grid-template-columns: repeat(2, 1fr); }
   .adm-row { grid-template-columns: 1fr; }
   .adm-main { padding: 24px 20px; }
+  .adm-rep__grid { grid-template-columns: 1fr; }
 }

--- a/apps/web/src/pages/detail.css
+++ b/apps/web/src/pages/detail.css
@@ -234,6 +234,45 @@
   .det-photo--main { grid-row: auto; }
   .det-gallery__hide-sm { display: none; }
 }
+/* modal de reporte (moderación por reportes, #250) */
+.det-report {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(28, 33, 26, 0.5);
+}
+.det-report__box {
+  width: 100%;
+  max-width: 440px;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-beige);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+}
+.det-report__title { font-family: var(--ts-font-serif); font-size: 22px; font-weight: 600; margin: 0 0 6px; }
+.det-report__lead { color: var(--ts-text-secondary); font-size: 14px; margin: 0 0 16px; }
+.det-report__label { display: block; font-size: 13px; font-weight: 600; margin: 12px 0 6px; }
+.det-report__select,
+.det-report__textarea {
+  width: 100%;
+  border: 1px solid #cdd6c8;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font: inherit;
+  font-size: 14px;
+  background: var(--ts-surface);
+  color: var(--ts-text);
+}
+.det-report__textarea { resize: vertical; }
+.det-report__error { color: #a5573a; font-size: 13px; margin: 10px 0 0; }
+.det-report__actions { display: flex; gap: 10px; margin-top: 20px; }
+.det-report__actions .det-btn { margin-bottom: 0; }
+
 @media (max-width: 560px) {
   .det-nav, .det-wrap { padding-left: 20px; padding-right: 20px; }
   .det-title { font-size: 34px; }

--- a/apps/web/src/pages/reportLabels.ts
+++ b/apps/web/src/pages/reportLabels.ts
@@ -1,0 +1,30 @@
+import type { ReportReason, ReportStatus, ReportTargetType } from "../services/adminApi";
+
+export const REASON_LABELS: Record<ReportReason, string> = {
+  spam: "Spam",
+  fraude: "Fraude",
+  contenido_inapropiado: "Contenido inapropiado",
+  informacion_falsa: "Información falsa",
+  otro: "Otro",
+};
+
+export const TARGET_LABELS: Record<ReportTargetType, string> = {
+  land: "Terreno",
+  user: "Usuario",
+  chat: "Chat",
+};
+
+export const STATUS_LABELS: Record<ReportStatus, string> = {
+  open: "Abierto",
+  reviewing: "En revisión",
+  resolved: "Resuelto",
+  dismissed: "Descartado",
+};
+
+/** Tono del badge editorial (adm-badge--*) por estado del reporte. */
+export const STATUS_BADGE: Record<ReportStatus, string> = {
+  open: "adm-badge--red",
+  reviewing: "adm-badge--amber",
+  resolved: "adm-badge--green",
+  dismissed: "adm-badge--teal",
+};

--- a/apps/web/src/routes/dashboard.admin.reports.$id.tsx
+++ b/apps/web/src/routes/dashboard.admin.reports.$id.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AdminRoute } from "../components/route-guards";
+import AdminLayout from "../components/AdminLayout";
+import AdminReportDetailPage from "../pages/AdminReportDetailPage";
+
+export const Route = createFileRoute("/dashboard/admin/reports/$id")({
+  component: () => (
+    <AdminRoute><AdminLayout><AdminReportDetailPage /></AdminLayout></AdminRoute>
+  ),
+});

--- a/apps/web/src/routes/dashboard.admin.reports.index.tsx
+++ b/apps/web/src/routes/dashboard.admin.reports.index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AdminRoute } from "../components/route-guards";
+import AdminLayout from "../components/AdminLayout";
+import AdminReportsPage from "../pages/AdminReportsPage";
+
+export const Route = createFileRoute("/dashboard/admin/reports/")({
+  component: () => (
+    <AdminRoute><AdminLayout><AdminReportsPage /></AdminLayout></AdminRoute>
+  ),
+});

--- a/apps/web/src/services/adminApi.ts
+++ b/apps/web/src/services/adminApi.ts
@@ -119,3 +119,56 @@ export const listAdminLeads = (filters: AdminLeadFilters = {}) => {
     `/api/v1/admin/leads${qs ? `?${qs}` : ""}`,
   );
 };
+
+// ─── Reports (moderación) ────────────────────────────────────────────────────
+
+export type ReportTargetType = "land" | "user" | "chat";
+export type ReportReason = "spam" | "fraude" | "contenido_inapropiado" | "informacion_falsa" | "otro";
+export type ReportStatus = "open" | "reviewing" | "resolved" | "dismissed";
+
+export interface AdminReportSummary {
+  id: string;
+  targetType: ReportTargetType;
+  targetId: string;
+  targetLabel: string;
+  reason: ReportReason;
+  status: ReportStatus;
+  reporterId: string;
+  reporterEmail: string;
+  createdAt?: string;
+}
+
+export interface AdminReportDetail extends AdminReportSummary {
+  description?: string;
+  reporterName?: string | null;
+  resolutionNote?: string;
+  resolvedBy?: string;
+  updatedAt?: string;
+}
+
+interface AdminReportFilters {
+  status?: string;
+  targetType?: string;
+  search?: string;
+}
+
+/** GET /api/v1/admin/reports?status=&targetType=&search= */
+export const listAdminReports = (filters: AdminReportFilters = {}) => {
+  const params = new URLSearchParams();
+  if (filters.status) params.set("status", filters.status);
+  if (filters.targetType) params.set("targetType", filters.targetType);
+  if (filters.search) params.set("search", filters.search);
+  const qs = params.toString();
+  return request<{ items: AdminReportSummary[]; total: number }>(
+    "GET",
+    `/api/v1/admin/reports${qs ? `?${qs}` : ""}`,
+  );
+};
+
+/** GET /api/v1/admin/reports/:reportId */
+export const getAdminReport = (reportId: string) =>
+  request<AdminReportDetail>("GET", `/api/v1/admin/reports/${reportId}`);
+
+/** PATCH /api/v1/admin/reports/:reportId — { status, resolutionNote? } */
+export const updateReportStatus = (reportId: string, status: ReportStatus, resolutionNote?: string) =>
+  request<AdminReportDetail>("PATCH", `/api/v1/admin/reports/${reportId}`, { status, resolutionNote });

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -306,6 +306,22 @@ export const updateMyProfile = async (payload: UserProfile): Promise<MeResponse 
   return res?.data ?? null;
 };
 
+export type ReportTargetType = "land" | "user" | "chat";
+export type ReportReason = "spam" | "fraude" | "contenido_inapropiado" | "informacion_falsa" | "otro";
+
+export interface CreateReportInput {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  description?: string;
+}
+
+/** POST /api/v1/reports — reporta un terreno/usuario/chat (usuario autenticado). */
+export const createReport = async (input: CreateReportInput): Promise<{ id: string } | null> => {
+  const res = await request<{ id: string }>("POST", "/api/v1/reports", input);
+  return res?.data ?? null;
+};
+
 export const api = {
   listLands,
   getMyLands,
@@ -322,4 +338,5 @@ export const api = {
   getMessages,
   sendMessage,
   getExternalContact,
+  createReport,
 };


### PR DESCRIPTION
## Objetivo
Moderación por reportes: panel admin (maquetas 09/26) + modelo/endpoints (sub-tarea de #134). Cierra #250.

## Backend
- Modelo `Report` (`targetType` land|user|chat, `reason`, `reporterId`, `status` open|reviewing|resolved|dismissed) + índices; `report` añadido al enum de auditoría.
- Endpoints: `POST /reports` (usuario auth) y `GET` / `GET/:id` / `PATCH /admin/reports` (solo admin, con auditoría). Registrados en `app.ts`.
- Seed de 30 reportes de ejemplo.

## Frontend
- `/dashboard/admin/reports` (lista 09) + `/dashboard/admin/reports/:id` (detalle + acciones de moderación 26), bajo `AdminRoute`.
- Enlace real **"Reportes"** en el nav del `AdminLayout` (reemplaza el placeholder).
- Modal para **reportar un terreno** desde su detalle.

## Verificación
- **213 tests backend ✓** (10 nuevos de reportes).
- E2E en vivo: crear (usuario) → listar (admin, con enriquecimiento + paginación) → detalle → transicionar a `resolved` (setea `resolvedBy`).
- `tsc --noEmit` web limpio.

Closes #250
