### PR TITLE
feat(web+backend): confianza en el detalle — verificación y perfil público del propietario (#150)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -28,6 +28,8 @@ export interface IUser extends Document {
   role: AppRole;
   status: UserStatus;
   profile: { fullName: string; phone?: string; province?: string; marketPreference?: "busco" | "ofrezco" };
+  /** Identidad verificada por TerraShare (#150). Alimenta el banner de confianza. */
+  verified?: boolean;
   deletedAt?: Date;
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +65,8 @@ export interface ILand extends Document {
   water?: string;
   access?: string;
   features?: string[];
+  /** Terreno verificado por TerraShare (identidad y linderos) (#150). */
+  verified?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -208,6 +212,7 @@ const UserSchema = new Schema<IUser>({
     province: String,
     marketPreference: { type: String, enum: ["busco", "ofrezco"] },
   },
+  verified: { type: Boolean, default: false },
   deletedAt: { type: Date, default: null },
 }, { timestamps: true });
 
@@ -241,6 +246,7 @@ const LandSchema = new Schema<ILand>({
   water: String,
   access: String,
   features: [String],
+  verified: { type: Boolean, default: false },
 }, { timestamps: true });
 
 LandSchema.index({ title: "text", description: "text" });

--- a/apps/backend-api/src/routes/auth.ts
+++ b/apps/backend-api/src/routes/auth.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { failure, success } from "../lib/api-response";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { getStore } from "../store/in-memory-db";
-import { User } from "../db/schemas";
+import { User, Land } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const authRoutes = new Hono<AppEnv>();
@@ -11,6 +11,35 @@ export const authRoutes = new Hono<AppEnv>();
 authRoutes.get("/auth/me", requireAuth, (c) => {
   const authUser = c.get("authUser");
   return success(c, authUser);
+});
+
+/**
+ * Perfil PÚBLICO de un propietario (#150). Alimenta la tarjeta de confianza del
+ * detalle de terreno con datos reales: nombre, verificación e indicadores
+ * honestos (miembro desde, nº de publicaciones activas). No expone datos
+ * sensibles (email, teléfono). Público: el detalle de terreno lo es.
+ */
+authRoutes.get("/users/:userId/public", async (c) => {
+  const userId = c.req.param("userId");
+
+  const user = await User.findOne({ clerkUserId: userId }).lean();
+  const store = getStore();
+  const memUser = store.users.get(userId);
+
+  const displayName = user?.profile?.fullName ?? memUser?.profile?.fullName ?? "Propietario";
+  const verified = user?.verified ?? false;
+  const memberSince = user?.createdAt ? new Date(user.createdAt).toISOString() : null;
+
+  // Nº de terrenos publicados (activos): señal de confianza real y barata.
+  const activeLandsCount = await Land.countDocuments({ ownerId: userId, status: "active" });
+
+  return success(c, {
+    id: userId,
+    displayName,
+    verified,
+    memberSince,
+    activeLandsCount,
+  });
 });
 
 authRoutes.patch("/auth/profile", requireAuth, async (c) => {

--- a/apps/backend-api/src/routes/public-owner.test.ts
+++ b/apps/backend-api/src/routes/public-owner.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { requestJson } from "../lib/http-test-utils";
+
+/**
+ * Perfil público del propietario (#150). Público (sin auth), solo datos no
+ * sensibles, con nº de terrenos activos como señal de confianza.
+ */
+describe("GET /users/:userId/public (#150)", () => {
+  it("devuelve el perfil público sin requerir autenticación", async () => {
+    // Creamos un terreno para tener un propietario con al menos una publicación.
+    const created = await requestJson("/api/v1/lands", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_owner_public_01" },
+      body: {
+        title: "Terreno del perfil público",
+        area: 20,
+        allowedUses: ["agricultura"],
+        location: { province: "Panama", district: "Panama" },
+        priceRule: { currency: "USD", pricePerMonth: 250 },
+      },
+    });
+    const landId = created.payload.data.id;
+    await requestJson(`/api/v1/lands/${landId}/status`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_owner_public_01" },
+      body: { status: "active" },
+    });
+
+    // Sin cabeceras de auth: el endpoint es público.
+    const { response, payload } = await requestJson(
+      "/api/v1/users/user_owner_public_01/public",
+    );
+
+    expect(response.status).toBe(200);
+    expect(payload.data.id).toBe("user_owner_public_01");
+    expect(typeof payload.data.displayName).toBe("string");
+    expect(typeof payload.data.verified).toBe("boolean");
+    expect(payload.data.activeLandsCount).toBeGreaterThanOrEqual(1);
+    // No debe exponer datos sensibles.
+    expect(payload.data.email).toBeUndefined();
+    expect(payload.data.phone).toBeUndefined();
+  });
+
+  it("un propietario desconocido devuelve un perfil por defecto (no 404)", async () => {
+    const { response, payload } = await requestJson("/api/v1/users/user_inexistente_xyz/public");
+    expect(response.status).toBe(200);
+    expect(payload.data.displayName).toBe("Propietario");
+    expect(payload.data.verified).toBe(false);
+    expect(payload.data.activeLandsCount).toBe(0);
+  });
+});

--- a/apps/web/src/pages/LandDetailPage.tsx
+++ b/apps/web/src/pages/LandDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useClerk, useUser } from "@clerk/clerk-react";
-import type { LandDto } from "@terrashare/shared";
+import type { LandDto, PublicOwnerProfileDto } from "@terrashare/shared";
 import {
   ArrowLeft,
   Heart,
@@ -15,10 +15,11 @@ import {
   ArrowRight,
   ImageIcon,
   ShieldCheck,
+  BadgeCheck,
   User,
   Flag,
 } from "lucide-react";
-import { createChat, getLandById, createReport } from "../services/api";
+import { createChat, getLandById, createReport, getOwnerPublicProfile } from "../services/api";
 import type { ReportReason } from "../services/api";
 import "./detail.css";
 
@@ -47,6 +48,13 @@ const USE_LABELS: Record<string, string> = {
 function formatUse(use?: string): string {
   if (!use) return "Terreno";
   return USE_LABELS[use] ?? use;
+}
+
+/** "julio de 2026" a partir de una fecha ISO; cadena vacía si es inválida (#150). */
+function formatMemberSince(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("es-PA", { month: "long", year: "numeric" });
 }
 
 function formatAvailable(iso?: string): string {
@@ -80,6 +88,7 @@ export default function LandDetailPage() {
 
   const [land, setLand] = useState<DetailLand | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [owner, setOwner] = useState<PublicOwnerProfileDto | null>(null);
 
   const [reportOpen, setReportOpen] = useState(false);
   const [reportReason, setReportReason] = useState<ReportReason>("fraude");
@@ -93,6 +102,12 @@ export default function LandDetailPage() {
         if (!active) return;
         setLand(data);
         setStatus(data ? "ready" : "error");
+        // Perfil público del propietario (#150) para la tarjeta de confianza.
+        if (data?.ownerId) {
+          getOwnerPublicProfile(data.ownerId)
+            .then((profile) => active && setOwner(profile))
+            .catch(() => active && setOwner(null));
+        }
       })
       .catch((err) => {
         console.error("Error cargando terreno:", err);
@@ -335,6 +350,11 @@ export default function LandDetailPage() {
               <span className={`det-badge ${isSale ? "det-badge--sale" : ""}`}>
                 {isSale ? "En venta" : formatUse(land.allowedUses?.[0])}
               </span>
+              {land.verified && (
+                <span className="det-badge det-badge--verified">
+                  <BadgeCheck size={13} /> Verificado
+                </span>
+              )}
             </div>
             <h1 className="det-title">{land.title}</h1>
             <p className="det-loc">
@@ -407,16 +427,36 @@ export default function LandDetailPage() {
                   <User size={20} />
                 </span>
                 <div>
-                  <div className="det-owner__name">Propietario</div>
-                  {/* TODO(#138): perfil del propietario (nombre, tiempo de respuesta). */}
-                  <div className="det-owner__role">Publica en TerraShare</div>
+                  <div className="det-owner__name">
+                    {owner?.displayName ?? "Propietario"}
+                    {owner?.verified && (
+                      <BadgeCheck size={15} className="det-owner__check" aria-label="Verificado" />
+                    )}
+                  </div>
+                  <div className="det-owner__role">
+                    {owner
+                      ? [
+                          owner.memberSince ? `Miembro desde ${formatMemberSince(owner.memberSince)}` : null,
+                          owner.activeLandsCount > 0
+                            ? `${owner.activeLandsCount} ${owner.activeLandsCount === 1 ? "terreno" : "terrenos"}`
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ") || "Publica en TerraShare"
+                      : "Publica en TerraShare"}
+                  </div>
                 </div>
               </div>
 
-              {/* TODO(#138): verificación de identidad/linderos aún no existe en backend. */}
-              <div className="det-note">
-                <ShieldCheck size={15} /> Coordina y acuerda de forma segura dentro de TerraShare
-              </div>
+              {owner?.verified ? (
+                <div className="det-note det-note--verified">
+                  <ShieldCheck size={15} /> Identidad del propietario verificada por TerraShare
+                </div>
+              ) : (
+                <div className="det-note">
+                  <ShieldCheck size={15} /> Coordina y acuerda de forma segura dentro de TerraShare
+                </div>
+              )}
             </div>
           </aside>
         </div>

--- a/apps/web/src/pages/detail.css
+++ b/apps/web/src/pages/detail.css
@@ -83,6 +83,13 @@
   border-radius: 999px;
 }
 .det-badge--sale { color: var(--ts-bg); background: var(--ts-green-ink); }
+.det-badge--verified {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--ts-green-ink);
+  background: var(--ts-tint-green);
+}
 .det-flag {
   display: inline-flex;
   align-items: center;
@@ -201,7 +208,15 @@
   justify-content: center;
   flex: 0 0 auto;
 }
-.det-owner__name { font-family: var(--ts-font-serif); font-weight: 600; font-size: 17px; }
+.det-owner__name {
+  font-family: var(--ts-font-serif);
+  font-weight: 600;
+  font-size: 17px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.det-owner__check { color: var(--ts-green); flex: 0 0 auto; }
 .det-owner__role { font-size: 12.5px; color: var(--ts-sage); }
 
 .det-note {
@@ -214,6 +229,11 @@
   background: var(--ts-tint-green);
   border-radius: 10px;
   padding: 10px 12px;
+}
+.det-note--verified {
+  color: var(--ts-green-ink);
+  background: var(--ts-tint-green);
+  font-weight: 600;
 }
 
 /* ── estados ─────────────────────────────────────────────────────────────── */

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -13,6 +13,7 @@ import type {
   ExternalContactDto,
   LandDto,
   PaymentDto,
+  PublicOwnerProfileDto,
   ReceiptDto,
   RentalRequestDto,
 } from "@terrashare/shared";
@@ -150,6 +151,14 @@ export const getRentalRequestById = async (requestId: string): Promise<RentalReq
 /** GET /api/v1/lands/:landId */
 export const getLandById = async (landId: string): Promise<LandDto | null> => {
   const res = await request<LandDto>("GET", `/api/v1/lands/${landId}`);
+  return res?.data ?? null;
+};
+
+/** GET /api/v1/users/:userId/public — perfil público del propietario (#150). */
+export const getOwnerPublicProfile = async (
+  userId: string,
+): Promise<PublicOwnerProfileDto | null> => {
+  const res = await request<PublicOwnerProfileDto>("GET", `/api/v1/users/${userId}/public`);
   return res?.data ?? null;
 };
 

--- a/packages/shared/src/dto/auth.ts
+++ b/packages/shared/src/dto/auth.ts
@@ -15,3 +15,16 @@ export interface UserSummaryDto {
 }
 
 export type AuthMeResponseDto = UserSummaryDto;
+
+/**
+ * Perfil público de un propietario (#150). Solo datos no sensibles para la
+ * tarjeta de confianza del detalle de terreno.
+ */
+export interface PublicOwnerProfileDto {
+  id: string;
+  displayName: string;
+  verified: boolean;
+  /** ISO date; null si no se conoce. */
+  memberSince: string | null;
+  activeLandsCount: number;
+}

--- a/packages/shared/src/dto/lands.ts
+++ b/packages/shared/src/dto/lands.ts
@@ -56,6 +56,8 @@ export interface LandDto {
   access?: string;
   /** Características destacadas del terreno (#138). */
   features?: string[];
+  /** Verificado por TerraShare (identidad y linderos) (#150). */
+  verified?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,7 @@ export type {
 
 export type {
   AuthMeResponseDto,
+  PublicOwnerProfileDto,
   UserStatus,
   UserSummaryDto,
 } from "./dto/auth";


### PR DESCRIPTION
Closes #150

Cierra #150.

El prototipo del detalle mostraba elementos de confianza **sin backend** (chip "Verificado", banner de identidad, tarjeta del propietario con nombre real). Ahora se alimentan de datos reales, **sin afirmar verificación falsa**.

## Backend
- Campo `verified` en **Land** (terreno) y **User** (identidad del propietario).
- **`GET /api/v1/users/:userId/public`** (público, sin auth): `displayName`, `verified`, `memberSince`, `activeLandsCount`. No expone datos sensibles (email/teléfono). Fallback honesto si el propietario no existe (perfil por defecto, no 404).

## Contratos (shared)
- `LandDto.verified` + nuevo `PublicOwnerProfileDto`.

## Web (`LandDetailPage`)
- Chip **"Verificado"** junto al título cuando `land.verified`.
- Tarjeta del propietario con **nombre real**, **"Miembro desde …"** y **nº de terrenos publicados** (señales de confianza reales).
- Banner **"Identidad del propietario verificada por TerraShare"** cuando `owner.verified`; si no, aviso genérico honesto.
- `getOwnerPublicProfile` en el cliente API.

## Verificación
- Suite backend: **251 tests verdes, 0 fallos** (+2 del endpoint público). `tsc` backend+shared+web limpio; build web OK.
- **E2E en vivo** contra MongoDB real:
  - Terreno/dueño verificados → chip **VERIFICADO** + check + banner de identidad; endpoint devuelve `{displayName:"José Hernández", verified:true, memberSince, activeLandsCount:4}`.
  - Terreno no verificado → datos reales del dueño ("Pedro Torres · Miembro desde diciembre de 2025 · 2 terrenos") con aviso genérico, **sin** afirmar verificación.

## Notas
- El indicador "responde en ~2h" del prototipo requiere analítica de chats; se deja como follow-up (se muestra solo lo que existe, honesto).
- Independiente de los otros PRs abiertos.