### PR TITLE
feat(favorites): guardados de terrenos, endpoint + UI (#147)

### DIFF
--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -13,6 +13,7 @@ import { authRoutes } from "./routes/auth";
 import { healthRoutes } from "./routes/health";
 import { adminRoutes } from "./routes/admin";
 import { landRoutes } from "./routes/lands";
+import { favoriteRoutes } from "./routes/favorites";
 import { leadRoutes } from "./routes/leads";
 import { rentalRequestRoutes } from "./routes/rental-requests";
 import { contractRoutes } from "./routes/contracts";
@@ -67,6 +68,7 @@ export function createApp() {
   app.route("/api/v1", authRoutes);
   app.route("/api/v1", adminRoutes);
   app.route("/api/v1", landRoutes);
+  app.route("/api/v1", favoriteRoutes);
   app.route("/api/v1", leadRoutes);
   app.route("/api/v1", rentalRequestRoutes);
   app.route("/api/v1", contractRoutes);

--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -197,6 +197,13 @@ export interface IReport extends Document {
   updatedAt: Date;
 }
 
+export interface IFavorite extends Document {
+  userId: string;
+  landId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 const UserSchema = new Schema<IUser>({
   clerkUserId: { type: String, required: true, unique: true },
   email: { type: String, required: true },
@@ -361,6 +368,11 @@ const ReportSchema = new Schema<IReport>({
   resolvedBy: String,
 }, { timestamps: true });
 
+const FavoriteSchema = new Schema<IFavorite>({
+  userId: { type: String, required: true },
+  landId: { type: String, required: true },
+}, { timestamps: true });
+
 // Índices secundarios (antes vivían en el driver nativo config/database.ts; se
 // migran aquí para que Mongoose sea la única fuente de índices — #135 A-1/A-6).
 LandSchema.index({ ownerId: 1 });
@@ -382,6 +394,8 @@ IdempotencyKeySchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 * 24 
 ReportSchema.index({ status: 1 });
 ReportSchema.index({ targetType: 1, targetId: 1 });
 ReportSchema.index({ reporterId: 1 });
+// Un usuario no puede guardar el mismo terreno dos veces (guardián de idempotencia).
+FavoriteSchema.index({ userId: 1, landId: 1 }, { unique: true });
 
 export const User = mongoose.model<IUser>("User", UserSchema);
 export const Land = mongoose.model<ILand>("Land", LandSchema);
@@ -394,4 +408,5 @@ export const AuditEvent = mongoose.model<IAuditEvent>("AuditEvent", AuditEventSc
 export const Lead = mongoose.model<ILead>("Lead", LeadSchema);
 export const WebhookEvent = mongoose.model<IWebhookEvent>("WebhookEvent", WebhookEventSchema);
 export const IdempotencyKey = mongoose.model<IIdempotencyKey>("IdempotencyKey", IdempotencyKeySchema);
+export const Favorite = mongoose.model<IFavorite>("Favorite", FavoriteSchema);
 export const Report = mongoose.model<IReport>("Report", ReportSchema);

--- a/apps/backend-api/src/routes/favorites.test.ts
+++ b/apps/backend-api/src/routes/favorites.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+
+import { requestJson } from "../lib/http-test-utils";
+
+/** Crea un terreno publicado (activo) y devuelve su id. */
+async function createActiveLand(ownerId: string, title: string): Promise<string> {
+  const create = await requestJson("/api/v1/lands", {
+    method: "POST",
+    headers: { "x-dev-user-id": ownerId },
+    body: {
+      title,
+      area: 30,
+      allowedUses: ["agricultura"],
+      location: { province: "Panama", district: "Panama" },
+      priceRule: { currency: "USD", pricePerMonth: 300 },
+    },
+  });
+  const landId = create.payload.data.id as string;
+  await requestJson(`/api/v1/lands/${landId}/status`, {
+    method: "PATCH",
+    headers: { "x-dev-user-id": ownerId },
+    body: { status: "active" },
+  });
+  return landId;
+}
+
+describe("favorites routes (#147)", () => {
+  it("guarda, lista y quita un terreno de favoritos", async () => {
+    const landId = await createActiveLand("user_fav_owner", "Terreno guardable");
+    const buyer = "user_fav_buyer_01";
+
+    const add = await requestJson(`/api/v1/users/me/favorites/${landId}`, {
+      method: "POST",
+      headers: { "x-dev-user-id": buyer },
+    });
+    expect(add.response.status).toBe(200);
+    expect(add.payload.data.favorited).toBe(true);
+
+    const list = await requestJson("/api/v1/users/me/favorites", {
+      headers: { "x-dev-user-id": buyer },
+    });
+    expect(list.response.status).toBe(200);
+    expect(Array.isArray(list.payload.data)).toBe(true);
+    expect(list.payload.data.some((l: { id: string }) => l.id === landId)).toBe(true);
+    // No debe filtrar campos internos de Mongo.
+    expect(list.payload.data[0]._id).toBeUndefined();
+
+    const remove = await requestJson(`/api/v1/users/me/favorites/${landId}`, {
+      method: "DELETE",
+      headers: { "x-dev-user-id": buyer },
+    });
+    expect(remove.response.status).toBe(200);
+    expect(remove.payload.data.favorited).toBe(false);
+
+    const listAfter = await requestJson("/api/v1/users/me/favorites", {
+      headers: { "x-dev-user-id": buyer },
+    });
+    expect(listAfter.payload.data.some((l: { id: string }) => l.id === landId)).toBe(false);
+  });
+
+  it("guardar dos veces es idempotente (no duplica)", async () => {
+    const landId = await createActiveLand("user_fav_owner", "Terreno idempotente");
+    const buyer = "user_fav_buyer_02";
+
+    await requestJson(`/api/v1/users/me/favorites/${landId}`, {
+      method: "POST",
+      headers: { "x-dev-user-id": buyer },
+    });
+    const second = await requestJson(`/api/v1/users/me/favorites/${landId}`, {
+      method: "POST",
+      headers: { "x-dev-user-id": buyer },
+    });
+    expect(second.response.status).toBe(200);
+
+    const list = await requestJson("/api/v1/users/me/favorites", {
+      headers: { "x-dev-user-id": buyer },
+    });
+    const matches = list.payload.data.filter((l: { id: string }) => l.id === landId);
+    expect(matches).toHaveLength(1);
+  });
+
+  it("guardar un terreno inexistente devuelve 404", async () => {
+    const res = await requestJson("/api/v1/users/me/favorites/land_no_existe", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_fav_buyer_03" },
+    });
+    expect(res.response.status).toBe(404);
+    expect(res.payload.error.code).toBe("NOT_FOUND");
+  });
+
+  it("los favoritos son privados por usuario", async () => {
+    const landId = await createActiveLand("user_fav_owner", "Terreno privado");
+    await requestJson(`/api/v1/users/me/favorites/${landId}`, {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_fav_alice" },
+    });
+
+    const bob = await requestJson("/api/v1/users/me/favorites", {
+      headers: { "x-dev-user-id": "user_fav_bob" },
+    });
+    expect(bob.payload.data.some((l: { id: string }) => l.id === landId)).toBe(false);
+  });
+
+  it("exige autenticación", async () => {
+    const res = await requestJson("/api/v1/users/me/favorites");
+    expect(res.response.status).toBe(401);
+  });
+});

--- a/apps/backend-api/src/routes/favorites.ts
+++ b/apps/backend-api/src/routes/favorites.ts
@@ -1,0 +1,89 @@
+import { Hono } from "hono";
+
+import { failure, success } from "../lib/api-response";
+import { requireAuth } from "../middleware/require-auth";
+import { rateLimitByUser } from "../middleware/rate-limit";
+import { Favorite, Land } from "../db/schemas";
+import type { LandRecord } from "../store/types";
+import type { AppEnv } from "../types";
+
+/**
+ * Favoritos / "Guardados" de terrenos (#147).
+ *
+ * El usuario guarda terrenos desde el catálogo y el detalle; la Home (Busco) los
+ * muestra en la sección "Guardados". Modelado como una colección propia
+ * (`Favorite`) con índice único (userId, landId) en lugar de un array embebido
+ * en el usuario: evita condiciones de carrera al guardar/quitar y escala mejor.
+ */
+export const favoriteRoutes = new Hono<AppEnv>();
+
+/** Elimina los campos internos de Mongo de un documento `lean`. */
+function clean<T>(doc: Record<string, unknown> | null | undefined): T | undefined {
+  if (!doc) return undefined;
+  const { _id, __v, ...rest } = doc;
+  return rest as T;
+}
+
+/**
+ * Lista los terrenos guardados por el usuario, más recientes primero. Devuelve
+ * los registros completos de terreno para que la Home pinte tarjetas reales.
+ * Los terrenos que ya no estén activos (borrados/despublicados) se omiten.
+ */
+favoriteRoutes.get("/users/me/favorites", requireAuth, rateLimitByUser(200), async (c) => {
+  const authUser = c.get("authUser");
+
+  const favorites = await Favorite.find({ userId: authUser.id })
+    .sort({ createdAt: -1 })
+    .lean();
+  const landIds = favorites.map((f) => f.landId);
+  if (landIds.length === 0) {
+    return success(c, []);
+  }
+
+  const docs = (await Land.find({
+    id: { $in: landIds },
+    status: { $ne: "inactive" },
+  }).lean()) as unknown as Record<string, unknown>[];
+
+  const byId = new Map(docs.map((d) => [d.id as string, clean<LandRecord>(d)!]));
+  // Conservar el orden por fecha de guardado (el $in no lo garantiza).
+  const lands = landIds.map((id) => byId.get(id)).filter((l): l is LandRecord => l !== undefined);
+
+  return success(c, lands);
+});
+
+/**
+ * Guarda un terreno. Idempotente: guardar dos veces devuelve 200 sin duplicar
+ * (el índice único protege ante carreras). Valida que el terreno exista y esté
+ * publicado antes de guardarlo.
+ */
+favoriteRoutes.post("/users/me/favorites/:landId", requireAuth, rateLimitByUser(200), async (c) => {
+  const authUser = c.get("authUser");
+  const landId = c.req.param("landId");
+
+  const land = await Land.findOne({ id: landId }).lean();
+  if (!land || land.status === "inactive") {
+    return failure(c, 404, "NOT_FOUND", "Land not found");
+  }
+
+  await Favorite.updateOne(
+    { userId: authUser.id, landId },
+    { $setOnInsert: { userId: authUser.id, landId } },
+    { upsert: true },
+  );
+
+  return success(c, { landId, favorited: true });
+});
+
+/**
+ * Quita un terreno de guardados. Idempotente: quitar algo no guardado devuelve
+ * 200 igualmente (estado final deseado ya alcanzado).
+ */
+favoriteRoutes.delete("/users/me/favorites/:landId", requireAuth, rateLimitByUser(200), async (c) => {
+  const authUser = c.get("authUser");
+  const landId = c.req.param("landId");
+
+  await Favorite.deleteOne({ userId: authUser.id, landId });
+
+  return success(c, { landId, favorited: false });
+});

--- a/apps/web/src/hooks/useFavorites.ts
+++ b/apps/web/src/hooks/useFavorites.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { addFavorite, getMyFavorites, removeFavorite } from "../services/api";
+
+interface UseFavoritesOptions {
+  /**
+   * Cuando es `false` no se consulta el backend (p. ej. en páginas públicas si
+   * el usuario no ha iniciado sesión). El set queda vacío y `ready` en true.
+   */
+  enabled?: boolean;
+}
+
+export interface UseFavoritesResult {
+  /** Ids de los terrenos guardados por el usuario. */
+  ids: Set<string>;
+  /** true una vez resuelta la carga inicial (con éxito o error). */
+  ready: boolean;
+  isFavorite: (landId: string) => boolean;
+  /** Alterna el estado guardado con actualización optimista; revierte si falla. */
+  toggle: (landId: string) => Promise<void>;
+}
+
+/**
+ * Estado de favoritos/"Guardados" (#147). Carga el set de ids una vez y expone
+ * un toggle optimista. Cada página que lo use mantiene su propia instancia; no
+ * hay estado global compartido, lo que simplifica su uso en páginas públicas
+ * (detalle) y autenticadas (home, catálogo) por igual.
+ */
+export function useFavorites({ enabled = true }: UseFavoritesOptions = {}): UseFavoritesResult {
+  const [ids, setIds] = useState<Set<string>>(new Set());
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setIds(new Set());
+      setReady(true);
+      return;
+    }
+    let active = true;
+    setReady(false);
+    getMyFavorites()
+      .then((lands) => {
+        if (!active) return;
+        setIds(new Set(lands.map((l) => l.id)));
+        setReady(true);
+      })
+      .catch(() => {
+        // Sin sesión válida o error transitorio: dejamos el set vacío pero listo.
+        if (active) setReady(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [enabled]);
+
+  const isFavorite = useCallback((landId: string) => ids.has(landId), [ids]);
+
+  const toggle = useCallback(async (landId: string) => {
+    const wasFavorite = ids.has(landId);
+    // Optimista: reflejamos el cambio de inmediato.
+    setIds((prev) => {
+      const next = new Set(prev);
+      if (wasFavorite) next.delete(landId);
+      else next.add(landId);
+      return next;
+    });
+    try {
+      if (wasFavorite) await removeFavorite(landId);
+      else await addFavorite(landId);
+    } catch (err) {
+      // Revertir ante fallo.
+      setIds((prev) => {
+        const next = new Set(prev);
+        if (wasFavorite) next.add(landId);
+        else next.delete(landId);
+        return next;
+      });
+      throw err;
+    }
+  }, [ids]);
+
+  return { ids, ready, isFavorite, toggle };
+}

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { LandDto } from "@terrashare/shared";
-import { Search, Sprout, MapPin, DollarSign, Tag, ChevronDown, ImageIcon, SearchX } from "lucide-react";
+import { Search, Sprout, MapPin, DollarSign, Tag, ChevronDown, ImageIcon, SearchX, Heart } from "lucide-react";
 import { listLands } from "../services/api";
 import PanamaMap from "../components/PanamaMap";
 import EmptyState from "../components/EmptyState";
+import { useFavorites } from "../hooks/useFavorites";
 import "./catalog.css";
 
 type LoadState = "loading" | "ready" | "error";
@@ -36,6 +37,9 @@ export default function CatalogPage() {
 
   const [lands, setLands] = useState<LandDto[]>([]);
   const [status, setStatus] = useState<LoadState>("loading");
+
+  // Favoritos (#147): el catálogo vive tras login, así que siempre habilitado.
+  const { isFavorite, toggle: toggleFavorite } = useFavorites();
 
   const [query, setQuery] = useState("");
   const [use, setUse] = useState("todos");
@@ -222,6 +226,30 @@ export default function CatalogPage() {
                     <div className="cat-card__thumb" aria-hidden="true">
                       <ImageIcon size={24} strokeWidth={1.5} />
                     </div>
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      className={`cat-card__fav${isFavorite(land.id) ? " is-active" : ""}`}
+                      aria-label={isFavorite(land.id) ? "Quitar de guardados" : "Guardar terreno"}
+                      aria-pressed={isFavorite(land.id)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleFavorite(land.id).catch((err) =>
+                          console.error("No se pudo actualizar el guardado:", err),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          toggleFavorite(land.id).catch((err) =>
+                            console.error("No se pudo actualizar el guardado:", err),
+                          );
+                        }
+                      }}
+                    >
+                      <Heart size={16} fill={isFavorite(land.id) ? "currentColor" : "none"} />
+                    </span>
                     <div className="cat-card__body">
                       <div className="cat-card__top">
                         <span className="cat-card__title">{land.title}</span>

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -17,7 +17,7 @@ import {
   Heart,
   MessageCircle,
 } from "lucide-react";
-import { getChats, getMyLands, listRentalRequests } from "../services/api";
+import { getChats, getMyFavorites, getMyLands, listRentalRequests } from "../services/api";
 import { getDisplayName } from "../components/authDisplay";
 import { useAppMode } from "../components/AppLayout";
 import EmptyState from "../components/EmptyState";
@@ -70,6 +70,8 @@ function BuscoHome({ name }: { name: string }) {
   const [reqState, setReqState] = useState<LoadState>("loading");
   const [chats, setChats] = useState<ChatDto[]>([]);
   const [chatsState, setChatsState] = useState<LoadState>("loading");
+  const [favorites, setFavorites] = useState<LandDto[]>([]);
+  const [favState, setFavState] = useState<LoadState>("loading");
 
   useEffect(() => {
     let active = true;
@@ -80,6 +82,13 @@ function BuscoHome({ name }: { name: string }) {
         setReqState("ready");
       })
       .catch(() => active && setReqState("error"));
+    getMyFavorites()
+      .then((data) => {
+        if (!active) return;
+        setFavorites(data);
+        setFavState("ready");
+      })
+      .catch(() => active && setFavState("error"));
     getChats()
       .then((data) => {
         if (!active) return;
@@ -184,14 +193,51 @@ function BuscoHome({ name }: { name: string }) {
         <section>
           <div className="hm-sec__head">
             <h2 className="hm-sec__title">Guardados</h2>
+            {favorites.length > 0 && (
+              <Link to="/catalog" className="hm-link">
+                Ver catálogo
+              </Link>
+            )}
           </div>
-          {/* TODO(#137): no existe endpoint de favoritos/guardados todavía. */}
-          <EmptyState
-            compact
-            icon={Heart}
-            title="Todavía no guardas terrenos"
-            description="Toca el corazón en un terreno para guardarlo aquí."
-          />
+          {favState === "loading" ? (
+            <div className="hm-empty">Cargando guardados…</div>
+          ) : favState === "error" ? (
+            <div className="hm-empty hm-empty--error">No pudimos cargar tus guardados.</div>
+          ) : favorites.length === 0 ? (
+            <EmptyState
+              compact
+              icon={Heart}
+              title="Todavía no guardas terrenos"
+              description="Toca el corazón en un terreno para guardarlo aquí."
+            />
+          ) : (
+            <div className="hm-favlist">
+              {favorites.slice(0, 4).map((land) => (
+                <Link
+                  key={land.id}
+                  to="/lands/$id"
+                  params={{ id: land.id }}
+                  className="hm-favcard"
+                >
+                  <span className="hm-favcard__thumb" aria-hidden="true">
+                    <Heart size={16} />
+                  </span>
+                  <span className="hm-favcard__body">
+                    <span className="hm-favcard__title">{land.title}</span>
+                    <span className="hm-favcard__meta">
+                      {land.location?.province ?? "—"} · {land.area} ha
+                    </span>
+                  </span>
+                  {typeof land.priceRule?.pricePerMonth === "number" && (
+                    <span className="hm-favcard__price">
+                      ${land.priceRule.pricePerMonth.toLocaleString("es-PA")}
+                      <span>/mes</span>
+                    </span>
+                  )}
+                </Link>
+              ))}
+            </div>
+          )}
         </section>
 
         <section>

--- a/apps/web/src/pages/LandDetailPage.tsx
+++ b/apps/web/src/pages/LandDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { createChat, getLandById, createReport } from "../services/api";
 import type { ReportReason } from "../services/api";
+import { useFavorites } from "../hooks/useFavorites";
 import "./detail.css";
 
 const REPORT_REASONS: { value: ReportReason; label: string }[] = [
@@ -80,6 +81,17 @@ export default function LandDetailPage() {
 
   const [land, setLand] = useState<DetailLand | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+
+  // Favoritos (#147): solo consultamos el backend si hay sesión.
+  const { isFavorite, toggle: toggleFavorite } = useFavorites({ enabled: Boolean(isSignedIn) });
+
+  const handleToggleFavorite = () => {
+    if (!isSignedIn) {
+      openSignIn({ redirectUrl: `/lands/${id}` });
+      return;
+    }
+    toggleFavorite(id!).catch((err) => console.error("No se pudo actualizar el guardado:", err));
+  };
 
   const [reportOpen, setReportOpen] = useState(false);
   const [reportReason, setReportReason] = useState<ReportReason>("fraude");
@@ -217,9 +229,15 @@ export default function LandDetailPage() {
         </Link>
         <BrandMark />
         <div className="det-nav__actions">
-          {/* TODO(#137): guardar/favoritos y compartir aún no tienen backend. */}
-          <button type="button" className="det-nav__action" title="Guardar (próximamente)">
-            <Heart size={18} /> Guardar
+          <button
+            type="button"
+            className={`det-nav__action${isFavorite(id!) ? " is-active" : ""}`}
+            title={isFavorite(id!) ? "Quitar de guardados" : "Guardar"}
+            aria-pressed={isFavorite(id!)}
+            onClick={handleToggleFavorite}
+          >
+            <Heart size={18} fill={isFavorite(id!) ? "currentColor" : "none"} />{" "}
+            {isFavorite(id!) ? "Guardado" : "Guardar"}
           </button>
           <button
             type="button"

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -105,9 +105,29 @@
   text-align: left;
   width: 100%;
   font: inherit;
+  position: relative;
 }
 .cat-card:hover { transform: translateY(-3px); box-shadow: 0 26px 44px -30px rgba(36, 49, 42, 0.4); }
 .cat-card.is-active { border-color: var(--ts-green); box-shadow: 0 0 0 1px var(--ts-green); }
+.cat-card__fav {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-beige);
+  color: var(--ts-sage-3);
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+.cat-card__fav:hover { color: var(--ts-clay); border-color: var(--ts-clay); }
+.cat-card__fav.is-active { color: var(--ts-clay); border-color: var(--ts-clay); background: var(--ts-surface); }
+.cat-card__fav:focus-visible { outline: 2px solid var(--ts-green); outline-offset: 2px; }
 .cat-card__thumb {
   width: 130px;
   height: 104px;

--- a/apps/web/src/pages/detail.css
+++ b/apps/web/src/pages/detail.css
@@ -42,6 +42,7 @@
   font-family: var(--ts-font-sans);
 }
 .det-nav__action:hover { color: var(--ts-clay); }
+.det-nav__action.is-active { color: var(--ts-clay); }
 
 /* ── contenido ───────────────────────────────────────────────────────────── */
 .det-wrap { max-width: 1200px; margin: 0 auto; padding: 34px 40px 70px; }

--- a/apps/web/src/pages/home.css
+++ b/apps/web/src/pages/home.css
@@ -246,6 +246,48 @@
 }
 .hm-dot { width: 9px; height: 9px; background: var(--ts-green); border-radius: 50%; flex: 0 0 auto; }
 
+/* ── Guardados (#147) ─────────────────────────────────────────────────────── */
+.hm-favlist {
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-beige);
+  border-radius: 16px;
+  overflow: hidden;
+}
+.hm-favcard {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid #f0e8d7;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.2s ease;
+}
+.hm-favcard:last-child { border-bottom: 0; }
+.hm-favcard:hover { background: #f7f1e5; }
+.hm-favcard__thumb {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--ts-tint-green);
+  color: var(--ts-green);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.hm-favcard__body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.hm-favcard__title {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hm-favcard__meta { font-size: 12.5px; color: var(--ts-sage); }
+.hm-favcard__price { font-size: 14px; font-weight: 700; color: var(--ts-green); flex: 0 0 auto; }
+.hm-favcard__price span { font-size: 11px; font-weight: 500; color: var(--ts-sage); }
+
 /* ── Ofrezco: stats ──────────────────────────────────────────────────────── */
 .hm-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-bottom: 40px; }
 .hm-stat {

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -159,6 +159,24 @@ export const createLand = async (dto: CreateLandDto): Promise<LandDto> => {
   return res.data;
 };
 
+// ─── Favorites (#147) ─────────────────────────────────────────────────────────
+
+/** GET /api/v1/users/me/favorites — terrenos guardados por el usuario. */
+export const getMyFavorites = async (): Promise<LandDto[]> => {
+  const res = await request<LandDto[]>("GET", "/api/v1/users/me/favorites");
+  return res?.data ?? [];
+};
+
+/** POST /api/v1/users/me/favorites/:landId — guarda un terreno (idempotente). */
+export const addFavorite = async (landId: string): Promise<void> => {
+  await request("POST", `/api/v1/users/me/favorites/${landId}`);
+};
+
+/** DELETE /api/v1/users/me/favorites/:landId — quita un terreno de guardados. */
+export const removeFavorite = async (landId: string): Promise<void> => {
+  await request("DELETE", `/api/v1/users/me/favorites/${landId}`);
+};
+
 // ─── Payments ─────────────────────────────────────────────────────────────────
 
 interface CheckoutSessionInput {
@@ -370,4 +388,7 @@ export const api = {
   sendMessage,
   getExternalContact,
   createReport,
+  getMyFavorites,
+  addFavorite,
+  removeFavorite,
 };


### PR DESCRIPTION
Closes #147

Cierra #147.

Detectado durante la paridad de diseno del flujo publico (#134): el prototipo muestra "Guardados" en la Home y un boton **Guardar** (corazon) en catalogo y detalle, pero **no existia backend de favoritos**.

## Backend
- Modelo `Favorite` con indice unico `(userId, landId)` (guardian de idempotencia; sin arrays embebidos en el usuario -> evita carreras).
- `GET /users/me/favorites` — terrenos guardados (registros completos, mas recientes primero; omite los no activos).
- `POST /users/me/favorites/:landId` — guarda (idempotente; valida que el terreno exista y este publicado -> 404 si no).
- `DELETE /users/me/favorites/:landId` — quita (idempotente).

## Web
- Cliente API: `getMyFavorites` / `addFavorite` / `removeFavorite`.
- Hook reutilizable `useFavorites` con **toggle optimista** (revierte ante fallo); `enabled` para paginas publicas sin sesion.
- **HomePage (Busco):** seccion "Guardados" con tarjetas reales (antes estado vacio).
- **LandDetailPage** (publica): boton "Guardar" funcional; si no hay sesion abre el login de Clerk.
- **Catalogo:** corazon guardar/quitar en cada tarjeta (accesible: role/aria-pressed/teclado).

## Verificacion
- 5 tests de ruta (guardar/listar/quitar, idempotencia, 404, privacidad por usuario, auth) verdes.
- `tsc` backend+web limpio; build web OK.
- **E2E contra MongoDB real:** POST -> guardado, GET -> terreno completo, terreno inexistente -> 404, DELETE -> lista vacia.
- UI: detalle publico renderiza "Guardar" y abre el sign-in de Clerk al pulsarlo sin sesion.