### PR TITLE
fix(payments): reembolso devuelve 4xx/5xx segun el error de Stripe (#265)

### DIFF
--- a/apps/backend-api/src/lib/api-response.ts
+++ b/apps/backend-api/src/lib/api-response.ts
@@ -14,6 +14,7 @@ type ErrorCode =
   | "BUSINESS_RULE_VIOLATION"
   | "INVALID_TRANSITION"
   | "STRIPE_NOT_CONFIGURED"
+  | "STRIPE_UPSTREAM_ERROR"
   | "MFA_REQUIRED"
   | "INTERNAL_ERROR";
 
@@ -26,6 +27,7 @@ export const ERROR_CATALOG = {
   BUSINESS_RULE_VIOLATION: { status: 422, message: "Business rule violated" },
   INVALID_TRANSITION: { status: 422, message: "Invalid state transition" },
   STRIPE_NOT_CONFIGURED: { status: 503, message: "Payment service unavailable" },
+  STRIPE_UPSTREAM_ERROR: { status: 503, message: "Payment provider temporarily unavailable" },
   INTERNAL_ERROR: { status: 500, message: "Internal server error" },
   RATE_LIMIT_EXCEEDED: { status: 429, message: "Rate limit exceeded" },
 } as const;

--- a/apps/backend-api/src/lib/stripe-errors.test.ts
+++ b/apps/backend-api/src/lib/stripe-errors.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+
+import { mapStripeError } from "./stripe-errors";
+
+describe("mapStripeError (#265)", () => {
+  it("mapea resource_missing (intent inexistente) a 404, no a 500", () => {
+    const err = {
+      type: "StripeInvalidRequestError",
+      code: "resource_missing",
+      statusCode: 404,
+      message: "No such payment_intent: 'pi_e2e'",
+    };
+    const mapped = mapStripeError(err);
+    expect(mapped.status).toBe(404);
+    expect(mapped.code).toBe("NOT_FOUND");
+  });
+
+  it("mapea charge_already_refunded a 422 con mensaje de negocio", () => {
+    const err = {
+      type: "StripeInvalidRequestError",
+      code: "charge_already_refunded",
+      statusCode: 400,
+    };
+    const mapped = mapStripeError(err);
+    expect(mapped.status).toBe(422);
+    expect(mapped.code).toBe("BUSINESS_RULE_VIOLATION");
+    expect(mapped.message).toContain("ya fue reembolsado");
+  });
+
+  it("mapea un error de solicitud genérico (importe inválido) a 422", () => {
+    const err = {
+      type: "StripeInvalidRequestError",
+      code: "parameter_invalid_integer",
+      statusCode: 400,
+      message: "Invalid amount",
+    };
+    const mapped = mapStripeError(err);
+    expect(mapped.status).toBe(422);
+    expect(mapped.code).toBe("BUSINESS_RULE_VIOLATION");
+    expect(mapped.message).toContain("Invalid amount");
+  });
+
+  it("mapea un fallo de conexión a 503 upstream (reintenta), no a INTERNAL_ERROR", () => {
+    const err = {
+      type: "StripeConnectionError",
+      message: "An error occurred with our connection to Stripe",
+    };
+    const mapped = mapStripeError(err);
+    expect(mapped.status).toBe(503);
+    expect(mapped.code).toBe("STRIPE_UPSTREAM_ERROR");
+    expect(mapped.message).toContain("Reintenta");
+  });
+
+  it("mapea un 5xx del lado de Stripe (StripeAPIError) a 503 upstream", () => {
+    const err = {
+      type: "StripeAPIError",
+      statusCode: 500,
+      message: "Stripe internal error",
+    };
+    const mapped = mapStripeError(err);
+    expect(mapped.status).toBe(503);
+    expect(mapped.code).toBe("STRIPE_UPSTREAM_ERROR");
+  });
+
+  it("mapea rate limit (429) a 503 upstream", () => {
+    const err = { type: "StripeRateLimitError", statusCode: 429 };
+    const mapped = mapStripeError(err);
+    expect(mapped.status).toBe(503);
+    expect(mapped.code).toBe("STRIPE_UPSTREAM_ERROR");
+  });
+
+  it("ante un error desconocido/sin campos, cae a 422 (no 500)", () => {
+    const mapped = mapStripeError(new Error("boom"));
+    expect(mapped.status).toBe(422);
+    expect(mapped.code).toBe("BUSINESS_RULE_VIOLATION");
+  });
+});

--- a/apps/backend-api/src/lib/stripe-errors.ts
+++ b/apps/backend-api/src/lib/stripe-errors.ts
@@ -1,0 +1,92 @@
+/**
+ * Clasificación de errores de Stripe para las respuestas HTTP (#265).
+ *
+ * Stripe distingue entre errores de *solicitud/estado* (el intent no existe, el
+ * cargo ya se reembolsó, importe inválido…) — que son responsabilidad del
+ * cliente/estado y deben ser 4xx — y errores *upstream* (red, timeout, 5xx del
+ * lado de Stripe) que son transitorios y deben ser 5xx de tipo "reintenta".
+ *
+ * Tratar cualquier excepción de Stripe como `500 INTERNAL_ERROR` disparaba
+ * falsas alarmas de "el servidor está roto" y, con reintentos automáticos,
+ * habría entrado en bucle. Este helper mapea la excepción a un status/código
+ * de negocio coherente. Es duck-typed (no depende de `instanceof`) para que sea
+ * fácil de testear y robusto ante distintas versiones del SDK.
+ */
+
+import type { ERROR_CATALOG } from "./api-response";
+
+type StripeErrorCode = Extract<
+  keyof typeof ERROR_CATALOG,
+  "NOT_FOUND" | "BUSINESS_RULE_VIOLATION" | "STRIPE_UPSTREAM_ERROR"
+>;
+
+export interface MappedStripeError {
+  status: 404 | 422 | 503;
+  code: StripeErrorCode;
+  message: string;
+}
+
+/** Tipos de error de Stripe que son fallos transitorios de infraestructura. */
+const UPSTREAM_TYPES = new Set([
+  "StripeConnectionError",
+  "StripeAPIError",
+  "StripeRateLimitError",
+]);
+
+function readField(err: unknown, key: string): string | number | undefined {
+  if (err && typeof err === "object" && key in err) {
+    const value = (err as Record<string, unknown>)[key];
+    if (typeof value === "string" || typeof value === "number") return value;
+  }
+  return undefined;
+}
+
+/**
+ * Mapea una excepción lanzada por el cliente de Stripe a la respuesta HTTP
+ * adecuada. Todo lo que no sea claramente un fallo upstream se trata como un
+ * error de solicitud (4xx), nunca como 500.
+ */
+export function mapStripeError(err: unknown): MappedStripeError {
+  const type = String(readField(err, "type") ?? "");
+  const code = String(readField(err, "code") ?? "");
+  const statusCode = readField(err, "statusCode");
+  const rawMessage = readField(err, "message");
+
+  const isUpstream =
+    UPSTREAM_TYPES.has(type) ||
+    (typeof statusCode === "number" && statusCode >= 500);
+
+  if (isUpstream) {
+    return {
+      status: 503,
+      code: "STRIPE_UPSTREAM_ERROR",
+      message:
+        "No se pudo contactar con Stripe (error temporal). Reintenta en unos momentos.",
+    };
+  }
+
+  // A partir de aquí es un error de solicitud/estado → 4xx.
+  if (code === "resource_missing" || statusCode === 404) {
+    return {
+      status: 404,
+      code: "NOT_FOUND",
+      message: "El pago no tiene un cargo reembolsable en Stripe (intent inexistente).",
+    };
+  }
+
+  if (code === "charge_already_refunded") {
+    return {
+      status: 422,
+      code: "BUSINESS_RULE_VIOLATION",
+      message: "El cargo ya fue reembolsado en Stripe.",
+    };
+  }
+
+  return {
+    status: 422,
+    code: "BUSINESS_RULE_VIOLATION",
+    message: rawMessage
+      ? `Stripe rechazó la solicitud: ${rawMessage}`
+      : "Stripe rechazó la solicitud de reembolso.",
+  };
+}

--- a/apps/backend-api/src/routes/payments.ts
+++ b/apps/backend-api/src/routes/payments.ts
@@ -25,6 +25,7 @@ import {
   markWebhookProcessed,
 } from "../lib/payments-idempotency";
 import { buildReceipt } from "../lib/payments-receipt";
+import { mapStripeError } from "../lib/stripe-errors";
 import type { AppEnv } from "../types";
 
 let stripeClient: Stripe | null = null;
@@ -653,7 +654,8 @@ paymentRoutes.post("/payments/confirm", requireAuth, async (c) => {
     }
   } catch (err) {
     console.error("Stripe confirm retrieval failed:", err);
-    return failure(c, 503, "INTERNAL_ERROR", "No se pudo verificar el pago con Stripe");
+    const mapped = mapStripeError(err);
+    return failure(c, mapped.status, mapped.code, mapped.message);
   }
 
   if (paidAtStripe) {
@@ -726,7 +728,8 @@ paymentRoutes.post("/payments/:paymentId/refund", requireAuth, requireAdmin, asy
       stripeRefundId = refund.id;
     } catch (err) {
       console.error("Stripe refund failed:", err);
-      return failure(c, 500, "INTERNAL_ERROR", "No se pudo procesar el reembolso en Stripe");
+      const mapped = mapStripeError(err);
+      return failure(c, mapped.status, mapped.code, mapped.message);
     }
   }
 


### PR DESCRIPTION
Closes #265

Cierra #265.

## Problema
El `catch` del reembolso (`POST /payments/:id/refund`) trataba **cualquier** excepcion de Stripe como `500 INTERNAL_ERROR`. Un intent inexistente (`resource_missing`) o un cargo ya reembolsado son errores de solicitud/estado (4xx), no fallos del servidor; el 500 disparaba falsas alarmas y, con reintentos automaticos, podria entrar en bucle.

## Solucion
- Nuevo helper reutilizable `mapStripeError()` (`lib/stripe-errors.ts`):
  - `resource_missing` / statusCode 404 -> **404 NOT_FOUND**
  - `charge_already_refunded` / importe invalido -> **422 BUSINESS_RULE_VIOLATION**
  - `StripeConnectionError` / `StripeAPIError` / `StripeRateLimitError` / 5xx -> **503 STRIPE_UPSTREAM_ERROR** ("reintenta")
- Aplicado en los `catch` de **reembolso** y **confirmacion** (mismo patron "todo Stripe -> 5xx generico").
- Nuevo codigo `STRIPE_UPSTREAM_ERROR` en el catalogo de errores.

## Criterios de aceptacion
- [x] Reembolso rechazado por `resource_missing` responde 4xx (no 500).
- [x] Fallo de conexion/servidor de Stripe responde 5xx upstream (503), no `INTERNAL_ERROR`.
- [x] El mensaje distingue "no reembolsable / intent inexistente" de "error temporal, reintenta".
- [x] Tests unitarios de ambas ramas (mock lanzando `StripeInvalidRequestError` y error de conexion).

## Verificacion
- 7 tests unitarios nuevos verdes.
- `tsc --noEmit` limpio; suite de payments (12 tests) sin regresiones.