### PR TITLE
docs+fix: alinear PRD/schema/DTOs (enums, operación, flujos) (#140)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -147,7 +147,7 @@ export interface IAuditEvent extends Document {
   actorId: string;
   actorRole: AppRole | "system";
   entity: "auth" | "user" | "land" | "rental_request" | "contract" | "payment" | "chat" | "report" | "webhook";
-  action: "created" | "updated" | "deleted" | "approved" | "rejected" | "cancelled" | "paid" | "refunded" | "status_changed";
+  action: "created" | "updated" | "deleted" | "approved" | "rejected" | "cancelled" | "paid" | "refunded" | "signed" | "completed" | "status_changed";
   entityId: string;
   metadata?: Record<string, unknown>;
   createdAt: Date;
@@ -325,7 +325,7 @@ const AuditEventSchema = new Schema<IAuditEvent>({
   actorId: { type: String, required: true },
   actorRole: { type: String, enum: ["user", "admin", "system"], required: true },
   entity: { type: String, enum: ["auth", "user", "land", "rental_request", "contract", "payment", "chat", "report", "webhook"], required: true },
-  action: { type: String, enum: ["created", "updated", "deleted", "approved", "rejected", "cancelled", "paid", "refunded", "status_changed"], required: true },
+  action: { type: String, enum: ["created", "updated", "deleted", "approved", "rejected", "cancelled", "paid", "refunded", "signed", "completed", "status_changed"], required: true },
   entityId: { type: String, required: true },
   metadata: Schema.Types.Mixed,
 }, { timestamps: true });

--- a/apps/backend-api/src/routes/analytics.test.ts
+++ b/apps/backend-api/src/routes/analytics.test.ts
@@ -32,6 +32,24 @@ describe("analytics routes", () => {
     expect(payload.data.totalLands).toBeGreaterThan(0);
   });
 
+  // #140 F-4: approvalRate dividía por las solicitudes recientes pero el guard
+  // era sobre el total, así que devolvía NaN (→ null en JSON) cuando había
+  // solicitudes históricas pero ninguna en los últimos 30 días. Debe ser
+  // siempre un número finito.
+  it("returns a finite approvalRate, never NaN/null (F-4)", async () => {
+    const { response, payload } = await requestJson("/api/v1/analytics/requests", {
+      headers: { "x-dev-user-id": "admin_analytics", "x-dev-role": "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    const rate = payload.data.approvalRate;
+    expect(rate).not.toBeNull();
+    expect(typeof rate).toBe("number");
+    expect(Number.isFinite(rate)).toBe(true);
+    expect(rate).toBeGreaterThanOrEqual(0);
+    expect(rate).toBeLessThanOrEqual(100);
+  });
+
   it("forbids owner analytics for a different, non-admin user", async () => {
     const { response, payload } = await requestJson("/api/v1/analytics/owner/user_owner_01", {
       headers: { "x-dev-user-id": "user_tenant_99" },

--- a/apps/backend-api/src/routes/analytics.ts
+++ b/apps/backend-api/src/routes/analytics.ts
@@ -172,7 +172,11 @@ analyticsRoutes.get("/analytics/requests", requireAdmin, async (c) => {
     byStatus,
     byIntendedUse,
     avgTimeToApprovalHours: Math.round(avgDecisionTimeMs / (1000 * 60 * 60) * 10) / 10,
-    approvalRate: requests.length > 0 ? Math.round((approvedLast30Days.length / recentRequests.length) * 100 * 10) / 10 : 0,
+    // Guarda contra división por cero (#140 F-4): la tasa se calcula sobre las
+    // solicitudes *recientes*, así que el guard debe ser sobre `recentRequests`
+    // (había un `requests.length > 0` que dejaba pasar NaN cuando había
+    // solicitudes históricas pero ninguna en los últimos 30 días).
+    approvalRate: recentRequests.length > 0 ? Math.round((approvedLast30Days.length / recentRequests.length) * 100 * 10) / 10 : 0,
   });
 });
 

--- a/apps/backend-api/src/routes/contracts.test.ts
+++ b/apps/backend-api/src/routes/contracts.test.ts
@@ -24,6 +24,39 @@ describe("contracts and audit routes", () => {
     expect(payload.data.rentalRequestId).toBe("rr_seed_01");
   });
 
+  // #140 F-3: el enum de AuditEvent.action carecía de "signed"/"completed", así
+  // que firmar un contrato reventaba al registrar la auditoría (500). Ahora el
+  // flujo completo debe funcionar y dejar el evento "signed".
+  it("signs a contract and records a 'signed' audit event (F-3)", async () => {
+    const created = await requestJson("/api/v1/contracts", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_owner_01" },
+      body: {
+        rentalRequestId: "rr_seed_01",
+        terms: {
+          summary: "Contrato para firmar",
+          startsAt: new Date().toISOString(),
+          endsAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365).toISOString(),
+        },
+      },
+    });
+    const contractId = created.payload.data.id;
+
+    const signed = await requestJson(`/api/v1/contracts/${contractId}/sign`, {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_owner_01" },
+    });
+    expect(signed.response.status).toBe(200);
+    expect(signed.payload.data.status).toBe("active");
+
+    const audit = await requestJson(
+      "/api/v1/audit-events?entity=contract&action=signed",
+      { headers: { "x-dev-user-id": "admin_test", "x-dev-role": "admin" } },
+    );
+    expect(audit.response.status).toBe(200);
+    expect(audit.payload.data.some((e: { entityId: string }) => e.entityId === contractId)).toBe(true);
+  });
+
   it("lists audit events for admin", async () => {
     const { response, payload } = await requestJson("/api/v1/audit-events", {
       headers: {

--- a/docs/AUDITORIA_HALLAZGOS.md
+++ b/docs/AUDITORIA_HALLAZGOS.md
@@ -140,17 +140,21 @@ Ejemplos: `lands POST` no valida tipos de `location`/`priceRule` a fondo; `leads
 - `ContractStatus`: PRD describe flujo de doble firma (`pending_owner_signature`, `pending_tenant_signature`, `signed`); el código usa `draft/active/completed/cancelled`.
 - `PaymentStatus`: PRD `pending/completed/failed/refunded`; código `pending/processing/paid/failed/cancelled`.
 **Propuesta:** definir la fuente de verdad única y alinear PRD + schema + DTOs compartidos.
+**✅ Resuelto (#140):** fuente única = código (enums en español). PRD.md §8 alineado; schemas Zod de `shared` extendidos con `operation`/`salePrice` (lands) y `operation`/`offerAmount` (rental-requests) para coincidir con DTOs y Mongoose.
 
 ### F-2 🟠 Flujo de firma de contrato simplificado
 El PRD describe firma de ambas partes; `contracts.ts::sign` solo pasa `draft → active` con una firma (`terms.signedAt`). No hay firma separada de owner/tenant.
 **Propuesta:** decidir si se implementa el flujo de doble firma (Fase 2) o se documenta el flujo simplificado actual.
+**✅ Resuelto (#140):** documentado el flujo de **firma única** (`draft→active→completed`) en PRD.md §8 y RN-06; eliminada la referencia a doble firma y al objeto `signatures`.
 
 ### F-3 🟡 Acciones de auditoría fuera del enum
 `contracts.ts` emite `action: "signed"` y `"completed"`, que **no** están en el `enum` de `AuditEventSchema` (`db/schemas.ts:239`). Como hoy la auditoría es en memoria (A-5) no falla en runtime, pero si se persiste con Mongoose (deseable) Mongoose lo rechazaría.
 **Propuesta:** ampliar el enum o normalizar las acciones.
+**✅ Resuelto (#140):** con A-5 ya persistiendo en Mongoose, firmar reventaba (500). Añadidos `signed`/`completed` al enum de `AuditEventSchema`, a `IAuditEvent` y a `AuditAction` de `shared`. Test de regresión: firmar contrato → 200 + evento `signed`.
 
 ### F-4 🟡 `/analytics/requests` puede dividir por cero
 `approvalRate` divide por `recentRequests.length` (`analytics.ts:170`); si no hay solicitudes recientes → `NaN`.
+**✅ Resuelto (#140):** el guard ahora es sobre `recentRequests.length` (antes sobre `requests.length`). Test: `approvalRate` es siempre un número finito en [0,100].
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -180,8 +180,8 @@ Dolores principales:
 | RN-03 | Solo el propietario de un terreno puede aprobar o rechazar solicitudes de ese terreno |
 | RN-04 | Usuarios bloqueados no pueden publicar terrenos ni solicitar alquiler |
 | RN-05 | Solicitudes deben tener estado: draft, pending_owner, approved, rejected, cancelled, pending_payment, paid |
-| RN-06 | Contratos deben tener estado: draft, pending_owner_signature, pending_tenant_signature, signed, completed, cancelled |
-| RN-07 | Pagos deben tener estado: pending, completed, failed, refunded |
+| RN-06 | Contratos deben tener estado: draft, active, completed, cancelled (firma única: draft→active→completed) |
+| RN-07 | Pagos deben tener estado: pending, processing, paid, failed, cancelled, refunded, partially_refunded |
 
 ## 7. Stack tecnológico
 
@@ -222,47 +222,52 @@ Dolores principales:
 
 ### 8.1 Enums y tipos auxiliares
 
+> **Fuente única de verdad (#140):** estos enums reflejan el código real
+> (`packages/shared` + schema Mongoose del backend). Los valores son en español
+> y coinciden entre PRD, DTOs (`packages/shared/src/dto`), schemas Zod
+> (`packages/shared/src/schemas`) y el modelo Mongoose (`apps/backend-api`).
+
 ```typescript
-enum LandUse {
-  AGRICULTURE = 'agriculture';
-  LIVESTOCK = 'livestock';
-  FORESTRY = 'forestry';
-  TOURISM = 'tourism';
-  OTHER = 'other';
-}
+// Usos permitidos de un terreno
+type LandUse =
+  | 'agricultura'
+  | 'ganaderia'
+  | 'forestal'
+  | 'acuicultura'
+  | 'mixto'
+  | 'otro';
 
-enum LandStatus {
-  DRAFT = 'draft';
-  PUBLISHED = 'published';
-  PAUSED = 'paused';
-  DELETED = 'deleted';
-}
+// Estado de publicación de un terreno
+type LandStatus = 'draft' | 'active' | 'inactive';
 
-enum RentalRequestStatus {
-  DRAFT = 'draft';
-  PENDING_OWNER = 'pending_owner';
-  APPROVED = 'approved';
-  REJECTED = 'rejected';
-  CANCELLED = 'cancelled';
-  PENDING_PAYMENT = 'pending_payment';
-  PAID = 'paid';
-}
+// Tipo de operación de una publicación (#138): alquiler, venta o ambas
+type LandOperation = 'alquiler' | 'venta' | 'ambas';
 
-enum ContractStatus {
-  DRAFT = 'draft';
-  PENDING_OWNER_SIGNATURE = 'pending_owner_signature';
-  PENDING_TENANT_SIGNATURE = 'pending_tenant_signature';
-  SIGNED = 'signed';
-  COMPLETED = 'completed';
-  CANCELLED = 'cancelled';
-}
+// Operación de una solicitud/trato (#249)
+type DealOperation = 'alquiler' | 'venta';
 
-enum PaymentStatus {
-  PENDING = 'pending';
-  COMPLETED = 'completed';
-  FAILED = 'failed';
-  REFUNDED = 'refunded';
-}
+type RentalRequestStatus =
+  | 'draft'
+  | 'pending_owner'
+  | 'approved'
+  | 'rejected'
+  | 'cancelled'
+  | 'pending_payment'
+  | 'paid';
+
+// Contrato: firma única (draft -> active) + cierre (active -> completed).
+// El PRD original describía doble firma; el flujo implementado es de una firma
+// (ver 8.x "Flujo de contrato").
+type ContractStatus = 'draft' | 'active' | 'completed' | 'cancelled';
+
+type PaymentStatus =
+  | 'pending'
+  | 'processing'
+  | 'paid'
+  | 'failed'
+  | 'cancelled'
+  | 'refunded'
+  | 'partially_refunded';
 ```
 
 ### User
@@ -296,20 +301,26 @@ enum PaymentStatus {
   location: {
     province: string;
     district: string;
-    lat: number;
-    lng: number;
-    address?: string;
+    corregimiento?: string;
+    addressLine?: string;
+    lat?: number;
+    lng?: number;
   };
-  images: string[];
+  photos: string[];
   availability: {
-    available: boolean;
-    availableFrom?: Date;
+    availableFrom?: string;
+    availableTo?: string;
   };
   priceRule: {
     currency: 'USD' | 'PAB';
     pricePerMonth: number;
   };
   status: LandStatus;
+  operation: LandOperation;       // #138: alquiler | venta | ambas
+  salePrice?: number;             // aplica cuando operation es venta/ambas
+  water?: string;
+  access?: string;
+  features?: string[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -322,12 +333,15 @@ enum PaymentStatus {
   id: string;
   landId: string;
   tenantId: string;
-  period: {
-    startDate: Date;
-    endDate: Date;
+  operation?: DealOperation;      // por defecto 'alquiler'
+  // Alquiler: period + intendedUse requeridos. Venta: offerAmount requerido.
+  period?: {
+    startDate: string;
+    endDate: string;
   };
-  intendedUse: LandUse;
-  message?: string;
+  intendedUse?: string;
+  offerAmount?: number;           // solo en operación de venta
+  notes?: string;
   status: RentalRequestStatus;
   createdAt: Date;
   updatedAt: Date;
@@ -344,18 +358,22 @@ enum PaymentStatus {
   tenantId: string;
   terms: {
     summary: string;
+    signedAt?: string;   // se fija al firmar (draft -> active)
     startsAt: Date;
     endsAt: Date;
   };
   status: ContractStatus;
-  signatures: {
-    owner?: { signedAt: Date };
-    tenant?: { signedAt: Date };
-  };
   createdAt: Date;
   updatedAt: Date;
 }
 ```
+
+> **Flujo de contrato (#140 F-2):** el sistema implementa **firma única**, no la
+> doble firma que describía el PRD original. Transiciones:
+> `draft → active` (`POST /contracts/:id/sign`, fija `terms.signedAt`) y
+> `active → completed` (`POST /contracts/:id/complete`). `cancelled` es un
+> estado terminal alternativo. No existen estados `pending_owner_signature` /
+> `pending_tenant_signature` ni un objeto `signatures` con doble firma.
 
 ### Payment
 

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -9,6 +9,7 @@ export type { UserSummaryInput, UserSummaryOutput } from "./auth";
 export {
   LandUseSchema,
   LandStatusSchema,
+  LandOperationSchema,
   LandLocationSchema,
   LandAvailabilitySchema,
   LandPriceRuleSchema,
@@ -34,6 +35,7 @@ export type {
 export {
   RentalRequestStatusSchema,
   RentalPeriodSchema,
+  DealOperationSchema,
   CreateRentalRequestSchema,
   UpdateRentalRequestStatusSchema,
 } from "./rental-requests";

--- a/packages/shared/src/schemas/lands.ts
+++ b/packages/shared/src/schemas/lands.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { LandSortField, LandStatus, LandUse } from "../dto/lands";
+import type { LandOperation, LandSortField, LandStatus, LandUse } from "../dto/lands";
 
 export const LandUseSchema = z.enum([
   "agricultura",
@@ -15,6 +15,13 @@ export type LandUseOutput = z.output<typeof LandUseSchema>;
 export const LandStatusSchema = z.enum(["draft", "active", "inactive"] as const);
 export type LandStatusInput = z.input<typeof LandStatusSchema>;
 export type LandStatusOutput = z.output<typeof LandStatusSchema>;
+
+/** Tipo de operación de una publicación: alquiler, venta o ambas (#138/#140). */
+export const LandOperationSchema = z.enum([
+  "alquiler",
+  "venta",
+  "ambas",
+] as const satisfies readonly LandOperation[]);
 
 export const LandLocationSchema = z.object({
   province: z.string().min(1, "Provincia requerida"),
@@ -43,6 +50,13 @@ export const CreateLandSchema = z.object({
   location: LandLocationSchema,
   availability: LandAvailabilitySchema.optional(),
   priceRule: LandPriceRuleSchema,
+  // Operación y campos de detalle (#138/#140). Alineados con LandDto/CreateLandDto
+  // y con el schema Mongoose del backend.
+  operation: LandOperationSchema.optional(),
+  salePrice: z.number().positive("Precio de venta debe ser mayor a 0").optional(),
+  water: z.string().optional(),
+  access: z.string().optional(),
+  features: z.array(z.string()).optional(),
 });
 
 export type CreateLandInput = z.input<typeof CreateLandSchema>;
@@ -63,6 +77,11 @@ export const UpdateLandSchema = z.object({
   }).optional(),
   availability: LandAvailabilitySchema.optional(),
   priceRule: LandPriceRuleSchema.optional(),
+  operation: LandOperationSchema.optional(),
+  salePrice: z.number().positive().optional(),
+  water: z.string().optional(),
+  access: z.string().optional(),
+  features: z.array(z.string()).optional(),
 });
 
 export type UpdateLandInput = z.input<typeof UpdateLandSchema>;

--- a/packages/shared/src/schemas/rental-requests.test.ts
+++ b/packages/shared/src/schemas/rental-requests.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { CreateRentalRequestSchema } from "./rental-requests";
+
+/**
+ * #140 F-1: el schema modela ambas operaciones (alquiler/venta) para coincidir
+ * con el backend y con CreateRentalRequestDto.
+ */
+describe("CreateRentalRequestSchema (#140)", () => {
+  const validPeriod = { startDate: "2026-01-01", endDate: "2026-02-01" };
+
+  it("acepta un alquiler con period + intendedUse", () => {
+    const result = CreateRentalRequestSchema.safeParse({
+      landId: "land_1",
+      period: validPeriod,
+      intendedUse: "agricultura",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rechaza un alquiler sin period (por defecto operation=alquiler)", () => {
+    const result = CreateRentalRequestSchema.safeParse({
+      landId: "land_1",
+      intendedUse: "agricultura",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("acepta una venta con offerAmount", () => {
+    const result = CreateRentalRequestSchema.safeParse({
+      landId: "land_1",
+      operation: "venta",
+      offerAmount: 150000,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rechaza una venta sin offerAmount", () => {
+    const result = CreateRentalRequestSchema.safeParse({
+      landId: "land_1",
+      operation: "venta",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes("offerAmount"))).toBe(true);
+    }
+  });
+
+  it("rechaza offerAmount no positivo en venta", () => {
+    const result = CreateRentalRequestSchema.safeParse({
+      landId: "land_1",
+      operation: "venta",
+      offerAmount: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/rental-requests.ts
+++ b/packages/shared/src/schemas/rental-requests.ts
@@ -31,12 +31,51 @@ export const RentalPeriodSchema = z
 export type RentalPeriodInput = z.input<typeof RentalPeriodSchema>;
 export type RentalPeriodOutput = z.output<typeof RentalPeriodSchema>;
 
-export const CreateRentalRequestSchema = z.object({
-  landId: z.string().min(1, "ID de terreno requerido"),
-  period: RentalPeriodSchema,
-  intendedUse: z.string().min(3, "Uso propuesto debe tener al menos 3 caracteres"),
-  notes: z.string().optional(),
-});
+/** Operación de una solicitud/trato: alquiler o venta (#249/#140). */
+export const DealOperationSchema = z.enum(["alquiler", "venta"] as const);
+
+/**
+ * Solicitud de alquiler o compra (#140). Modela ambas operaciones para coincidir
+ * con el backend y con `CreateRentalRequestDto`:
+ *  - `venta`  → requiere `offerAmount` (> 0); sin period/intendedUse.
+ *  - `alquiler` (por defecto) → requiere `period` y `intendedUse`.
+ */
+export const CreateRentalRequestSchema = z
+  .object({
+    landId: z.string().min(1, "ID de terreno requerido"),
+    operation: DealOperationSchema.optional(),
+    period: RentalPeriodSchema.optional(),
+    intendedUse: z.string().min(3, "Uso propuesto debe tener al menos 3 caracteres").optional(),
+    offerAmount: z.number().positive("La oferta debe ser mayor a 0").optional(),
+    notes: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    const operation = data.operation ?? "alquiler";
+    if (operation === "venta") {
+      if (data.offerAmount === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["offerAmount"],
+          message: "offerAmount es requerido para una operación de venta",
+        });
+      }
+    } else {
+      if (data.period === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["period"],
+          message: "period es requerido para una operación de alquiler",
+        });
+      }
+      if (data.intendedUse === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["intendedUse"],
+          message: "intendedUse es requerido para una operación de alquiler",
+        });
+      }
+    }
+  });
 
 export type CreateRentalRequestInput = z.input<typeof CreateRentalRequestSchema>;
 export type CreateRentalRequestOutput = z.output<typeof CreateRentalRequestSchema>;

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -23,6 +23,8 @@ export type AuditAction =
   | "cancelled"
   | "paid"
   | "refunded"
+  | "signed"
+  | "completed"
   | "status_changed";
 
 export type Resource =


### PR DESCRIPTION
Closes #140

Cierra #140 (hallazgos F-1..F-4 de `docs/AUDITORIA_HALLAZGOS.md`).

## F-1 — Enums divergentes PRD ↔ código
**Fuente única = código** (enums en español; DTOs, schemas Zod y Mongoose ya coincidían entre sí).
- `docs/PRD.md` §8 alineado: `LandUse` (agricultura…), `LandStatus` (draft/active/inactive), `ContractStatus` (draft/active/completed/cancelled), `PaymentStatus` (…/processing/paid/…/partially_refunded), + `LandOperation`/`DealOperation`.
- **Schemas Zod de `shared` extendidos** para coincidir con los DTOs y el modelo Mongoose:
  - lands: `operation`, `salePrice`, `water`, `access`, `features`.
  - rental-requests: modela **ambas operaciones** — `venta` requiere `offerAmount`; `alquiler` requiere `period`+`intendedUse` (via `superRefine`). Esto completa lo que #139 dejó pendiente en `POST /rental-requests`.

## F-2 — Flujo de contrato
Documentado el flujo de **firma única** (`draft→active→completed`) en PRD.md §8 y RN-06; eliminada la doble firma y el objeto `signatures` del PRD, que no existen en el código.

## F-3 — Acciones de auditoría fuera del enum (bug latente)
Con la auditoría ya persistida en Mongoose (A-5), **firmar un contrato reventaba (500)** porque el enum de `AuditEvent.action` carecía de `signed`/`completed`. Añadidos a `AuditEventSchema`, `IAuditEvent` y `AuditAction` de `shared`.

## F-4 — `approvalRate` división por cero
El guard era sobre `requests.length` pero se dividía por `recentRequests.length` → `NaN` (→ `null` en JSON) cuando había solicitudes históricas pero ninguna reciente. Corregido el guard.

## Verificación
- Suite backend: **251 tests verdes, 0 fallos** (+2 nuevos: firma F-3, approvalRate F-4). Shared: 8 verdes (+5: schema alquiler/venta F-1).
- `tsc` shared + backend + web limpio; build web OK.
- **E2E en vivo** contra MongoDB real: firmar `contract_0007` → 200 `active` + evento auditoría `signed` registrado (antes 500); `/analytics/requests` → `approvalRate: 27.3` (número finito).

## Notas
- Solo **docs + shared + 2 fixes de backend**; no toca los handlers de escritura, así que es independiente de #266/#267/#268 y mergeable en cualquier orden.
- Wirear `POST /rental-requests` al schema (ahora completo) es un follow-up trivial una vez mergeados este y #268.