### PR TITLE
feat(backend): validación de payloads con Zod compartido (#139)

### DIFF
--- a/apps/backend-api/src/lib/validate.ts
+++ b/apps/backend-api/src/lib/validate.ts
@@ -1,0 +1,71 @@
+import type { Context } from "hono";
+import type { z } from "@terrashare/shared";
+
+import { failure } from "./api-response";
+
+/**
+ * Validación de payloads con los schemas Zod compartidos de
+ * `@terrashare/shared` (#139).
+ *
+ * Antes cada endpoint validaba a mano (`if (!body.x)`), con mensajes y códigos
+ * dispares y huecos (p. ej. un body no-JSON caía al handler y devolvía 500 en
+ * vez de 400). Este helper centraliza la validación: un fallo produce siempre
+ * `400 VALIDATION_ERROR` con detalle por campo.
+ *
+ * Importante: varios endpoints aceptan campos que aún no viven en el schema
+ * compartido (p. ej. `operation`/`salePrice` en terrenos). Por eso el resultado
+ * expone tanto `data` (parseado y coaccionado, útil para filtros y campos
+ * tipados) como `raw` (el cuerpo original), para que el handler pueda conservar
+ * esos campos extra sin que Zod los descarte.
+ */
+
+interface ValidationDetail {
+  field: string;
+  message: string;
+}
+
+function toDetails(error: z.ZodError): ValidationDetail[] {
+  return error.issues.map((issue) => ({
+    field: issue.path.length > 0 ? issue.path.join(".") : "(root)",
+    message: issue.message,
+  }));
+}
+
+type ValidationResult<T> =
+  | { success: true; data: T; raw: unknown }
+  | { success: false; response: Response };
+
+/** Valida un valor ya disponible (p. ej. query params) contra un schema. */
+export function validate<S extends z.ZodTypeAny>(
+  c: Context,
+  schema: S,
+  value: unknown,
+): ValidationResult<z.output<S>> {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    return {
+      success: false,
+      response: failure(c, 400, "VALIDATION_ERROR", "Invalid request data", toDetails(result.error)),
+    };
+  }
+  return { success: true, data: result.data, raw: value };
+}
+
+/**
+ * Lee el cuerpo JSON de la petición y lo valida. Un cuerpo ausente o no-JSON se
+ * trata como `null` y produce un 400 con detalle (nunca un 500).
+ */
+export async function validateBody<S extends z.ZodTypeAny>(
+  c: Context,
+  schema: S,
+): Promise<ValidationResult<z.output<S>>> {
+  const raw = await c.req.json().catch(() => null);
+  const result = schema.safeParse(raw);
+  if (!result.success) {
+    return {
+      success: false,
+      response: failure(c, 400, "VALIDATION_ERROR", "Invalid request data", toDetails(result.error)),
+    };
+  }
+  return { success: true, data: result.data, raw };
+}

--- a/apps/backend-api/src/routes/auth.ts
+++ b/apps/backend-api/src/routes/auth.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
+import { UpdateProfileSchema } from "@terrashare/shared";
 
-import { failure, success } from "../lib/api-response";
+import { success } from "../lib/api-response";
+import { validateBody } from "../lib/validate";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { getStore } from "../store/in-memory-db";
 import { User } from "../db/schemas";
