### PR TITLE
[web+backend] Variante de Trato COMPRA/VENTA (maqueta 24/28) (#249)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -60,11 +60,13 @@ export interface IRentalRequest extends Document {
   id: string;
   landId: string;
   tenantId: string;
-  period: {
+  operation: "alquiler" | "venta";
+  period?: {
     startDate: string;
     endDate: string;
   };
-  intendedUse: string;
+  intendedUse?: string;
+  offerAmount?: number;
   notes?: string;
   status: RentalRequestStatus;
   createdAt: Date;
@@ -195,11 +197,16 @@ const RentalRequestSchema = new Schema<IRentalRequest>({
   id: { type: String, required: true, unique: true },
   landId: { type: String, required: true },
   tenantId: { type: String, required: true },
+  // Tipo de trato: alquiler (07) o compra/venta (28). Por defecto alquiler para
+  // compatibilidad con las solicitudes existentes (#249).
+  operation: { type: String, enum: ["alquiler", "venta"], default: "alquiler" },
+  // period/intendedUse solo aplican al alquiler; offerAmount solo a la compra.
   period: {
-    startDate: { type: String, required: true },
-    endDate: { type: String, required: true },
+    startDate: { type: String },
+    endDate: { type: String },
   },
-  intendedUse: { type: String, required: true },
+  intendedUse: { type: String },
+  offerAmount: { type: Number },
   notes: String,
   status: { type: String, enum: ["draft", "pending_owner", "approved", "rejected", "cancelled", "pending_payment", "paid"], default: "draft" },
 }, { timestamps: true });

--- a/apps/backend-api/src/db/seed.ts
+++ b/apps/backend-api/src/db/seed.ts
@@ -168,20 +168,38 @@ function generateRentalRequests(count: number, landIds: string[], userIds: strin
   for (let i = 0; i < count; i++) {
     const startDate = randomDateFuture(90);
     const endDate = randomDateFuture(180);
-    requests.push({
-      id: `rr_${String(i + 1).padStart(4, "0")}`,
-      landId: randomItem(landIds),
-      tenantId: randomItem(userIds.filter((_, idx) => idx >= 3)),
-      period: {
-        startDate,
-        endDate,
-      },
-      intendedUse: randomItem(LAND_USES),
-      notes: `Interesado en alquilar este terreno para ${randomItem(LAND_USES)}.`,
-      status: randomItem(statuses),
-      createdAt: randomDate(90),
-      updatedAt: randomDate(30),
-    });
+    // ~20% de las solicitudes son ofertas de compra (#249): sin periodo/uso, con
+    // un monto ofertado; el resto son alquileres con periodo e uso previsto.
+    const isSale = i % 5 === 0;
+    if (isSale) {
+      requests.push({
+        id: `rr_${String(i + 1).padStart(4, "0")}`,
+        landId: randomItem(landIds),
+        tenantId: randomItem(userIds.filter((_, idx) => idx >= 3)),
+        operation: "venta",
+        offerAmount: randomBetween(20, 250) * 1000,
+        notes: "Oferta de compra por el terreno.",
+        status: randomItem(statuses),
+        createdAt: randomDate(90),
+        updatedAt: randomDate(30),
+      });
+    } else {
+      requests.push({
+        id: `rr_${String(i + 1).padStart(4, "0")}`,
+        landId: randomItem(landIds),
+        tenantId: randomItem(userIds.filter((_, idx) => idx >= 3)),
+        operation: "alquiler",
+        period: {
+          startDate,
+          endDate,
+        },
+        intendedUse: randomItem(LAND_USES),
+        notes: `Interesado en alquilar este terreno para ${randomItem(LAND_USES)}.`,
+        status: randomItem(statuses),
+        createdAt: randomDate(90),
+        updatedAt: randomDate(30),
+      });
+    }
   }
   return requests;
 }

--- a/apps/backend-api/src/routes/analytics.ts
+++ b/apps/backend-api/src/routes/analytics.ts
@@ -147,7 +147,9 @@ analyticsRoutes.get("/analytics/requests", requireAdmin, async (c) => {
 
   const byIntendedUse: Record<string, number> = {};
   for (const req of recentRequests) {
-    byIntendedUse[req.intendedUse] = (byIntendedUse[req.intendedUse] || 0) + 1;
+    // Las ofertas de compra no tienen intendedUse (#249); se agrupan como "venta".
+    const key = req.intendedUse ?? (req.operation === "venta" ? "venta" : "otro");
+    byIntendedUse[key] = (byIntendedUse[key] || 0) + 1;
   }
 
   const approvedLast30Days = requests.filter(

--- a/apps/backend-api/src/routes/payments.ts
+++ b/apps/backend-api/src/routes/payments.ts
@@ -105,8 +105,15 @@ function getStripeClient() {
 async function computePaymentAmount(rentalRequestId: string, fallback = 1000) {
   const request = await RentalRequest.findOne({ id: rentalRequestId }).lean();
   if (!request) return fallback;
-  
+
   const land = await Land.findOne({ id: request.landId }).lean();
+
+  // Compra/venta (#249): se cobra la oferta acordada, o el precio de venta del
+  // terreno como respaldo. El alquiler cobra el precio mensual (primer mes).
+  if (request.operation === "venta") {
+    return request.offerAmount ?? land?.salePrice ?? fallback;
+  }
+
   return land?.priceRule?.pricePerMonth ?? fallback;
 }
 

--- a/apps/backend-api/src/routes/rental-requests-extra.test.ts
+++ b/apps/backend-api/src/routes/rental-requests-extra.test.ts
@@ -75,6 +75,56 @@ describe("rental requests - extended coverage", () => {
     expect(payload.data.status).toBe("rejected");
   });
 
+  it("creates a purchase offer on a land that is for sale (#249)", async () => {
+    const { response, payload } = await requestJson("/api/v1/rental-requests", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_buyer_01" },
+      body: { landId: "land_seed_04", operation: "venta", offerAmount: 190000 },
+    });
+    expect(response.status).toBe(201);
+    expect(payload.ok).toBe(true);
+    expect(payload.data.operation).toBe("venta");
+    expect(payload.data.offerAmount).toBe(190000);
+    expect(payload.data.status).toBe("pending_owner");
+  });
+
+  it("rejects a purchase offer without an offerAmount", async () => {
+    const { response, payload } = await requestJson("/api/v1/rental-requests", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_buyer_02" },
+      body: { landId: "land_seed_04", operation: "venta" },
+    });
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+  });
+
+  it("rejects a purchase offer on a rent-only land", async () => {
+    const { response, payload } = await requestJson("/api/v1/rental-requests", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_buyer_03" },
+      body: { landId: "land_seed_01", operation: "venta", offerAmount: 50000 },
+    });
+    expect(response.status).toBe(422);
+    expect(payload.ok).toBe(false);
+  });
+
+  it("owner can approve a purchase offer", async () => {
+    const createRes = await requestJson("/api/v1/rental-requests", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_buyer_04" },
+      body: { landId: "land_seed_04", operation: "venta", offerAmount: 205000 },
+    });
+    const requestId = createRes.payload.data.id;
+
+    const { response, payload } = await requestJson(`/api/v1/rental-requests/${requestId}/status`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_owner_02" },
+      body: { status: "approved" },
+    });
+    expect(response.status).toBe(200);
+    expect(payload.data.status).toBe("approved");
+  });
+
   it("prevents non-owner from changing status", async () => {
     const createRes = await requestJson("/api/v1/rental-requests", {
       method: "POST",

--- a/apps/backend-api/src/routes/rental-requests.ts
+++ b/apps/backend-api/src/routes/rental-requests.ts
@@ -34,20 +34,19 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
   const body = (await c.req.json().catch(() => null)) as
     | {
         landId?: string;
+        operation?: "alquiler" | "venta";
         period?: { startDate?: string; endDate?: string };
         intendedUse?: string;
+        offerAmount?: number;
         notes?: string;
       }
     | null;
 
-  if (
-    !body?.landId ||
-    !body.period?.startDate ||
-    !body.period?.endDate ||
-    !body.intendedUse
-  ) {
+  if (!body?.landId) {
     return failure(c, 400, "VALIDATION_ERROR", "Missing required rental request fields");
   }
+
+  const operation = body.operation === "venta" ? "venta" : "alquiler";
 
   const land = await Land.findOne({ id: body.landId }).lean();
   if (!land) {
@@ -56,6 +55,53 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
 
   if (!canCreateRentalRequest(authUser, land)) {
     return failure(c, 422, "BUSINESS_RULE_VIOLATION", "Owner cannot create request for own land");
+  }
+
+  // La operación solicitada debe estar permitida por el terreno ("ambas" acepta
+  // las dos). Evita ofertar compra sobre un terreno que solo se alquila (#249).
+  const landOperation = land.operation ?? "alquiler";
+  if (landOperation !== "ambas" && landOperation !== operation) {
+    return failure(
+      c,
+      422,
+      "BUSINESS_RULE_VIOLATION",
+      `Este terreno no admite la operación '${operation}'`,
+    );
+  }
+
+  // A new request always awaits owner approval; it must not be auto-approved.
+  const initialStatus = "pending_owner";
+
+  if (operation === "venta") {
+    const offerAmount = Number(body.offerAmount);
+    if (!Number.isFinite(offerAmount) || offerAmount <= 0) {
+      return failure(c, 400, "VALIDATION_ERROR", "offerAmount must be a positive number");
+    }
+
+    const record = await RentalRequest.create({
+      id: `rr_${crypto.randomUUID()}`,
+      landId: body.landId,
+      tenantId: authUser.id,
+      operation: "venta",
+      offerAmount,
+      notes: body.notes,
+      status: initialStatus,
+    });
+
+    await createAuditEvent({
+      actor: authUser,
+      entity: "rental_request",
+      action: "created",
+      entityId: record.id,
+      metadata: { landId: record.landId, operation: "venta", offerAmount },
+    });
+
+    return success(c, record, 201);
+  }
+
+  // ── Alquiler ──
+  if (!body.period?.startDate || !body.period?.endDate || !body.intendedUse) {
+    return failure(c, 400, "VALIDATION_ERROR", "Missing required rental request fields");
   }
 
   const allowedUses = (land.allowedUses ?? []) as string[];
@@ -76,10 +122,11 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
 
   const overlappingPaid = await RentalRequest.findOne({
     landId: body.landId,
+    operation: { $ne: "venta" },
     status: { $in: ["approved", "pending_payment", "paid"] },
   }).lean();
 
-  if (overlappingPaid) {
+  if (overlappingPaid?.period) {
     const existingStart = Date.parse(overlappingPaid.period.startDate);
     const existingEnd = Date.parse(overlappingPaid.period.endDate);
     if (periodStart < existingEnd && periodEnd > existingStart) {
@@ -92,13 +139,11 @@ rentalRequestRoutes.post("/rental-requests", requireAuth, async (c) => {
     }
   }
 
-  // A new request always awaits owner approval; it must not be auto-approved.
-  const initialStatus = "pending_owner";
-
   const record = await RentalRequest.create({
     id: `rr_${crypto.randomUUID()}`,
     landId: body.landId,
     tenantId: authUser.id,
+    operation: "alquiler",
     period: {
       startDate: body.period.startDate,
       endDate: body.period.endDate,

--- a/apps/backend-api/src/store/types.ts
+++ b/apps/backend-api/src/store/types.ts
@@ -62,11 +62,13 @@ export interface RentalRequestRecord {
   id: string;
   landId: string;
   tenantId: string;
-  period: {
+  operation?: "alquiler" | "venta";
+  period?: {
     startDate: string;
     endDate: string;
   };
-  intendedUse: string;
+  intendedUse?: string;
+  offerAmount?: number;
   notes?: string;
   status: RentalRequestStatus;
   createdAt: string;

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -59,7 +59,8 @@ function formatPeriod(startDate?: string, endDate?: string): string {
   return `${formatMonth(startDate)} – ${formatMonth(endDate)}`;
 }
 
-function useLabel(use: string): string {
+function useLabel(use?: string): string {
+  if (!use) return "Terreno";
   return USE_LABELS[use] ?? use;
 }
 
@@ -150,7 +151,9 @@ function BuscoHome({ name }: { name: string }) {
               return (
                 <div key={req.id} className="hm-req">
                   <div className="hm-req__top">
-                    <span className="hm-req__title">{useLabel(req.intendedUse)}</span>
+                    <span className="hm-req__title">
+                      {req.operation === "venta" ? "Compra" : useLabel(req.intendedUse)}
+                    </span>
                     <span className={`hm-badge ${status.badge}`}>{status.label}</span>
                   </div>
                   <div className="hm-req__meta">

--- a/apps/web/src/pages/PaymentPage.tsx
+++ b/apps/web/src/pages/PaymentPage.tsx
@@ -4,7 +4,7 @@ import { useParams, Link } from "@tanstack/react-router";
 import { loadStripe } from "@stripe/stripe-js";
 import { Elements, PaymentElement, useStripe, useElements } from "@stripe/react-stripe-js";
 import { ArrowLeft, Sprout, Check, CreditCard, FileText, Flag, Lock, MessageCircle } from "lucide-react";
-import { confirmPayment, createPaymentIntent, getPaymentsByRequest } from "../services/api";
+import { confirmPayment, createPaymentIntent, getPaymentsByRequest, getRentalRequestById } from "../services/api";
 import "./deal.css";
 
 const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY);
@@ -31,14 +31,14 @@ function DealNav({ requestId }: { requestId?: string }) {
   );
 }
 
-function Stepper() {
+function Stepper({ isSale = false }: { isSale?: boolean }) {
   return (
     <div className="dl-stepper">
       <div className="dl-step">
         <span className="dl-step__dot dl-step__dot--done">
           <Check size={17} />
         </span>
-        <div className="dl-step__label dl-step__label--done">Solicitud</div>
+        <div className="dl-step__label dl-step__label--done">{isSale ? "Oferta" : "Solicitud"}</div>
       </div>
       <div className="dl-line dl-line--done" />
       <div className="dl-step">
@@ -123,6 +123,7 @@ export default function PaymentPage() {
   const [error, setError] = useState("");
   const [paymentData, setPaymentData] = useState<PaymentData | null>(null);
   const [alreadyPaid, setAlreadyPaid] = useState(false);
+  const [isSale, setIsSale] = useState(false);
 
   useEffect(() => {
     if (!requestId) {
@@ -132,6 +133,9 @@ export default function PaymentPage() {
     }
     const initPayment = async () => {
       try {
+        // La operación del trato define la variante (alquiler 07 vs compra 28, #249).
+        const req = await getRentalRequestById(requestId).catch(() => null);
+        if (req?.operation === "venta") setIsSale(true);
         // Verifica contra Stripe por si ya se pagó (p. ej. sin webhook local).
         await confirmPayment(requestId).catch(() => null);
         const payments = await getPaymentsByRequest(requestId);
@@ -210,12 +214,14 @@ export default function PaymentPage() {
               <Sprout size={24} strokeWidth={1.4} />
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
-              <div className="dl-head__title">Trato de alquiler</div>
-              <div className="dl-head__meta">Solicitud #{requestId?.slice(0, 8)}</div>
+              <div className="dl-head__title">{isSale ? "Trato de compra" : "Trato de alquiler"}</div>
+              <div className="dl-head__meta">
+                {isSale ? "Oferta" : "Solicitud"} #{requestId?.slice(0, 8)}
+              </div>
             </div>
             <span className="dl-head__status">Aprobada · falta pago</span>
           </div>
-          <Stepper />
+          <Stepper isSale={isSale} />
         </div>
 
         <div className="dl-body">
@@ -223,16 +229,22 @@ export default function PaymentPage() {
             <h3 className="dl-section-title">Actividad</h3>
             <div className="dl-timeline">
               <div>
-                <div className="dl-tl__title">Solicitud enviada</div>
-                <div className="dl-tl__meta">Enviaste tu solicitud de alquiler</div>
+                <div className="dl-tl__title">{isSale ? "Oferta enviada" : "Solicitud enviada"}</div>
+                <div className="dl-tl__meta">
+                  {isSale ? "Enviaste tu oferta de compra" : "Enviaste tu solicitud de alquiler"}
+                </div>
               </div>
               <div>
-                <div className="dl-tl__title">Solicitud aprobada</div>
-                <div className="dl-tl__meta">El propietario aceptó tu solicitud</div>
+                <div className="dl-tl__title">{isSale ? "Oferta aceptada" : "Solicitud aprobada"}</div>
+                <div className="dl-tl__meta">
+                  {isSale ? "El propietario aceptó tu oferta" : "El propietario aceptó tu solicitud"}
+                </div>
               </div>
               <div>
                 <div className="dl-tl__title dl-tl__title--accent">Esperando tu pago</div>
-                <div className="dl-tl__meta">Completa el pago para activar el alquiler</div>
+                <div className="dl-tl__meta">
+                  {isSale ? "Completa el pago para cerrar la compra" : "Completa el pago para activar el alquiler"}
+                </div>
               </div>
             </div>
 
@@ -250,7 +262,9 @@ export default function PaymentPage() {
             <div className="dl-pay__card">
               <div className="dl-pay__k">Total a pagar</div>
               <div className="dl-pay__amount">${paymentData.amount}</div>
-              <div className="dl-pay__sub">Primer mes de alquiler · {paymentData.currency}</div>
+              <div className="dl-pay__sub">
+                {isSale ? "Precio de compra" : "Primer mes de alquiler"} · {paymentData.currency}
+              </div>
               <Elements
                 stripe={stripePromise}
                 options={{

--- a/apps/web/src/pages/ReservePage.tsx
+++ b/apps/web/src/pages/ReservePage.tsx
@@ -16,6 +16,8 @@ const USO_OPCIONES = [
   { value: "otro", label: "Otro" },
 ];
 
+type Operation = "alquiler" | "venta" | "ambas";
+
 interface ReserveLand {
   id?: string;
   type?: string;
@@ -24,6 +26,8 @@ interface ReserveLand {
   district?: string;
   areaHectares?: number;
   monthlyPrice?: number;
+  operation?: Operation;
+  salePrice?: number;
   availableFrom?: string;
   features?: string[];
 }
@@ -40,6 +44,8 @@ type LandLike = Record<string, unknown> & {
   area?: number;
   monthlyPrice?: number;
   priceRule?: { pricePerMonth?: number };
+  operation?: Operation;
+  salePrice?: number;
   availableFrom?: string;
   availability?: { availableFrom?: string };
   features?: string[];
@@ -62,6 +68,8 @@ function normalizeReserveLand(land: LandLike | null | undefined): ReserveLand | 
     district: land.district ?? land.location?.district ?? "",
     areaHectares: land.areaHectares ?? land.area ?? 0,
     monthlyPrice: land.monthlyPrice ?? land.priceRule?.pricePerMonth ?? 0,
+    operation: land.operation ?? "alquiler",
+    salePrice: land.salePrice,
     availableFrom: land.availableFrom ?? land.availability?.availableFrom ?? "",
     features: land.features,
   };
@@ -71,6 +79,7 @@ interface ReserveForm {
   startDate: string;
   endDate: string;
   intendedUse: string;
+  offerAmount: string;
   notes: string;
 }
 
@@ -103,6 +112,7 @@ export default function ReservePage() {
     startDate: "",
     endDate: "",
     intendedUse: "",
+    offerAmount: "",
     notes: "",
   });
 
@@ -133,11 +143,39 @@ export default function ReservePage() {
     setError("");
   };
 
+  const isSale = (land?.operation ?? "alquiler") !== "alquiler";
+
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (!isSignedIn && !import.meta.env.DEV) {
       navigate({ to: "/login", replace: true });
+      return;
+    }
+
+    if (isSale) {
+      const offer = Number(form.offerAmount);
+      if (!Number.isFinite(offer) || offer <= 0) {
+        setError("Ingresa un monto de oferta válido.");
+        return;
+      }
+
+      setSubmitting(true);
+      setError("");
+      try {
+        const result = await createRentalRequest({
+          landId: landId!,
+          operation: "venta",
+          offerAmount: offer,
+          notes: form.notes || undefined,
+        });
+        setSuccess(`El propietario revisará tu oferta pronto. ID: ${result?.id ?? "—"}.`);
+        setTimeout(() => navigate({ to: "/dashboard", replace: true }), 3000);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Error al enviar la oferta.");
+      } finally {
+        setSubmitting(false);
+      }
       return;
     }
 
@@ -159,6 +197,7 @@ export default function ReservePage() {
     try {
       const result = await createRentalRequest({
         landId: landId!,
+        operation: "alquiler",
         period: { startDate: form.startDate, endDate: form.endDate },
         intendedUse: form.intendedUse,
         notes: form.notes || undefined,
@@ -240,7 +279,16 @@ export default function ReservePage() {
                 </div>
               </div>
               <div className="rsv-summary__price">
-                {(land.monthlyPrice ?? 0) > 0 ? (
+                {isSale ? (
+                  typeof land.salePrice === "number" && land.salePrice > 0 ? (
+                    <>
+                      ${land.salePrice.toLocaleString("es-PA")}
+                      <span> venta</span>
+                    </>
+                  ) : (
+                    "Precio a consultar"
+                  )
+                ) : (land.monthlyPrice ?? 0) > 0 ? (
                   <>
                     ${land.monthlyPrice?.toLocaleString("es-PA")}
                     <span>/mes</span>
@@ -255,8 +303,12 @@ export default function ReservePage() {
 
         {/* formulario */}
         <section>
-          <h1 className="rsv-title">Solicitar alquiler</h1>
-          <p className="rsv-sub">Completa los datos para enviar tu solicitud al propietario.</p>
+          <h1 className="rsv-title">{isSale ? "Hacer oferta" : "Solicitar alquiler"}</h1>
+          <p className="rsv-sub">
+            {isSale
+              ? "Propón tu precio de compra y envíalo al propietario."
+              : "Completa los datos para enviar tu solicitud al propietario."}
+          </p>
 
           <div className="rsv-card">
             {success ? (
@@ -264,64 +316,90 @@ export default function ReservePage() {
                 <div className="rsv-success__icon">
                   <Check size={28} />
                 </div>
-                <h2>¡Solicitud enviada!</h2>
+                <h2>{isSale ? "¡Oferta enviada!" : "¡Solicitud enviada!"}</h2>
                 <p>{success}</p>
                 <p>Redirigiendo al panel…</p>
               </div>
             ) : (
               <form onSubmit={handleSubmit}>
-                <div className="rsv-row">
+                {isSale ? (
                   <div className="rsv-field">
-                    <label className="rsv-label" htmlFor="startDate">
-                      Fecha de inicio
+                    <label className="rsv-label" htmlFor="offerAmount">
+                      Tu oferta (USD)
                     </label>
                     <input
-                      id="startDate"
+                      id="offerAmount"
                       className="rsv-input"
-                      type="date"
-                      value={form.startDate}
-                      onChange={(e) => handleChange("startDate", e.target.value)}
-                      min={new Date().toISOString().split("T")[0]}
+                      type="number"
+                      min={1}
+                      step={100}
+                      value={form.offerAmount}
+                      onChange={(e) => handleChange("offerAmount", e.target.value)}
+                      placeholder={
+                        typeof land.salePrice === "number" && land.salePrice > 0
+                          ? `Precio pedido: $${land.salePrice.toLocaleString("es-PA")}`
+                          : "Ingresa tu oferta"
+                      }
                       required
                       disabled={submitting}
                     />
                   </div>
-                  <div className="rsv-field">
-                    <label className="rsv-label" htmlFor="endDate">
-                      Fecha de fin
-                    </label>
-                    <input
-                      id="endDate"
-                      className="rsv-input"
-                      type="date"
-                      value={form.endDate}
-                      onChange={(e) => handleChange("endDate", e.target.value)}
-                      min={form.startDate || new Date().toISOString().split("T")[0]}
-                      required
-                      disabled={submitting}
-                    />
-                  </div>
-                </div>
+                ) : (
+                  <>
+                    <div className="rsv-row">
+                      <div className="rsv-field">
+                        <label className="rsv-label" htmlFor="startDate">
+                          Fecha de inicio
+                        </label>
+                        <input
+                          id="startDate"
+                          className="rsv-input"
+                          type="date"
+                          value={form.startDate}
+                          onChange={(e) => handleChange("startDate", e.target.value)}
+                          min={new Date().toISOString().split("T")[0]}
+                          required
+                          disabled={submitting}
+                        />
+                      </div>
+                      <div className="rsv-field">
+                        <label className="rsv-label" htmlFor="endDate">
+                          Fecha de fin
+                        </label>
+                        <input
+                          id="endDate"
+                          className="rsv-input"
+                          type="date"
+                          value={form.endDate}
+                          onChange={(e) => handleChange("endDate", e.target.value)}
+                          min={form.startDate || new Date().toISOString().split("T")[0]}
+                          required
+                          disabled={submitting}
+                        />
+                      </div>
+                    </div>
 
-                <div className="rsv-field">
-                  <label className="rsv-label" htmlFor="intendedUse">
-                    Uso del terreno
-                  </label>
-                  <select
-                    id="intendedUse"
-                    className="rsv-input"
-                    value={form.intendedUse}
-                    onChange={(e) => handleChange("intendedUse", e.target.value)}
-                    required
-                    disabled={submitting}
-                  >
-                    {USO_OPCIONES.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+                    <div className="rsv-field">
+                      <label className="rsv-label" htmlFor="intendedUse">
+                        Uso del terreno
+                      </label>
+                      <select
+                        id="intendedUse"
+                        className="rsv-input"
+                        value={form.intendedUse}
+                        onChange={(e) => handleChange("intendedUse", e.target.value)}
+                        required
+                        disabled={submitting}
+                      >
+                        {USO_OPCIONES.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </>
+                )}
 
                 <div className="rsv-field">
                   <label className="rsv-label" htmlFor="notes">
@@ -332,7 +410,11 @@ export default function ReservePage() {
                     className="rsv-input"
                     value={form.notes}
                     onChange={(e) => handleChange("notes", e.target.value)}
-                    placeholder="Preséntate y cuéntale sobre tu proyecto…"
+                    placeholder={
+                      isSale
+                        ? "Cuéntale por qué te interesa el terreno…"
+                        : "Preséntate y cuéntale sobre tu proyecto…"
+                    }
                     rows={4}
                     disabled={submitting}
                   />
@@ -342,7 +424,7 @@ export default function ReservePage() {
 
                 <div className="rsv-actions">
                   <button type="submit" className="rsv-submit" disabled={submitting}>
-                    {submitting ? "Enviando…" : "Enviar solicitud"}
+                    {submitting ? "Enviando…" : isSale ? "Enviar oferta" : "Enviar solicitud"}
                   </button>
                   <Link to={landId ? "/lands/$id" : "/catalog"} params={{ id: landId }} className="rsv-cancel">
                     Cancelar
@@ -350,8 +432,10 @@ export default function ReservePage() {
                 </div>
 
                 <p className="rsv-note">
-                  <Info size={15} /> El propietario recibirá tu solicitud y podrá aceptarla o
-                  rechazarla. No se cobra nada hasta que sea aprobada.
+                  <Info size={15} />{" "}
+                  {isSale
+                    ? "El propietario recibirá tu oferta y podrá aceptarla o rechazarla. No se cobra nada hasta que sea aprobada."
+                    : "El propietario recibirá tu solicitud y podrá aceptarla o rechazarla. No se cobra nada hasta que sea aprobada."}
                 </p>
               </form>
             )}

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -126,6 +126,12 @@ export const listRentalRequests = async (): Promise<RentalRequestDto[]> => {
   return res?.data ?? [];
 };
 
+/** GET /api/v1/rental-requests/:requestId */
+export const getRentalRequestById = async (requestId: string): Promise<RentalRequestDto | null> => {
+  const res = await request<RentalRequestDto>("GET", `/api/v1/rental-requests/${requestId}`);
+  return res?.data ?? null;
+};
+
 /** GET /api/v1/lands/:landId */
 export const getLandById = async (landId: string): Promise<LandDto | null> => {
   const res = await request<LandDto>("GET", `/api/v1/lands/${landId}`);
@@ -312,6 +318,7 @@ export const api = {
   getLandById,
   createRentalRequest,
   listRentalRequests,
+  getRentalRequestById,
   createCheckoutSession,
   getPaymentsByRequest,
   getMyPayments,

--- a/packages/shared/src/dto/rental-requests.ts
+++ b/packages/shared/src/dto/rental-requests.ts
@@ -12,12 +12,16 @@ export interface RentalPeriodDto {
   endDate: string;
 }
 
+export type DealOperation = "alquiler" | "venta";
+
 export interface RentalRequestDto {
   id: string;
   landId: string;
   tenantId: string;
-  period: RentalPeriodDto;
-  intendedUse: string;
+  operation?: DealOperation;
+  period?: RentalPeriodDto;
+  intendedUse?: string;
+  offerAmount?: number;
   notes?: string;
   status: RentalRequestStatus;
   createdAt: string;
@@ -26,8 +30,10 @@ export interface RentalRequestDto {
 
 export interface CreateRentalRequestDto {
   landId: string;
-  period: RentalPeriodDto;
-  intendedUse: string;
+  operation?: DealOperation;
+  period?: RentalPeriodDto;
+  intendedUse?: string;
+  offerAmount?: number;
   notes?: string;
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,6 +42,7 @@ export type {
   RentalRequestDto,
   RentalRequestStatus,
   UpdateRentalRequestStatusDto,
+  DealOperation,
 } from "./dto/rental-requests";
 
 export type {


### PR DESCRIPTION
## Objetivo
Variante de Trato COMPRA/VENTA (maquetas 24/28) con flujo completo backend + frontend (sub-tarea de #134). Cierra #249.

## Backend
- `RentalRequest` gana `operation` (alquiler|venta) y `offerAmount`; `period`/`intendedUse` pasan a opcionales (solo alquiler).
- `POST /rental-requests` ramifica por operación: la oferta de compra exige `offerAmount>0` y que el terreno admita venta (venta/ambas); el alquiler mantiene validación de periodo/uso y solapamiento.
- El monto de pago usa la oferta o el `salePrice` del terreno para compras; el alquiler sigue cobrando el precio mensual.
- Seed: ~20% de solicitudes son ofertas de compra.

## Frontend
- `ReservePage`: variante **"Hacer oferta"** (24) con monto de oferta según `land.operation`.
- `PaymentPage`: variante **"Trato de compra"** (28) — copys, stepper y etiqueta de monto según la operación del trato.
- DTOs compartidos + `api.getRentalRequestById`.

## Ruta
La ruta del trato permanece en `/pay/:requestId`; el mapa del épico #134 se actualizó para reflejarlo (en lugar de `/deals/:id`).

## Verificación
- **207 tests backend ✓** (4 nuevos de compra/venta).
- E2E en vivo: crear terreno de venta → oferta de compra aceptada (201, `offerAmount` guardado) → guard alquiler-sobre-venta 422.
- `tsc --noEmit` web limpio.

Closes #249
