### PR TITLE
fix(web+backend): el rol admin llega al backend y adminApi autentica en produccion (#262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,21 @@ Un admin logueado ve la entrada **"Panel admin"** en el menu de usuario de la Na
 2. **Cualquier cuenta:** en el [Dashboard de Clerk](https://dashboard.clerk.com) → Users → (usuario) → **Metadata → Public**, agrega `{ "role": "admin" }` y guarda. Al re-loguear, el usuario tendra acceso al panel.
 
 > Nota: los usuarios `role:"admin"` creados por `apps/backend-api/src/db/seed.ts` (emails `@terrashare.test`) son datos de relleno para poblar las vistas; **no permiten iniciar sesion** porque no existen como identidades en Clerk.
+
+### Como llega el rol al backend
+
+El token de sesion por defecto de Clerk **no incluye `public_metadata`**, asi que el backend no puede leer el rol de los claims. Para resolverlo, `resolveClerkAuthUser` consulta la **Clerk Backend API** (con `CLERK_SECRET_KEY`, cacheada 5 min) y obtiene de ahi el rol y el estado de 2FA del usuario.
+
+Consecuencias practicas:
+
+- **`CLERK_SECRET_KEY` es obligatoria** para que un admin real sea reconocido por la API. Sin ella, todos los usuarios llegan como `role: "user"` y `/api/v1/admin/*` responde `403`.
+- Si prefieres evitar la llamada a Clerk, puedes anadir un claim `role` (o `public_metadata`) al token mediante una **JWT template / custom session claims** en Clerk; cuando el claim existe, el backend no consulta la API.
+
+### MFA para admins
+
+`requireAdmin` puede exigir 2FA a los endpoints `/admin/*`, controlado por `REQUIRE_ADMIN_MFA`:
+
+- **Produccion:** activo por defecto. Un admin sin 2FA recibe `403 MFA_REQUIRED`.
+- **Fuera de produccion:** desactivado por defecto (las cuentas admin locales rara vez tienen 2FA).
+
+El estado de 2FA se lee del usuario real en Clerk (`twoFactorEnabled`), no de un claim que el token nunca emitia.

--- a/apps/backend-api/.env.example
+++ b/apps/backend-api/.env.example
@@ -10,6 +10,11 @@ CLERK_SECRET_KEY=sk_test_your_clerk_secret_key
 # Set to "true" to bypass Clerk auth in local dev (NEVER enable in production)
 ALLOW_DEV_AUTH_BYPASS=false
 
+# Exige 2FA (Clerk) para los endpoints /admin/*. Por defecto: "true" en
+# produccion, "false" fuera de ella. El backend lee el 2FA real del usuario via
+# Clerk Backend API, asi que requiere CLERK_SECRET_KEY.
+REQUIRE_ADMIN_MFA=false
+
 # Stripe — get these from the Stripe dashboard
 STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret

--- a/apps/backend-api/src/config/env.ts
+++ b/apps/backend-api/src/config/env.ts
@@ -7,6 +7,7 @@ export const envSchema = z.object({
   CLERK_JWKS_URL: z.string().url("CLERK_JWKS_URL must be a valid URL"),
   CLERK_ISSUER: z.string().min(1, "CLERK_ISSUER is required"),
   ALLOW_DEV_AUTH_BYPASS: z.string().optional(),
+  REQUIRE_ADMIN_MFA: z.string().optional(),
   ADMIN_SEED_EMAIL: z.string().default("terradmin@gmail.com"),
   STRIPE_SECRET_KEY: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
@@ -35,6 +36,15 @@ export const env = {
   get allowDevAuthBypass() {
     const fallback = process.env.NODE_ENV !== "production" ? "true" : "false";
     return (process.env.ALLOW_DEV_AUTH_BYPASS ?? fallback) === "true";
+  },
+  /**
+   * Exige 2FA para los endpoints de admin. En producción va activo por defecto;
+   * fuera de producción se apaga salvo que se pida explícitamente, porque las
+   * cuentas admin locales rara vez tienen 2FA configurado en Clerk (#262).
+   */
+  get requireAdminMfa() {
+    const fallback = process.env.NODE_ENV === "production" ? "true" : "false";
+    return (process.env.REQUIRE_ADMIN_MFA ?? fallback) === "true";
   },
   adminSeedEmail: parsed.ADMIN_SEED_EMAIL.toLowerCase(),
   clerkSecretKey: parsed.CLERK_SECRET_KEY,

--- a/apps/backend-api/src/lib/auth-helpers.test.ts
+++ b/apps/backend-api/src/lib/auth-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { requireAdmin } from "../middleware/require-auth";
 import type { AuthContextUser } from "../types";
@@ -286,6 +286,17 @@ const mfaAdminUser = {
 };
 
 describe("requireAdmin", () => {
+  // La exigencia de MFA pasa a ser configurable (#262): activa por defecto en
+  // produccion. Estas pruebas la fuerzan para no depender de NODE_ENV.
+  const previousRequireAdminMfa = process.env.REQUIRE_ADMIN_MFA;
+  beforeEach(() => {
+    process.env.REQUIRE_ADMIN_MFA = "true";
+  });
+  afterEach(() => {
+    if (previousRequireAdminMfa === undefined) delete process.env.REQUIRE_ADMIN_MFA;
+    else process.env.REQUIRE_ADMIN_MFA = previousRequireAdminMfa;
+  });
+
   it("rechaza admin sin MFA en produccion", async () => {
     const c = {
       get: (key: string) => {

--- a/apps/backend-api/src/lib/clerk-backend.test.ts
+++ b/apps/backend-api/src/lib/clerk-backend.test.ts
@@ -11,6 +11,8 @@ interface FakeUserShape {
   primaryEmailAddress: { emailAddress: string } | null;
   fullName: string | null;
   primaryPhoneNumber: { phoneNumber: string } | null;
+  publicMetadata?: Record<string, unknown>;
+  twoFactorEnabled?: boolean;
 }
 
 function makeFakeClient(
@@ -60,7 +62,29 @@ describe("getClerkUserProfile", () => {
       email: "real@example.com",
       fullName: "Real Person",
       phone: "+50761234567",
+      role: undefined,
+      twoFactorEnabled: false,
     });
+  });
+
+  it("maps role from publicMetadata and the 2FA flag (#262)", async () => {
+    const counter = { calls: 0 };
+    __setClerkClientForTests(
+      makeFakeClient(
+        {
+          primaryEmailAddress: { emailAddress: "admin@example.com" },
+          fullName: "Admin Person",
+          primaryPhoneNumber: null,
+          publicMetadata: { role: "admin" },
+          twoFactorEnabled: true,
+        },
+        counter,
+      ),
+    );
+
+    const profile = await getClerkUserProfile("user_admin");
+    expect(profile?.role).toBe("admin");
+    expect(profile?.twoFactorEnabled).toBe(true);
   });
 
   it("caches the result and does not hit Clerk twice", async () => {

--- a/apps/backend-api/src/lib/clerk-backend.ts
+++ b/apps/backend-api/src/lib/clerk-backend.ts
@@ -6,11 +6,17 @@ import { env } from "../config/env";
  * Perfil enriquecido que devuelve la Clerk Backend API.
  * Todos los campos son opcionales: el token de sesión por defecto de Clerk no
  * incluye email/nombre, así que los resolvemos aquí (issue #132, Opción B).
+ *
+ * El token tampoco incluye `public_metadata` ni el estado de 2FA, así que el rol
+ * y `twoFactorEnabled` también se resuelven aquí; sin esto el backend nunca veía
+ * como admin a un usuario que sí lo es en Clerk (issue #262).
  */
 export interface ClerkUserProfile {
   email?: string;
   fullName?: string;
   phone?: string;
+  role?: string;
+  twoFactorEnabled?: boolean;
 }
 
 interface CacheEntry {
@@ -71,10 +77,13 @@ export async function getClerkUserProfile(
 
   try {
     const user = await clerk.users.getUser(userId);
+    const metadataRole = (user.publicMetadata as Record<string, unknown> | undefined)?.role;
     const profile: ClerkUserProfile = {
       email: user.primaryEmailAddress?.emailAddress ?? undefined,
       fullName: user.fullName?.trim() || undefined,
       phone: user.primaryPhoneNumber?.phoneNumber ?? undefined,
+      role: typeof metadataRole === "string" ? metadataRole : undefined,
+      twoFactorEnabled: user.twoFactorEnabled === true,
     };
     cache.set(userId, { value: profile, expiresAt: Date.now() + CACHE_TTL_MS });
     return profile;

--- a/apps/backend-api/src/lib/clerk-user.test.ts
+++ b/apps/backend-api/src/lib/clerk-user.test.ts
@@ -53,6 +53,8 @@ interface FakeUserShape {
   primaryEmailAddress: { emailAddress: string } | null;
   fullName: string | null;
   primaryPhoneNumber: { phoneNumber: string } | null;
+  publicMetadata?: Record<string, unknown>;
+  twoFactorEnabled?: boolean;
 }
 
 function fakeClerkClient(
@@ -75,7 +77,7 @@ describe("resolveClerkAuthUser", () => {
     __clearClerkUserProfileCache();
   });
 
-  it("does not call Clerk when the token already has email and name", async () => {
+  it("does not call Clerk when the token already has email, name and role", async () => {
     const counter = { calls: 0 };
     __setClerkClientForTests(
       fakeClerkClient(
@@ -92,10 +94,79 @@ describe("resolveClerkAuthUser", () => {
       sub: "user_present",
       email: "present@example.com",
       full_name: "Present User",
+      role: "user",
     });
 
     expect(user.email).toBe("present@example.com");
     expect(user.profile.fullName).toBe("Present User");
+    expect(counter.calls).toBe(0);
+  });
+
+  it("resolves the admin role from Clerk publicMetadata when the token lacks it (#262)", async () => {
+    const counter = { calls: 0 };
+    __setClerkClientForTests(
+      fakeClerkClient(
+        {
+          primaryEmailAddress: { emailAddress: "real.admin@example.com" },
+          fullName: "Real Admin",
+          primaryPhoneNumber: null,
+          publicMetadata: { role: "admin" },
+          twoFactorEnabled: true,
+        },
+        counter,
+      ),
+    );
+
+    const user = await resolveClerkAuthUser({ sub: "user_meta_admin" });
+
+    expect(user.role).toBe("admin");
+    expect(user.mfaVerified).toBe(true);
+    expect(counter.calls).toBe(1);
+  });
+
+  it("keeps a non-admin as user and reflects 2FA disabled", async () => {
+    const counter = { calls: 0 };
+    __setClerkClientForTests(
+      fakeClerkClient(
+        {
+          primaryEmailAddress: { emailAddress: "plain@example.com" },
+          fullName: "Plain User",
+          primaryPhoneNumber: null,
+          publicMetadata: {},
+          twoFactorEnabled: false,
+        },
+        counter,
+      ),
+    );
+
+    const user = await resolveClerkAuthUser({ sub: "user_plain" });
+
+    expect(user.role).toBe("user");
+    expect(user.mfaVerified).toBe(false);
+  });
+
+  it("does not let Clerk metadata override an explicit role claim", async () => {
+    const counter = { calls: 0 };
+    __setClerkClientForTests(
+      fakeClerkClient(
+        {
+          primaryEmailAddress: { emailAddress: "claim@example.com" },
+          fullName: "Claim User",
+          primaryPhoneNumber: null,
+          publicMetadata: { role: "admin" },
+        },
+        counter,
+      ),
+    );
+
+    const user = await resolveClerkAuthUser({
+      sub: "user_claim",
+      email: "claim@example.com",
+      full_name: "Claim User",
+      role: "user",
+    });
+
+    expect(user.role).toBe("user");
     expect(counter.calls).toBe(0);
   });
 

--- a/apps/backend-api/src/lib/clerk-user.ts
+++ b/apps/backend-api/src/lib/clerk-user.ts
@@ -109,21 +109,29 @@ export function mapClerkClaimsToAuthUser(payload: JWTPayload): AuthContextUser {
 
 /**
  * Igual que {@link mapClerkClaimsToAuthUser}, pero cuando el token no trae
- * `email`/`name` (caso del token de sesión por defecto de Clerk) enriquece el
- * usuario con un fetch a la Clerk Backend API usando el `sub` (issue #132).
+ * `email`/`name`/`role` (caso del token de sesión por defecto de Clerk)
+ * enriquece el usuario con un fetch a la Clerk Backend API usando el `sub`
+ * (issues #132 y #262).
  *
  * El perfil obtenido se superpone sobre los claims y se re-mapea, de modo que
- * la lógica de rol (admin por email semilla) vuelve a evaluarse con el email
- * real. Si Clerk no está configurado o el fetch falla, degrada al mapeo puro.
+ * la lógica de rol (admin por email semilla o por `publicMetadata.role`) vuelve
+ * a evaluarse con los datos reales. Si Clerk no está configurado o el fetch
+ * falla, degrada al mapeo puro.
  */
 export async function resolveClerkAuthUser(
   payload: JWTPayload,
 ): Promise<AuthContextUser> {
   const base = mapClerkClaimsToAuthUser(payload);
+  const claims = payload as ClaimRecord;
 
   const needsEmail = base.email === FALLBACK_EMAIL;
   const needsName = base.profile.fullName === FALLBACK_NAME;
-  if (!needsEmail && !needsName) {
+  // Sin claim de rol no podemos saber si es admin: el token de sesión por
+  // defecto de Clerk no incluye `public_metadata` (#262).
+  const hasRoleClaim =
+    readClaim(claims, "role") !== undefined || readPublicMetadata(claims, "role") !== undefined;
+
+  if (!needsEmail && !needsName && hasRoleClaim) {
     return base;
   }
 
@@ -132,7 +140,7 @@ export async function resolveClerkAuthUser(
     return base;
   }
 
-  const enrichedClaims: ClaimRecord = { ...(payload as ClaimRecord) };
+  const enrichedClaims: ClaimRecord = { ...claims };
   if (needsEmail && profile.email) {
     enrichedClaims.email = profile.email;
   }
@@ -141,6 +149,15 @@ export async function resolveClerkAuthUser(
   }
   if (!base.profile.phone && profile.phone) {
     enrichedClaims.phone_number = profile.phone;
+  }
+  if (!hasRoleClaim && profile.role) {
+    const metadata = (claims.public_metadata as ClaimRecord | undefined) ?? {};
+    enrichedClaims.public_metadata = { ...metadata, role: profile.role };
+  }
+  // El 2FA real de Clerk sustituye al claim `mfa_verified`, que el token de
+  // sesión tampoco emite: sin esto la exigencia de MFA para admins era inerte.
+  if (readClaim(claims, "mfa_verified") === undefined && profile.twoFactorEnabled !== undefined) {
+    enrichedClaims.mfa_verified = profile.twoFactorEnabled;
   }
 
   return mapClerkClaimsToAuthUser(enrichedClaims as JWTPayload);

--- a/apps/backend-api/src/middleware/require-auth.ts
+++ b/apps/backend-api/src/middleware/require-auth.ts
@@ -148,7 +148,7 @@ export const requireAdmin: MiddlewareHandler<AppEnv> = async (c, next) => {
 
   const hasDevHeader = Boolean(c.req.header("x-dev-user-id") || c.req.header("x-dev-role"));
   const isDevBypass = hasDevHeader && env.allowDevAuthBypass;
-  if (!isDevBypass && authUser.mfaVerified !== true) {
+  if (env.requireAdminMfa && !isDevBypass && authUser.mfaVerified !== true) {
     return failure(c, 403, "MFA_REQUIRED", "Admin must have MFA enabled");
   }
 

--- a/apps/web/src/pages/AdminAuditPage.tsx
+++ b/apps/web/src/pages/AdminAuditPage.tsx
@@ -54,7 +54,18 @@ export default function AdminAuditPage() {
         if (token) headers["Authorization"] = `Bearer ${token}`;
         else if (import.meta.env.DEV) { headers["x-dev-role"] = "admin"; headers["x-dev-user-id"] = "web_dev_admin"; }
         const res = await fetch(`${BASE_URL}/api/v1/audit-events`, { headers });
-        const json = await res.json();
+        const json = await res.json().catch(() => null);
+        // Un 401/403 traía `data` vacío y la pantalla mentía con "no hay eventos";
+        // ahora se distingue el error de permisos de una lista realmente vacía (#262).
+        if (!res.ok || json?.ok === false) {
+          setError(
+            res.status === 401 || res.status === 403
+              ? "No tienes permisos para ver la bitácora de auditoría."
+              : "No pudimos cargar los eventos de auditoría.",
+          );
+          setEvents([]);
+          return;
+        }
         // El endpoint de main devuelve un array plano en `data`; toleramos también
         // una eventual forma paginada { items } por si el backend cambia más adelante.
         const list: AuditEventItem[] = Array.isArray(json?.data)
@@ -63,7 +74,7 @@ export default function AdminAuditPage() {
         setEvents(list);
         setPage(1);
       } catch {
-        setError("Error loading audit events");
+        setError("No pudimos cargar los eventos de auditoría.");
       } finally {
         setLoading(false);
       }

--- a/apps/web/src/services/adminApi.ts
+++ b/apps/web/src/services/adminApi.ts
@@ -1,14 +1,28 @@
 /**
  * Admin API client — connects to backend-api admin endpoints.
- * Always uses dev bypass headers in development.
- * No authentication tokens required.
+ *
+ * Cuando hay sesión de Clerk envía su JWT real (`Authorization: Bearer`), igual
+ * que `services/api.ts`. El bypass de dev (`x-dev-*`) solo actúa como respaldo
+ * sin sesión: antes era la única identidad que se enviaba, así que en producción
+ * el panel admin viajaba sin autenticación (#262).
  */
 import type { ApiSuccess, LandDto, UserSummaryDto } from "@terrashare/shared";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
 
-const buildHeaders = (): Record<string, string> => {
+const buildHeaders = async (): Promise<Record<string, string>> => {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+  try {
+    const token = await window.Clerk?.session?.getToken();
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+      return headers;
+    }
+  } catch {
+    // Sin token utilizable → caemos al fallback de dev.
+  }
+
   if (import.meta.env.DEV) {
     headers["x-dev-role"] = "admin";
     headers["x-dev-user-id"] = "web_dev_admin";
@@ -20,21 +34,26 @@ const handleResponse = async (res: Response): Promise<unknown> => {
   if (!res.ok) {
     let err: any;
     try { err = await res.json(); } catch { err = {}; }
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(err?.error?.message || "No tienes permisos de administrador.");
+    }
     throw new Error(err?.error?.message || `HTTP ${res.status}`);
   }
   return res.json();
 };
 
-const request = <T = unknown>(
+const request = async <T = unknown>(
   method: string,
   path: string,
   body?: unknown,
-): Promise<ApiSuccess<T>> =>
-  fetch(`${BASE_URL}${path}`, {
+): Promise<ApiSuccess<T>> => {
+  const res = await fetch(`${BASE_URL}${path}`, {
     method,
-    headers: buildHeaders(),
+    headers: await buildHeaders(),
     body: body != null ? JSON.stringify(body) : undefined,
-  }).then(handleResponse) as Promise<ApiSuccess<T>>;
+  });
+  return (await handleResponse(res)) as ApiSuccess<T>;
+};
 
 interface AdminUserFilters {
   role?: string;


### PR DESCRIPTION
## Problema

El **token de sesión por defecto de Clerk no incluye `public_metadata`**, así que el backend derivaba `role: "user"` para todo el mundo y respondía **403 a un admin real**.

Consecuencias que se veían en la app:
- **Auditoría** se tragaba el 403 y mentía con *"No hay eventos de auditoría"*.
- **Observabilidad** no podía leer `/metrics`.
- El resto del panel (Reportes, Usuarios, Terrenos, Leads) "funcionaba" solo porque `adminApi.ts` enviaba cabeceras `x-dev-*` en DEV. **En producción no enviaba ninguna autenticación**, así que el panel entero habría dado 401.

Además, `requireAdmin` exigía MFA leyendo un claim `mfa_verified` que el token nunca emite: el control era **inerte** y a la vez bloqueaba a cualquier admin real.

## Cambios

### Backend
- `getClerkUserProfile` ahora resuelve también `publicMetadata.role` y `twoFactorEnabled` desde la Clerk Backend API (reusa la caché de 5 min existente).
- `resolveClerkAuthUser` consulta Clerk cuando el token **no trae claim de rol** y re-evalúa rol y MFA con los datos reales. Un claim explícito de rol **sigue teniendo prioridad** (no se puede sobreescribir desde metadata).
- La exigencia de MFA pasa a la variable **`REQUIRE_ADMIN_MFA`**: activa por defecto en producción, apagada fuera de ella. El estado de 2FA se lee del usuario real (`twoFactorEnabled`), no de un claim inexistente.

### Frontend
- `adminApi.ts` envía el **JWT real de Clerk** (`Authorization: Bearer`), igual que `services/api.ts`; el bypass `x-dev-*` queda solo como respaldo sin sesión.
- `AdminAuditPage` distingue un **401/403 de una lista vacía** y muestra el error.

### Docs
- README: cómo llega el rol al backend (hace falta `CLERK_SECRET_KEY`, o añadir un claim `role` vía JWT template) y el nuevo flag de MFA.
- `.env.example`: documenta `REQUIRE_ADMIN_MFA`.

## Verificación

**Tests:** `221 pass / 0 fail` (+4 nuevos). Dos expectativas se actualizaron a propósito: el test *"rechaza admin sin MFA en produccion"* nunca ponía el entorno en producción, y el perfil de Clerk ahora tiene campos nuevos.

**En vivo, con una cuenta admin real de Clerk (sin dev-bypass):**

| Endpoint | Antes | Después |
|---|---|---|
| `/api/v1/audit-events` | 403 | **200** |
| `/api/v1/metrics` | 403 | **200** |
| `/api/v1/admin/reports` | 403 | **200** |
| `/api/v1/admin/summary` | 403 | **200** |
| `/api/v1/admin/users` | 403 | **200** |

**Prueba negativa (sin escalada de privilegios):** quité `publicMetadata.role` del usuario en Clerk, reinicié el backend para limpiar la caché → los tres endpoints devolvieron **403 FORBIDDEN**. Restauré el rol → **200** de nuevo.

**Pantallas:**
- Auditoría lista ahora **20 eventos reales** (antes: "No hay eventos").
- Observabilidad muestra métricas reales (37 solicitudes, 0.0% errores, 135ms) y las sondas/dependencias en `ok`.
- Reportes sigue cargando, ya autenticado por JWT y no por bypass.

`tsc --noEmit` ✅ (backend y web) · `vite build` ✅

## Nota

`CLERK_SECRET_KEY` pasa a ser **obligatoria** para que un admin real sea reconocido por la API. Si se prefiere evitar la llamada a Clerk, basta con añadir un claim `role` al token mediante una JWT template; en ese caso el backend no consulta la API. Ambas rutas quedan documentadas en el README.

Closes #262