@@ -15,29 +17,10 @@ authRoutes.get("/auth/me", requireAuth, (c) => {
 
 authRoutes.patch("/auth/profile", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const body = (await c.req.json().catch(() => null)) as
-    | { fullName?: string; phone?: string; province?: string; marketPreference?: "busco" | "ofrezco" }
-    | null;
 
-  const hasAnyField =
-    body &&
-    (body.fullName !== undefined ||
-      body.phone !== undefined ||
-      body.province !== undefined ||
-      body.marketPreference !== undefined);
-
-  if (!hasAnyField) {
-    return failure(
-      c,
-      400,
-      "VALIDATION_ERROR",
-      "Provide fullName, phone, province and/or marketPreference",
-    );
-  }
-
-  if (body.marketPreference !== undefined && !["busco", "ofrezco"].includes(body.marketPreference)) {
-    return failure(c, 400, "VALIDATION_ERROR", "marketPreference must be 'busco' or 'ofrezco'");
-  }
+  const parsed = await validateBody(c, UpdateProfileSchema);
+  if (!parsed.success) return parsed.response;
+  const body = parsed.data;
 
   const store = getStore();
   const existing = store.users.get(authUser.id) ?? authUser;

--- a/apps/backend-api/src/routes/chat.ts
+++ b/apps/backend-api/src/routes/chat.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
+import { CreateChatSchema, CreateChatMessageSchema } from "@terrashare/shared";
 
 import { env } from "../config/env";
 import { failure, success } from "../lib/api-response";
+import { validateBody } from "../lib/validate";
 import { canReadChat } from "../lib/auth-helpers";
 import { requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
@@ -77,17 +79,9 @@ chatRoutes.get("/chats", requireAuth, async (c) => {
 
 chatRoutes.post("/chats", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const body = (await c.req.json().catch(() => null)) as
-    | {
-        landId?: string;
-        rentalRequestId?: string;
-        participants?: { userId: string; role: "owner" | "tenant" | "admin" }[];
-      }
-    | null;
-
-  if (!body?.participants?.length) {
-    return failure(c, 400, "VALIDATION_ERROR", "Participants are required");
-  }
+  const parsed = await validateBody(c, CreateChatSchema);
+  if (!parsed.success) return parsed.response;
+  const body = parsed.data;
 
   if (!body.participants.some((participant) => participant.userId === authUser.id)) {
     return failure(c, 403, "FORBIDDEN", "Current user must be part of chat participants");
@@ -146,8 +140,10 @@ chatRoutes.post("/chats/:chatId/messages", requireAuth, async (c) => {
     return failure(c, 403, "FORBIDDEN", "Not allowed to send messages in this chat");
   }
 
-  const body = (await c.req.json().catch(() => null)) as { text?: string } | null;
-  if (!body?.text?.trim()) {
+  const parsed = await validateBody(c, CreateChatMessageSchema);
+  if (!parsed.success) return parsed.response;
+  const text = parsed.data.text.trim();
+  if (!text) {
     return failure(c, 400, "VALIDATION_ERROR", "Message text is required");
   }
 
@@ -155,7 +151,7 @@ chatRoutes.post("/chats/:chatId/messages", requireAuth, async (c) => {
     id: `msg_${crypto.randomUUID()}`,
     chatId: chat.id,
     senderId: authUser.id,
-    text: body.text.trim(),
+    text,
   });
 
   await createAuditEvent({

--- a/apps/backend-api/src/routes/contracts.ts
+++ b/apps/backend-api/src/routes/contracts.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
+import { CreateContractSchema, UpdateContractStatusSchema } from "@terrashare/shared";
 
 import { failure, success } from "../lib/api-response";
+import { validateBody } from "../lib/validate";
 import {
   canCreateContract,
   canMutateContract,
@@ -11,22 +13,13 @@ import { createAuditEvent } from "../store/audit";
 import { Contract, AuditEvent, RentalRequest, Land } from "../db/schemas";
 import type { AppEnv } from "../types";
 
-const allowedContractStatus = new Set(["active", "completed", "cancelled"]);
-
 export const contractRoutes = new Hono<AppEnv>();
 
 contractRoutes.post("/contracts", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const body = (await c.req.json().catch(() => null)) as
-    | {
-        rentalRequestId?: string;
-        terms?: { summary?: string; signedAt?: string; startsAt?: string; endsAt?: string };
-      }
-    | null;
-
-  if (!body?.rentalRequestId || !body.terms?.summary || !body.terms?.startsAt || !body.terms?.endsAt) {
-    return failure(c, 400, "VALIDATION_ERROR", "Missing contract fields");
-  }
+  const parsed = await validateBody(c, CreateContractSchema);
+  if (!parsed.success) return parsed.response;
+  const body = parsed.data;
 
   const request = await RentalRequest.findOne({ id: body.rentalRequestId }).lean();
   if (!request) {
@@ -109,12 +102,10 @@ contractRoutes.patch("/contracts/:contractId/status", requireAuth, async (c) => 
     return failure(c, 403, "FORBIDDEN", "Only owner or admin can update contract status");
   }
 
-  const body = (await c.req.json().catch(() => null)) as { status?: string; reason?: string } | null;
-  const status = body?.status;
-
-  if (!status || !allowedContractStatus.has(status)) {
-    return failure(c, 400, "VALIDATION_ERROR", "Invalid contract status");
-  }
+  const parsed = await validateBody(c, UpdateContractStatusSchema);
+  if (!parsed.success) return parsed.response;
+  const status = parsed.data.status;
+  const body = parsed.data;
 
   await Contract.updateOne(
     { id: contractId },

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
+import { CreateLandSchema, UpdateLandSchema, UpdateLandStatusSchema } from "@terrashare/shared";
 
 import { failure, success } from "../lib/api-response";
+import { validateBody } from "../lib/validate";
 import { canMutateLand } from "../lib/auth-helpers";
 import { getNumericQuery, getOptionalNumericQuery } from "../lib/request-utils";
 import { requireAuth } from "../middleware/require-auth";
@@ -179,32 +181,33 @@ landRoutes.get("/lands/:landId", async (c) => {
 
 landRoutes.post("/lands", requireAuth, rateLimitByUser(200), async (c) => {
   const authUser = c.get("authUser");
-  const body = (await c.req.json().catch(() => null)) as Partial<LandRecord> | null;
 
-  if (!body || !body.title || !body.area || !body.location || !body.priceRule || !body.allowedUses?.length) {
-    return failure(c, 400, "VALIDATION_ERROR", "Missing required land fields", [
-      { field: "title|area|location|priceRule|allowedUses", message: "Required" },
-    ]);
-  }
+  const parsed = await validateBody(c, CreateLandSchema);
+  if (!parsed.success) return parsed.response;
+  // `data`: campos validados y tipados por el schema compartido. `extra`: el
+  // cuerpo original, para los campos aún no cubiertos por el schema
+  // (operation/salePrice/water/access/features/photos).
+  const data = parsed.data;
+  const extra = parsed.raw as Partial<LandRecord>;
 
   const now = new Date().toISOString();
   const land: LandRecord = {
     id: `land_${crypto.randomUUID()}`,
     ownerId: authUser.id,
-    title: body.title,
-    description: body.description,
-    area: Number(body.area),
-    allowedUses: body.allowedUses,
-    photos: body.photos ?? [],
-    location: body.location,
-    availability: body.availability ?? {},
-    priceRule: body.priceRule,
+    title: data.title,
+    description: data.description,
+    area: data.area,
+    allowedUses: data.allowedUses,
+    photos: extra.photos ?? [],
+    location: data.location,
+    availability: data.availability ?? {},
+    priceRule: data.priceRule,
     status: "draft",
-    operation: body.operation ?? "alquiler",
-    salePrice: body.salePrice,
-    water: body.water,
-    access: body.access,
-    features: body.features ?? [],
+    operation: extra.operation ?? "alquiler",
+    salePrice: extra.salePrice,
+    water: extra.water,
+    access: extra.access,
+    features: extra.features ?? [],
     createdAt: now,
     updatedAt: now,
   };
@@ -236,10 +239,9 @@ landRoutes.patch("/lands/:landId", requireAuth, rateLimitByUser(200), async (c) 
     return failure(c, 403, "FORBIDDEN", "Only owner or admin can update this land");
   }
 
-  const body = (await c.req.json().catch(() => null)) as Partial<LandRecord> | null;
-  if (!body) {
-    return failure(c, 400, "VALIDATION_ERROR", "Invalid JSON payload");
-  }
+  const parsed = await validateBody(c, UpdateLandSchema);
+  if (!parsed.success) return parsed.response;
+  const body = parsed.raw as Partial<LandRecord>;
 
   const updated: LandRecord = {
     ...current,
@@ -276,12 +278,9 @@ landRoutes.patch("/lands/:landId/status", requireAuth, rateLimitByUser(200), asy
     return failure(c, 403, "FORBIDDEN", "Only owner or admin can update status");
   }
 
-  const body = (await c.req.json().catch(() => null)) as { status?: LandRecord["status"] } | null;
-  const status = body?.status;
-
-  if (!status || !["draft", "active", "inactive"].includes(status)) {
-    return failure(c, 400, "VALIDATION_ERROR", "Invalid land status");
-  }
+  const parsed = await validateBody(c, UpdateLandStatusSchema);
+  if (!parsed.success) return parsed.response;
+  const status = parsed.data.status;
 
   const updated: LandRecord = {
     ...current,

--- a/apps/backend-api/src/routes/leads.ts
+++ b/apps/backend-api/src/routes/leads.ts
@@ -1,32 +1,30 @@
 import { Hono } from "hono";
+import { CreateLeadSchema } from "@terrashare/shared";
 
 import { failure, success } from "../lib/api-response";
+import { validateBody } from "../lib/validate";
 import { Lead } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const leadRoutes = new Hono<AppEnv>();
 
 leadRoutes.post("/leads", async (c) => {
-  const body = await c.req.json();
+  // Antes hacía `await c.req.json()` sin `.catch`: un body no-JSON caía al
+  // handler y devolvía 500 en vez de 400 (hallazgo E-2, #139).
+  const parsed = await validateBody(c, CreateLeadSchema);
+  if (!parsed.success) return parsed.response;
 
-  if (!body.email || typeof body.email !== "string") {
-    return failure(c, 400, "VALIDATION_ERROR", "email is required");
-  }
+  const email = parsed.data.email.trim().toLowerCase();
 
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(body.email)) {
-    return failure(c, 400, "VALIDATION_ERROR", "Invalid email format");
-  }
-
-  const existingLead = await Lead.findOne({ email: body.email.trim().toLowerCase() });
+  const existingLead = await Lead.findOne({ email });
   if (existingLead) {
     return failure(c, 409, "CONFLICT", "Email already registered as lead");
   }
 
   const lead = await Lead.create({
     id: `lead_${crypto.randomUUID()}`,
-    email: body.email.trim().toLowerCase(),
-    source: body.source || "landing",
+    email,
+    source: parsed.data.source ?? "landing",
   });
 
   return success(c, { id: lead.id, email: lead.email, createdAt: lead.createdAt }, 201);

--- a/apps/backend-api/src/routes/payments.ts
+++ b/apps/backend-api/src/routes/payments.ts
@@ -1,9 +1,15 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
 import Stripe from "stripe";
+import {
+  CreatePaymentIntentSchema,
+  CreateCheckoutSessionSchema,
+  CreateRefundSchema,
+} from "@terrashare/shared";
 
 import { env } from "../config/env";
 import { failure, success } from "../lib/api-response";
+import { validateBody } from "../lib/validate";
 import { requireAuth, requireAdmin } from "../middleware/require-auth";
 import { verifyStripeWebhook, WebhookVerificationError } from "../lib/stripe-webhook";
 import { createAuditEvent, SYSTEM_ACTOR } from "../store/audit";
@@ -270,11 +276,10 @@ export const paymentRoutes = new Hono<AppEnv>();
 
 paymentRoutes.post("/payments/create-intent", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const body = (await c.req.json().catch(() => null)) as { rentalRequestId?: string; currency?: "USD" | "PAB" } | null;
 
-  if (!body?.rentalRequestId || !body.currency) {
-    return failure(c, 400, "VALIDATION_ERROR", "Missing rentalRequestId or currency");
-  }
+  const parsed = await validateBody(c, CreatePaymentIntentSchema);
+  if (!parsed.success) return parsed.response;
+  const body = parsed.data;
 
   const request = await RentalRequest.findOne({ id: body.rentalRequestId }).lean();
   if (!request) {
@@ -373,18 +378,10 @@ paymentRoutes.post("/payments/create-intent", requireAuth, async (c) => {
 
 paymentRoutes.post("/payments/checkout-session", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const body = (await c.req.json().catch(() => null)) as
-    | {
-        rentalRequestId?: string;
-        currency?: "USD" | "PAB";
-        successUrl?: string;
-        cancelUrl?: string;
-      }
-    | null;
 
-  if (!body?.rentalRequestId || !body.currency || !body.successUrl || !body.cancelUrl) {
-    return failure(c, 400, "VALIDATION_ERROR", "Missing checkout session fields");
-  }
+  const parsed = await validateBody(c, CreateCheckoutSessionSchema);
+  if (!parsed.success) return parsed.response;
+  const body = parsed.data;
 
   const request = await RentalRequest.findOne({ id: body.rentalRequestId }).lean();
   if (!request) {
@@ -682,7 +679,10 @@ paymentRoutes.post("/payments/confirm", requireAuth, async (c) => {
 paymentRoutes.post("/payments/:paymentId/refund", requireAuth, requireAdmin, async (c) => {
   const authUser = c.get("authUser");
   const paymentId = c.req.param("paymentId");
-  const body = (await c.req.json().catch(() => null)) as { amount?: number; reason?: string } | null;
+
+  const parsed = await validateBody(c, CreateRefundSchema);
+  if (!parsed.success) return parsed.response;
+  const body = parsed.data;
 
   const payment = await Payment.findOne({ id: paymentId }).lean();
   if (!payment) {

--- a/apps/backend-api/src/routes/rental-requests.ts
+++ b/apps/backend-api/src/routes/rental-requests.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
+import { UpdateRentalRequestStatusSchema } from "@terrashare/shared";
 
 import { failure, success } from "../lib/api-response";
+import { validateBody } from "../lib/validate";
 import {
   canCreateRentalRequest,
   canListRentalRequests,
@@ -227,14 +229,10 @@ rentalRequestRoutes.patch("/rental-requests/:requestId/status", requireAuth, asy
     return failure(c, 404, "NOT_FOUND", "Related land not found");
   }
 
-  const body = (await c.req.json().catch(() => null)) as
-    | { status?: RentalRequestStatus; reason?: string }
-    | null;
-
-  const nextStatus = body?.status;
-  if (!nextStatus) {
-    return failure(c, 400, "VALIDATION_ERROR", "Missing status");
-  }
+  const parsed = await validateBody(c, UpdateRentalRequestStatusSchema);
+  if (!parsed.success) return parsed.response;
+  const nextStatus = parsed.data.status as RentalRequestStatus;
+  const body = parsed.data;
 
   if (!canTransition(current.status, nextStatus)) {
     return failure(c, 409, "CONFLICT", `Invalid status transition ${current.status} -> ${nextStatus}`);

--- a/apps/backend-api/src/routes/validation.test.ts
+++ b/apps/backend-api/src/routes/validation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+
+import { createApp } from "../app";
+import { requestJson } from "../lib/http-test-utils";
+
+const DEV = { "x-dev-user-id": "user_validation_01" };
+
+/**
+ * Validación de payloads con schemas Zod compartidos (#139). Cada endpoint
+ * responde 400 VALIDATION_ERROR con `details` por campo ante un payload inválido.
+ */
+describe("validación de payloads (#139)", () => {
+  it("POST /lands: faltan campos requeridos → 400 con detalle", async () => {
+    const { response, payload } = await requestJson("/api/v1/lands", {
+      method: "POST",
+      headers: DEV,
+      body: { title: "ab" }, // título corto y sin area/location/priceRule/allowedUses
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(payload.error.details)).toBe(true);
+    expect(payload.error.details.length).toBeGreaterThan(0);
+  });
+
+  it("POST /lands: uso de terreno inválido → 400", async () => {
+    const { response, payload } = await requestJson("/api/v1/lands", {
+      method: "POST",
+      headers: DEV,
+      body: {
+        title: "Terreno válido",
+        area: 10,
+        allowedUses: ["mineria"], // no está en el enum
+        location: { province: "Panama", district: "Panama" },
+        priceRule: { currency: "USD", pricePerMonth: 100 },
+      },
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("PATCH /lands/:id/status: estado inválido → 400", async () => {
+    // Creamos un terreno primero para tener un id real.
+    const created = await requestJson("/api/v1/lands", {
+      method: "POST",
+      headers: DEV,
+      body: {
+        title: "Terreno estado",
+        area: 10,
+        allowedUses: ["agricultura"],
+        location: { province: "Panama", district: "Panama" },
+        priceRule: { currency: "USD", pricePerMonth: 100 },
+      },
+    });
+    const landId = created.payload.data.id;
+    const { response, payload } = await requestJson(`/api/v1/lands/${landId}/status`, {
+      method: "PATCH",
+      headers: DEV,
+      body: { status: "publicado" }, // no es draft/active/inactive
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("POST /contracts: resumen demasiado corto → 400", async () => {
+    const { response, payload } = await requestJson("/api/v1/contracts", {
+      method: "POST",
+      headers: DEV,
+      body: {
+        rentalRequestId: "rr_x",
+        terms: { summary: "corto", startsAt: "2026-01-01", endsAt: "2026-02-01" },
+      },
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("POST /leads: email inválido → 400", async () => {
+    const { response, payload } = await requestJson("/api/v1/leads", {
+      method: "POST",
+      body: { email: "no-es-un-email" },
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("POST /leads: body NO-JSON → 400 (no 500) — regresión E-2", async () => {
+    const app = createApp();
+    const response = await app.request("/api/v1/leads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "esto no es json {",
+    });
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("PATCH /auth/profile: body vacío → 400", async () => {
+    const { response, payload } = await requestJson("/api/v1/auth/profile", {
+      method: "PATCH",
+      headers: DEV,
+      body: {},
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("POST /chats: sin participantes → 400", async () => {
+    const { response, payload } = await requestJson("/api/v1/chats", {
+      method: "POST",
+      headers: DEV,
+      body: { participants: [] },
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("POST /payments/create-intent: falta currency → 400", async () => {
+    const { response, payload } = await requestJson("/api/v1/payments/create-intent", {
+      method: "POST",
+      headers: DEV,
+      body: { rentalRequestId: "rr_x" },
+    });
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/apps/backend-api/tsconfig.json
+++ b/apps/backend-api/tsconfig.json
@@ -6,7 +6,11 @@
     "strict": true,
     "skipLibCheck": true,
     "types": ["node", "bun"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@terrashare/shared": ["../../packages/shared/src/index.ts"]
+    }
   },
   "include": [
     "src/**/*.ts"

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -17,3 +17,26 @@ export const UserSummarySchema = z.object({
 
 export type UserSummaryInput = z.input<typeof UserSummarySchema>;
 export type UserSummaryOutput = z.output<typeof UserSummarySchema>;
+
+/**
+ * Actualización parcial de perfil (`PATCH /auth/profile`). Todos los campos son
+ * opcionales pero se exige al menos uno para evitar peticiones vacías.
+ */
+export const UpdateProfileSchema = z
+  .object({
+    fullName: z.string().min(1).optional(),
+    phone: z.string().optional(),
+    province: z.string().optional(),
+    marketPreference: z.enum(["busco", "ofrezco"]).optional(),
+  })
+  .refine(
+    (data) =>
+      data.fullName !== undefined ||
+      data.phone !== undefined ||
+      data.province !== undefined ||
+      data.marketPreference !== undefined,
+    { message: "Provide fullName, phone, province and/or marketPreference" },
+  );
+
+export type UpdateProfileInput = z.input<typeof UpdateProfileSchema>;
+export type UpdateProfileOutput = z.output<typeof UpdateProfileSchema>;

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -2,8 +2,18 @@
 export {
   UserStatusSchema,
   UserSummarySchema,
+  UpdateProfileSchema,
 } from "./auth";
-export type { UserSummaryInput, UserSummaryOutput } from "./auth";
+export type {
+  UserSummaryInput,
+  UserSummaryOutput,
+  UpdateProfileInput,
+  UpdateProfileOutput,
+} from "./auth";
+
+// Lead schemas
+export { CreateLeadSchema } from "./leads";
+export type { CreateLeadInput, CreateLeadOutput } from "./leads";
 
 // Land schemas
 export {
@@ -66,11 +76,14 @@ export type {
 export {
   IDEMPOTENCY_HEADER,
   PaymentStatusSchema,
+  CreatePaymentIntentSchema,
   CreateCheckoutSessionSchema,
   CreateRefundSchema,
   PaymentListFilterSchema,
 } from "./payments";
 export type {
+  CreatePaymentIntentInput,
+  CreatePaymentIntentOutput,
   CreateCheckoutSessionInput,
   CreateCheckoutSessionOutput,
   CreateRefundInput,

--- a/packages/shared/src/schemas/leads.ts
+++ b/packages/shared/src/schemas/leads.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+/**
+ * Captura de leads desde la landing / app / panel (#139). `source` por defecto
+ * "landing"; el email se normaliza (trim + minúsculas) en el backend.
+ */
+export const CreateLeadSchema = z.object({
+  email: z.string().email("Formato de email inválido"),
+  source: z.enum(["landing", "app-web", "admin-dashboard"]).optional(),
+});
+
+export type CreateLeadInput = z.input<typeof CreateLeadSchema>;
+export type CreateLeadOutput = z.output<typeof CreateLeadSchema>;

--- a/packages/shared/src/schemas/payments.ts
+++ b/packages/shared/src/schemas/payments.ts
@@ -25,6 +25,14 @@ export const CreateRefundSchema = z.object({
 export type CreateRefundInput = z.input<typeof CreateRefundSchema>;
 export type CreateRefundOutput = z.output<typeof CreateRefundSchema>;
 
+export const CreatePaymentIntentSchema = z.object({
+  rentalRequestId: z.string().min(1, "ID de solicitud requerido"),
+  currency: z.enum(["USD", "PAB"]),
+});
+
+export type CreatePaymentIntentInput = z.input<typeof CreatePaymentIntentSchema>;
+export type CreatePaymentIntentOutput = z.output<typeof CreatePaymentIntentSchema>;
+
 export const CreateCheckoutSessionSchema = z.object({
   rentalRequestId: z.string().min(1, "ID de solicitud requerido"),
   currency: z.enum(["USD", "PAB"]),


### PR DESCRIPTION
Closes #139

Cierra #139 (hallazgos E-1, E-2 de `docs/AUDITORIA_HALLAZGOS.md`).

## Problema
El backend **no importaba** `@terrashare/shared` y validaba a mano (`if (!body.x)`), con mensajes/códigos dispares y huecos — p. ej. `POST /leads` hacía `await c.req.json()` sin `.catch`, así que un body no-JSON caía al handler y devolvía **500** en vez de 400.

## Solución
- **Conecta el backend a `@terrashare/shared`** vía alias de `tsconfig` (`paths`), igual que `apps/web`. Bun lo resuelve desde fuente (verificado con smoke test).
- **Helper `lib/validate.ts`**: `validateBody`/`validate` → `400 VALIDATION_ERROR` con `details` por campo. Un body ausente/no-JSON se trata como `null` → 400, nunca 500.
- **Endpoints validados** con el schema compartido correspondiente:
  - lands: create / update / status
  - rental-requests: status
  - contracts: create / status
  - payments: create-intent / checkout-session / refund
  - chat: create / message
  - leads: create (**arregla E-2**)
  - auth: profile
- **Nuevos schemas compartidos**: `CreatePaymentIntentSchema`, `UpdateProfileSchema`, `CreateLeadSchema`.

### Patrón seguro (sin regresiones)
Varios endpoints aceptan campos que el schema compartido aún no modela (`operation`/`salePrice`/`water`… en terrenos). Se **valida** con el schema pero se **conservan** esos campos desde el cuerpo original, para que Zod no los descarte.

## Criterios de aceptación
- [x] Cada endpoint (del alcance) valida con el schema Zod compartido.
- [x] Respuestas de error consistentes (400 con `details` por campo).
- [x] Tests de validación por endpoint (incluye regresión E-2 body no-JSON).

## Verificación
- Suite completa backend: **249 tests verdes, 0 fallos** (sin regresiones) + 9 tests de validación nuevos.
- `tsc` backend + shared + web limpio; build web OK.
- **E2E en vivo**: body no-JSON → 400 (antes 500); email inválido → 400 con `details:[{field:"email"}]`; lands inválido → 400 con detalle por campo.

## Notas
- `POST /rental-requests` soporta `venta` (`operation`/`offerAmount`) que el schema compartido aún no modela; su alineación se deja a **#140** (fuente única de enums/operación). Mantiene su validación manual robusta por ahora.
- Toca `payments.ts` en regiones distintas a #266 (#265): #266 cambia el `catch`; este PR, el parseo del body. No deberían solaparse al mergear.