### PR TITLE
feat(backend): migraciones de BD versionadas (HU-55 #173)

### DIFF
--- a/apps/backend-api/package.json
+++ b/apps/backend-api/package.json
@@ -8,6 +8,7 @@
     "start": "bun src/index.ts",
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
+    "migrate": "bun scripts/migrate.ts",
     "test": "bun test"
   },
   "dependencies": {

--- a/apps/backend-api/scripts/migrate.ts
+++ b/apps/backend-api/scripts/migrate.ts
@@ -1,0 +1,53 @@
+/**
+ * CLI de migraciones de base de datos (#173).
+ *
+ *   bun scripts/migrate.ts status   # lista migraciones y su estado
+ *   bun scripts/migrate.ts up       # aplica las pendientes
+ *   bun scripts/migrate.ts down [n] # revierte las últimas n (por defecto 1)
+ *
+ * Lee `MONGODB_URI` del entorno (Bun carga `.env` automáticamente).
+ */
+import mongoose from "mongoose";
+
+import { connectMongoose, disconnectMongoose } from "../src/db/mongoose";
+import { migrateDown, migrateUp, migrationStatus } from "../src/lib/migrator";
+
+async function main(): Promise<void> {
+  const command = process.argv[2] ?? "status";
+  await connectMongoose();
+  const db = mongoose.connection.db;
+  if (!db) throw new Error("No hay conexión a MongoDB");
+
+  switch (command) {
+    case "up": {
+      const ran = await migrateUp(db);
+      console.log(ran.length ? `Aplicadas: ${ran.join(", ")}` : "Sin migraciones pendientes.");
+      break;
+    }
+    case "down": {
+      const steps = Number(process.argv[3] ?? "1");
+      const reverted = await migrateDown(db, { steps });
+      console.log(reverted.length ? `Revertidas: ${reverted.join(", ")}` : "Nada que revertir.");
+      break;
+    }
+    case "status": {
+      const status = await migrationStatus(db);
+      for (const entry of status) {
+        const mark = entry.applied ? "✓" : "·";
+        const when = entry.appliedAt ? ` (${entry.appliedAt.toISOString()})` : "";
+        console.log(`${mark} ${entry.id} ${entry.name}${when}`);
+      }
+      break;
+    }
+    default:
+      console.error(`Comando desconocido: ${command}. Usa status | up | down [n].`);
+      process.exitCode = 1;
+  }
+
+  await disconnectMongoose();
+}
+
+main().catch((err) => {
+  console.error("Migración falló:", err);
+  process.exit(1);
+});

--- a/apps/backend-api/src/index.ts
+++ b/apps/backend-api/src/index.ts
@@ -1,7 +1,10 @@
+import mongoose from "mongoose";
+
 import { env } from "./config/env";
 import { connectMongoose } from "./db/mongoose";
 import { createApp } from "./app";
 import { seedDatabase } from "./db/seed";
+import { migrateUp } from "./lib/migrator";
 import { Land } from "./db/schemas";
 
 const app = createApp();
@@ -10,6 +13,19 @@ async function init() {
   try {
     await connectMongoose();
     console.log("[backend-api] Using MongoDB database (Mongoose)");
+
+    // Migraciones versionadas (#173): aplica las pendientes al arrancar, de forma
+    // idempotente. Se puede desactivar con RUN_MIGRATIONS=false (p. ej. si se
+    // corren en un paso de despliegue aparte).
+    if (process.env.RUN_MIGRATIONS !== "false") {
+      const db = mongoose.connection.db;
+      if (db) {
+        const applied = await migrateUp(db);
+        if (applied.length > 0) {
+          console.log(`[backend-api] Migraciones aplicadas: ${applied.join(", ")}`);
+        }
+      }
+    }
 
     const needsSeed = (await Land.estimatedDocumentCount()) === 0;
     if (needsSeed || process.env.FORCE_SEED === "true") {

--- a/apps/backend-api/src/lib/migrator.test.ts
+++ b/apps/backend-api/src/lib/migrator.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import mongoose from "mongoose";
+
+import {
+  MIGRATIONS_COLLECTION,
+  migrateDown,
+  migrateUp,
+  migrationStatus,
+} from "./migrator";
+import type { Migration } from "../migrations/types";
+
+function db() {
+  const conn = mongoose.connection.db;
+  if (!conn) throw new Error("No DB connection");
+  return conn;
+}
+
+/** Migraciones de prueba: crean/borran un documento marcador en una colección. */
+const TEST_COLLECTION = "_migrator_test_marker";
+function makeTestMigrations(): Migration[] {
+  return [
+    {
+      id: "t01",
+      name: "primera",
+      async up(d) {
+        await d.collection(TEST_COLLECTION).insertOne({ step: "t01" });
+      },
+      async down(d) {
+        await d.collection(TEST_COLLECTION).deleteOne({ step: "t01" });
+      },
+    },
+    {
+      id: "t02",
+      name: "segunda",
+      async up(d) {
+        await d.collection(TEST_COLLECTION).insertOne({ step: "t02" });
+      },
+      async down(d) {
+        await d.collection(TEST_COLLECTION).deleteOne({ step: "t02" });
+      },
+    },
+  ];
+}
+
+describe("migrator (#173)", () => {
+  beforeEach(async () => {
+    // El ledger de migraciones no lo resetea el preload; limpiamos las de prueba.
+    await db().collection(MIGRATIONS_COLLECTION).deleteMany({ id: { $in: ["t01", "t02"] } });
+    await db().collection(TEST_COLLECTION).deleteMany({});
+  });
+
+  it("aplica migraciones pendientes en orden y las registra", async () => {
+    const migrations = makeTestMigrations();
+    const ran = await migrateUp(db(), { migrations });
+    expect(ran).toEqual(["t01", "t02"]);
+
+    const markers = await db().collection(TEST_COLLECTION).find().toArray();
+    expect(markers.map((m) => m.step).sort()).toEqual(["t01", "t02"]);
+  });
+
+  it("es idempotente: reaplicar no ejecuta nada", async () => {
+    const migrations = makeTestMigrations();
+    await migrateUp(db(), { migrations });
+    const secondRun = await migrateUp(db(), { migrations });
+    expect(secondRun).toEqual([]);
+
+    // No se duplican los marcadores.
+    const count = await db().collection(TEST_COLLECTION).countDocuments();
+    expect(count).toBe(2);
+  });
+
+  it("status refleja aplicadas vs pendientes", async () => {
+    const migrations = makeTestMigrations();
+    await migrateUp(db(), { migrations: [migrations[0]!] });
+    const status = await migrationStatus(db(), { migrations });
+    expect(status.find((s) => s.id === "t01")?.applied).toBe(true);
+    expect(status.find((s) => s.id === "t02")?.applied).toBe(false);
+  });
+
+  it("down revierte la última migración aplicada", async () => {
+    const migrations = makeTestMigrations();
+    await migrateUp(db(), { migrations });
+
+    const reverted = await migrateDown(db(), { migrations, steps: 1 });
+    expect(reverted).toEqual(["t02"]);
+
+    const markers = await db().collection(TEST_COLLECTION).find().toArray();
+    expect(markers.map((m) => m.step)).toEqual(["t01"]);
+
+    const status = await migrationStatus(db(), { migrations });
+    expect(status.find((s) => s.id === "t02")?.applied).toBe(false);
+    expect(status.find((s) => s.id === "t01")?.applied).toBe(true);
+  });
+
+  it("la migración real crea índices únicos consistentes (id, clerkUserId)", async () => {
+    await migrateUp(db()); // migraciones reales por defecto
+
+    const landIndexes = await db().collection("lands").indexes();
+    const idIdx = landIndexes.find((i) => i.key?.id === 1);
+    expect(idIdx?.unique).toBe(true);
+
+    const userIndexes = await db().collection("users").indexes();
+    const clerkIdx = userIndexes.find((i) => i.key?.clerkUserId === 1);
+    expect(clerkIdx?.unique).toBe(true);
+  });
+});

--- a/apps/backend-api/src/lib/migrator.ts
+++ b/apps/backend-api/src/lib/migrator.ts
@@ -1,0 +1,107 @@
+import { migrations as defaultMigrations } from "../migrations";
+import type { Db, Migration } from "../migrations/types";
+
+/**
+ * Migrador de base de datos versionado (#173 / HU-55).
+ *
+ * Aplica migraciones ordenadas de forma reproducible y reversible, registrando
+ * las aplicadas en la colección `_migrations`. Reaplicar es un no-op (solo se
+ * ejecutan las pendientes); revertir ejecuta el `down` de las más recientes.
+ */
+
+export const MIGRATIONS_COLLECTION = "_migrations";
+
+export interface MigrationRecord {
+  id: string;
+  name: string;
+  appliedAt: Date;
+}
+
+export interface MigrationStatusEntry {
+  id: string;
+  name: string;
+  applied: boolean;
+  appliedAt: Date | null;
+}
+
+interface MigratorOptions {
+  /** Lista de migraciones a considerar (por defecto, todas las registradas). */
+  migrations?: Migration[];
+}
+
+/** Garantiza el índice único que evita registrar dos veces la misma migración. */
+async function ensureLedger(db: Db): Promise<void> {
+  await db.collection(MIGRATIONS_COLLECTION).createIndex({ id: 1 }, { unique: true });
+}
+
+async function getApplied(db: Db): Promise<MigrationRecord[]> {
+  return db
+    .collection<MigrationRecord>(MIGRATIONS_COLLECTION)
+    .find()
+    .sort({ id: 1 })
+    .toArray();
+}
+
+/** Estado de cada migración: aplicada o pendiente. */
+export async function migrationStatus(
+  db: Db,
+  { migrations = defaultMigrations }: MigratorOptions = {},
+): Promise<MigrationStatusEntry[]> {
+  const applied = new Map((await getApplied(db)).map((r) => [r.id, r.appliedAt]));
+  return migrations.map((m) => ({
+    id: m.id,
+    name: m.name,
+    applied: applied.has(m.id),
+    appliedAt: applied.get(m.id) ?? null,
+  }));
+}
+
+/**
+ * Aplica todas las migraciones pendientes en orden. Idempotente: las ya
+ * registradas se omiten. Devuelve los ids realmente aplicados.
+ */
+export async function migrateUp(
+  db: Db,
+  { migrations = defaultMigrations }: MigratorOptions = {},
+): Promise<string[]> {
+  await ensureLedger(db);
+  const appliedIds = new Set((await getApplied(db)).map((r) => r.id));
+  const pending = [...migrations]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .filter((m) => !appliedIds.has(m.id));
+
+  const ran: string[] = [];
+  for (const migration of pending) {
+    await migration.up(db);
+    await db
+      .collection<MigrationRecord>(MIGRATIONS_COLLECTION)
+      .insertOne({ id: migration.id, name: migration.name, appliedAt: new Date() });
+    ran.push(migration.id);
+  }
+  return ran;
+}
+
+/**
+ * Revierte las últimas `steps` migraciones aplicadas (por defecto 1), de la más
+ * reciente a la más antigua. Devuelve los ids revertidos.
+ */
+export async function migrateDown(
+  db: Db,
+  { steps = 1, migrations = defaultMigrations }: MigratorOptions & { steps?: number } = {},
+): Promise<string[]> {
+  await ensureLedger(db);
+  const applied = await getApplied(db);
+  const toRevert = applied.slice(-steps).reverse();
+  const byId = new Map(migrations.map((m) => [m.id, m]));
+
+  const reverted: string[] = [];
+  for (const record of toRevert) {
+    const migration = byId.get(record.id);
+    if (migration) {
+      await migration.down(db);
+    }
+    await db.collection(MIGRATIONS_COLLECTION).deleteOne({ id: record.id });
+    reverted.push(record.id);
+  }
+  return reverted;
+}

--- a/apps/backend-api/src/migrations/001-unique-indexes.ts
+++ b/apps/backend-api/src/migrations/001-unique-indexes.ts
@@ -1,0 +1,63 @@
+import type { Migration } from "./types";
+import {
+  User,
+  Land,
+  RentalRequest,
+  Contract,
+  Payment,
+  Chat,
+  ChatMessage,
+  AuditEvent,
+  Lead,
+  WebhookEvent,
+  IdempotencyKey,
+  Report,
+} from "../db/schemas";
+
+/**
+ * Índices únicos que garantizan la identidad de cada entidad (#173).
+ *
+ * Los nombres de colección se derivan de los modelos Mongoose (`.collection.name`)
+ * en vez de escribirse a mano: así la migración apunta SIEMPRE a la colección real
+ * que la app lee (Mongoose pluraliza en minúsculas: `RentalRequest` →
+ * `rentalrequests`), evitando el desajuste camelCase del hallazgo A-2.
+ *
+ * Se usan los nombres de índice por defecto de Mongo (`<campo>_1`), idénticos a
+ * los que crearía `autoIndex`, para que `createIndex` sea idempotente y no
+ * choque con un índice ya existente.
+ */
+const UNIQUE_INDEXES: { collection: string; field: string }[] = [
+  { collection: User.collection.name, field: "clerkUserId" },
+  { collection: Land.collection.name, field: "id" },
+  { collection: RentalRequest.collection.name, field: "id" },
+  { collection: Contract.collection.name, field: "id" },
+  { collection: Payment.collection.name, field: "id" },
+  { collection: Chat.collection.name, field: "id" },
+  { collection: ChatMessage.collection.name, field: "id" },
+  { collection: AuditEvent.collection.name, field: "id" },
+  { collection: Lead.collection.name, field: "id" },
+  { collection: WebhookEvent.collection.name, field: "eventId" },
+  { collection: IdempotencyKey.collection.name, field: "key" },
+  { collection: Report.collection.name, field: "id" },
+];
+
+export const migration: Migration = {
+  id: "001",
+  name: "unique-indexes",
+  async up(db) {
+    for (const { collection, field } of UNIQUE_INDEXES) {
+      await db.collection(collection).createIndex({ [field]: 1 }, { unique: true });
+    }
+  },
+  async down(db) {
+    for (const { collection, field } of UNIQUE_INDEXES) {
+      // Nombre por defecto de Mongo para un índice de un solo campo ascendente.
+      await db
+        .collection(collection)
+        .dropIndex(`${field}_1`)
+        .catch(() => {
+          /* el índice puede no existir; down debe ser tolerante */
+        });
+    }
+  },
+};

--- a/apps/backend-api/src/migrations/index.ts
+++ b/apps/backend-api/src/migrations/index.ts
@@ -1,0 +1,8 @@
+import type { Migration } from "./types";
+import { migration as m001UniqueIndexes } from "./001-unique-indexes";
+
+/**
+ * Registro ordenado de migraciones (#173). Añade nuevas migraciones al final,
+ * con un `id` estrictamente mayor. El migrador las aplica en este orden.
+ */
+export const migrations: Migration[] = [m001UniqueIndexes];

--- a/apps/backend-api/src/migrations/types.ts
+++ b/apps/backend-api/src/migrations/types.ts
@@ -1,0 +1,27 @@
+import type { Connection } from "mongoose";
+
+/**
+ * Tipo `Db` derivado del `Connection` de Mongoose (no de `mongodb` directamente):
+ * el proyecto tiene dos versiones de `mongodb` en el árbol (la propia y la que
+ * anida Mongoose), y `mongoose.connection.db` devuelve la de Mongoose. Derivarlo
+ * de aquí garantiza compatibilidad de tipos.
+ */
+export type Db = NonNullable<Connection["db"]>;
+
+/**
+ * Una migración versionada de base de datos (#173 / HU-55).
+ *
+ * Cada migración es reproducible (idempotente al reaplicarse) y reversible
+ * (`down` deshace lo que hace `up`). El `id` es ordenable y único; las
+ * migraciones se aplican en orden ascendente de `id`.
+ */
+export interface Migration {
+  /** Identificador ordenable y único, p. ej. "001". */
+  id: string;
+  /** Descripción legible de qué hace la migración. */
+  name: string;
+  /** Aplica la migración. Debe ser idempotente. */
+  up(db: Db): Promise<void>;
+  /** Revierte la migración. Debe tolerar que lo revertido ya no exista. */
+  down(db: Db): Promise<void>;
+}

--- a/apps/backend-api/src/routes/admin-migrations.test.ts
+++ b/apps/backend-api/src/routes/admin-migrations.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+
+import { requestJson } from "../lib/http-test-utils";
+
+describe("GET /admin/migrations (#173)", () => {
+  it("devuelve el estado de migraciones a un admin", async () => {
+    const { response, payload } = await requestJson("/api/v1/admin/migrations", {
+      headers: { "x-dev-user-id": "admin_migrations", "x-dev-role": "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(payload.data.migrations)).toBe(true);
+    // La migración de índices únicos siempre está registrada en el catálogo.
+    expect(payload.data.migrations.some((m: { id: string }) => m.id === "001")).toBe(true);
+    expect(typeof payload.data.applied).toBe("number");
+    expect(typeof payload.data.pending).toBe("number");
+  });
+
+  it("prohíbe el acceso a un usuario no admin", async () => {
+    const { response } = await requestJson("/api/v1/admin/migrations", {
+      headers: { "x-dev-user-id": "user_plain_01" },
+    });
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -1,14 +1,33 @@
 import { Hono } from "hono";
+import mongoose from "mongoose";
 
 import { failure, success } from "../lib/api-response";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
 import { getStore } from "../store/in-memory-db";
+import { migrationStatus } from "../lib/migrator";
 import { User, Land, RentalRequest, Lead } from "../db/schemas";
 import type { UserStatus } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const adminRoutes = new Hono<AppEnv>();
+
+/**
+ * Estado de las migraciones de BD (#173). Da visibilidad al equipo sobre qué
+ * migraciones se han aplicado sin abrir la base de datos.
+ */
+adminRoutes.get("/admin/migrations", requireAuth, requireAdmin, async (c) => {
+  const db = mongoose.connection.db;
+  if (!db) {
+    return failure(c, 503, "INTERNAL_ERROR", "Database connection not available");
+  }
+  const status = await migrationStatus(db);
+  return success(c, {
+    migrations: status,
+    applied: status.filter((m) => m.applied).length,
+    pending: status.filter((m) => !m.applied).length,
+  });
+});
 
 adminRoutes.get("/admin/users", requireAuth, requireAdmin, async (c) => {
   const role = c.req.query("role") as "user" | "admin" | undefined;

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,6 +4,47 @@
 
 ---
 
+## Migraciones versionadas de esquema (#173 / HU-55)
+
+Sistema de migraciones **reproducibles y reversibles** para evolucionar el
+esquema sin pérdida de datos. Las migraciones aplicadas se registran en la
+colección `_migrations`.
+
+### Estructura
+- `src/migrations/` — una migración por archivo (`NNN-nombre.ts`) que exporta un
+  objeto `Migration` con `id`, `name`, `up(db)` y `down(db)`. Se registran en
+  orden en `src/migrations/index.ts`.
+- `src/lib/migrator.ts` — runner: `migrateUp`, `migrateDown`, `migrationStatus`.
+  Idempotente (solo aplica pendientes) y reversible (`down` de las más recientes).
+- `scripts/migrate.ts` — CLI.
+
+### Uso
+
+```bash
+cd apps/backend-api
+bun run migrate status     # lista migraciones y su estado (✓ aplicada / · pendiente)
+bun run migrate up         # aplica las pendientes
+bun run migrate down [n]   # revierte las últimas n (por defecto 1)
+```
+
+Al **arrancar** el backend, las migraciones pendientes se aplican
+automáticamente (idempotente). Desactivable con `RUN_MIGRATIONS=false` para
+correrlas en un paso de despliegue aparte. El estado también se consulta vía
+`GET /api/v1/admin/migrations` (admin).
+
+### Añadir una migración
+1. Crear `src/migrations/NNN-descripcion.ts` con `id` mayor que el último.
+2. Implementar `up` (idempotente) y `down` (tolerante a que no exista lo revertido).
+3. Registrarla en `src/migrations/index.ts`.
+
+### Migraciones existentes
+- **001 unique-indexes** — índices únicos consistentes en la identidad de cada
+  entidad (`id`, y `clerkUserId`/`eventId`/`key` donde aplica). Los nombres de
+  colección se derivan de los modelos Mongoose para apuntar siempre a la
+  colección real (evita el desajuste de nombres del hallazgo A-2).
+
+---
+
 ## TAREA 1: MongoDB - Migración Completa
 
 ### Estado Actual


### PR DESCRIPTION
Closes #173

Cierra #173.

**Como equipo, quiero migraciones versionadas, para evolucionar el esquema sin pérdida de datos.**

## Qué incluye
- **`src/migrations/`** — una migración por archivo (`NNN-nombre.ts`) que exporta `{ id, name, up(db), down(db) }`; registradas en orden en `index.ts`.
- **`src/lib/migrator.ts`** — runner:
  - `migrateUp` **idempotente** (solo aplica pendientes; las registra en la colección `_migrations` con índice único que evita doble aplicación).
  - `migrateDown` **reversible** (ejecuta `down` de las más recientes).
  - `migrationStatus`.
- **Migración `001-unique-indexes`** — índices únicos consistentes de identidad (`id`, y `clerkUserId`/`eventId`/`key` donde aplica). Deriva los nombres de colección de los **modelos Mongoose** para apuntar siempre a la colección real (evita el desajuste camelCase del hallazgo **A-2**).
- **CLI** `scripts/migrate.ts` + script `bun run migrate`: `status | up | down [n]`.
- **Arranque**: aplica pendientes automáticamente (idempotente); desactivable con `RUN_MIGRATIONS=false` para correrlas en un paso de despliegue aparte.
- **`GET /api/v1/admin/migrations`** (admin) — estado de migraciones para visibilidad sin abrir la BD.
- `docs/MIGRATION.md`: guía del sistema.

## Criterios de aceptación
- [x] Migraciones **reproducibles** (idempotentes) y **reversibles** (`up`/`down`).
- [x] Índices únicos (`id`, `clerkUserId`) creados de forma **consistente**.

## Verificación
- Suite backend: **256 tests verdes, 0 fallos** (+7: mecánica del migrador, índices únicos reales, endpoint admin). `tsc` limpio.
- **E2E en vivo** contra MongoDB real: `status` (· pendiente) → `up` (Aplicadas: 001) → `up` (idempotente: sin pendientes) → `down 1` (Revertidas: 001) → `up` (restaura). Test verifica que `lands.id` y `users.clerkUserId` quedan con índice `unique: true`.

## Notas
- Vertical: la historia es de **infraestructura**; su "cara visible" es el endpoint admin de estado. Un panel en `apps/web` para mostrarlo es un follow-up opcional (no requerido por los criterios).
- Independiente de #266/#267/#268/#269 (no toca sus archivos).