### PR TITLE
feat(mcp): base completa del servidor MCP (fundación + identidad/permisos + andamiaje) (#234)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,22 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun test
 
+  mcp-server:
+    name: MCP Server
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/mcp-server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun test
+
   web-build:
     name: Web Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Install shared package deps (zod, resuelto desde fuente)
+        run: cd ../../packages/shared && bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
 
@@ -37,6 +39,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Install shared package deps (zod, resuelto desde fuente)
+        run: cd ../../packages/shared && bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bun test
 
@@ -52,6 +56,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Install shared package deps (zod, resuelto desde fuente)
+        run: cd ../../packages/shared && bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun test
@@ -68,6 +74,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Install shared package deps (zod, resuelto desde fuente)
+        run: cd ../../packages/shared && bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bun run build
         env:
@@ -87,6 +95,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Install shared package deps (zod, resuelto desde fuente)
+        run: cd ../../packages/shared && bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium
       - run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           bun-version: latest
       - name: Install shared package deps (zod, resuelto desde fuente)
         run: cd ../../packages/shared && bun install --frozen-lockfile
+      - name: Install backend-api deps (reutilizadas vía @backend/*)
+        run: cd ../backend-api && bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun test

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -30,11 +30,51 @@ El servidor habla por **stdio** (stdout = canal del protocolo; los logs van a st
 | Variable | Requerida | Descripción |
 |----------|-----------|-------------|
 | `MONGODB_URI` | recomendado | Misma BD que el backend. Default: `mongodb://127.0.0.1:27017/terrashare`. |
+| `MCP_ACTING_USER_ID` | para tools con permisos | `clerkUserId` del usuario en cuyo nombre actúa el servidor. Su rol/estado se resuelven desde Mongo. Sin él, solo funcionan las tools públicas. |
 | `MCP_API_KEY` | opcional | Si se define, activa la autenticación por API key (para transportes remotos). |
 | `MCP_PROVIDED_KEY` | si hay `MCP_API_KEY` | Key que aporta el proceso que lanza el servidor; debe coincidir. |
 
 En uso local por stdio la confianza es del proceso que lo lanza; la API key está
 pensada para el transporte remoto (HTTP/SSE), a añadir después.
+
+## Identidad y permisos
+
+Las tools que exponen o mutan datos con permisos usan los helpers `can*` del
+backend (reexportados en `src/permissions.ts`), que necesitan saber **quién
+actúa**. Ese usuario se configura con `MCP_ACTING_USER_ID` (su `clerkUserId`); el
+servidor resuelve su rol/estado desde Mongo y lo expone a cada tool como
+`ctx.actingUser`.
+
+Cada tool declara su acceso con `requires`:
+
+| `requires` | Significado |
+|------------|-------------|
+| `"public"` (default) | No requiere identidad (p. ej. `search_lands`). |
+| `"user"` | Requiere `MCP_ACTING_USER_ID` (usuario activo, no bloqueado). |
+| `"admin"` | Requiere que ese usuario tenga rol `admin`. |
+
+El andamiaje (`src/tools/define-tool.ts`) aplica esta puerta automáticamente y
+devuelve un error legible si no se cumple.
+
+## Cómo construir una tool (para el equipo) — HU-64..HU-92
+
+Cada tool es independiente. Pasos:
+
+1. Copia `src/tools/_template.ts` a `src/tools/<mi-tool>.ts`.
+2. Define el `inputSchema` (shape Zod, con `.describe()` en cada campo).
+3. Escribe la lógica en el `handler(args, ctx)`:
+   - Usa `ctx.actingUser` (garantizado si `requires` es `"user"`/`"admin"`).
+   - Aplica permisos por recurso con los helpers de `../permissions`
+     (p. ej. `canMutateLand(ctx.actingUser!, land)`).
+   - Lanza `ToolError("mensaje")` para errores de negocio (se devuelven como
+     resultado de error, sin tumbar el servidor).
+   - Devuelve un objeto plano (se serializa a JSON + `structuredContent`).
+4. Regístrala añadiéndola al array `TOOLS` de `src/server.ts`.
+5. Añade `src/tools/<mi-tool>.test.ts` (el preload levanta Mongo en memoria y
+   siembra terrenos/usuarios; ver `search-lands.test.ts` y `define-tool.test.ts`).
+
+No dupliques lógica de negocio: reutiliza modelos (`@backend/db/schemas`) y
+reglas (`@backend/lib/auth-helpers` vía `../permissions`).
 
 ## Conectar un cliente MCP
 
@@ -50,7 +90,8 @@ Añade el servidor a la config de MCP del cliente (`claude_desktop_config.json` 
       "command": "bun",
       "args": ["run", "C:/ruta/al/repo/apps/mcp-server/src/index.ts"],
       "env": {
-        "MONGODB_URI": "mongodb://127.0.0.1:27017/terrashare"
+        "MONGODB_URI": "mongodb://127.0.0.1:27017/terrashare",
+        "MCP_ACTING_USER_ID": "<clerkUserId opcional para tools con permisos>"
       }
     }
   }

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -1,0 +1,82 @@
+# TerraShare MCP Server (#234)
+
+Servidor **MCP (Model Context Protocol)** que expone el dominio de TerraShare como
+*tools* consumibles por clientes MCP (Claude Desktop, Claude Code, etc.).
+
+Esta es la **fundación** del épico #234: servidor + transporte stdio + autenticación
+por API key + la primera tool (`search_lands`, HU-63 #180). Las 30 tools están
+desglosadas en los issues HU-63…HU-92 y se registran en `src/server.ts`.
+
+## Arquitectura
+
+- Runtime **Bun** (alineado con `apps/backend-api`).
+- SDK oficial `@modelcontextprotocol/sdk` (TypeScript).
+- **Reutiliza** la capa de datos del backend (`@backend/db/*`: modelos Mongoose y
+  conexión) — no se duplica lógica. La misma `MONGODB_URI`.
+- Cada tool valida su entrada con Zod y devuelve `structuredContent`.
+
+## Ejecutar
+
+```bash
+cd apps/mcp-server
+bun install
+MONGODB_URI="mongodb://127.0.0.1:27017/terrashare" bun run start
+```
+
+El servidor habla por **stdio** (stdout = canal del protocolo; los logs van a stderr).
+
+## Variables de entorno
+
+| Variable | Requerida | Descripción |
+|----------|-----------|-------------|
+| `MONGODB_URI` | recomendado | Misma BD que el backend. Default: `mongodb://127.0.0.1:27017/terrashare`. |
+| `MCP_API_KEY` | opcional | Si se define, activa la autenticación por API key (para transportes remotos). |
+| `MCP_PROVIDED_KEY` | si hay `MCP_API_KEY` | Key que aporta el proceso que lanza el servidor; debe coincidir. |
+
+En uso local por stdio la confianza es del proceso que lo lanza; la API key está
+pensada para el transporte remoto (HTTP/SSE), a añadir después.
+
+## Conectar un cliente MCP
+
+### Claude Desktop / Claude Code
+
+Añade el servidor a la config de MCP del cliente (`claude_desktop_config.json` o
+`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "terrashare": {
+      "command": "bun",
+      "args": ["run", "C:/ruta/al/repo/apps/mcp-server/src/index.ts"],
+      "env": {
+        "MONGODB_URI": "mongodb://127.0.0.1:27017/terrashare"
+      }
+    }
+  }
+}
+```
+
+Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
+
+## Tools
+
+| Tool | HU | Issue | Estado |
+|------|-----|-------|--------|
+| `search_lands` | HU-63 | #180 | ✅ implementada |
+
+`search_lands`: busca terrenos publicados (activos) con filtros por texto,
+ubicación, uso, operación y precio; devuelve resultados paginados.
+
+Ejemplo de argumentos:
+
+```json
+{ "province": "Chiriqui", "use": "agricultura", "priceMax": 1000, "pageSize": 10 }
+```
+
+## Tests
+
+```bash
+bun test        # tools + auth + E2E (cliente MCP real contra Mongo en memoria)
+bun run typecheck
+```

--- a/apps/mcp-server/bun.lock
+++ b/apps/mcp-server/bun.lock
@@ -1,0 +1,322 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@terrashare/mcp-server",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "mongoose": "^8.9.5",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "mongodb-memory-server": "^10.1.2",
+        "typescript": "^5.6.3",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.12", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
+
+    "@types/whatwg-url": ["@types/whatwg-url@11.0.5", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
+
+    "bare-fs": ["bare-fs@4.7.4", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ=="],
+
+    "bare-path": ["bare-path@3.1.1", "", {}, "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="],
+
+    "bare-stream": ["bare-stream@2.13.3", "", { "dependencies": { "b4a": "^1.8.1", "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ=="],
+
+    "bare-url": ["bare-url@2.4.5", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
+
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.29", "", {}, "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "kareem": ["kareem@2.6.3", "", {}, "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q=="],
+
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "mongodb": ["mongodb@6.20.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^6.10.4", "mongodb-connection-string-url": "^3.0.2" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.1.0 || ^2.0.0", "gcp-metadata": "^5.2.0", "kerberos": "^2.0.1", "mongodb-client-encryption": ">=6.0.0 <7", "snappy": "^7.3.2", "socks": "^2.7.1" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ=="],
+
+    "mongodb-connection-string-url": ["mongodb-connection-string-url@3.0.2", "", { "dependencies": { "@types/whatwg-url": "^11.0.2", "whatwg-url": "^14.1.0 || ^13.0.0" } }, "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA=="],
+
+    "mongodb-memory-server": ["mongodb-memory-server@10.4.3", "", { "dependencies": { "mongodb-memory-server-core": "10.4.3", "tslib": "^2.8.1" } }, "sha512-CDZvFisXvGIigsIw5gqH6r9NI/zxGa/uRdutgUL/isuJh+inj0YXb7Ykw6oFMFzqgTJWb7x0I5DpzrqCstBWpg=="],
+
+    "mongodb-memory-server-core": ["mongodb-memory-server-core@10.4.3", "", { "dependencies": { "async-mutex": "^0.5.0", "camelcase": "^6.3.0", "debug": "^4.4.3", "find-cache-dir": "^3.3.2", "follow-redirects": "^1.15.11", "https-proxy-agent": "^7.0.6", "mongodb": "^6.9.0", "new-find-package-json": "^2.0.0", "semver": "^7.7.3", "tar-stream": "^3.1.7", "tslib": "^2.8.1", "yauzl": "^3.2.0" } }, "sha512-IPjlw73IoSYopnqBibQKxmAXMbOEPf5uGAOsBcaUiNH/TOI7V19WO+K7n5KYtnQ9FqzLGLpvwCGuPOTBSg4s5Q=="],
+
+    "mongoose": ["mongoose@8.24.1", "", { "dependencies": { "bson": "^6.10.4", "kareem": "2.6.3", "mongodb": "~6.20.0", "mpath": "0.9.0", "mquery": "5.0.0", "ms": "2.1.3", "sift": "17.1.3" } }, "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA=="],
+
+    "mpath": ["mpath@0.9.0", "", {}, "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="],
+
+    "mquery": ["mquery@5.0.0", "", { "dependencies": { "debug": "4.x" } }, "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "new-find-package-json": ["new-find-package-json@2.0.0", "", { "dependencies": { "debug": "^4.3.4" } }, "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "sift": ["sift@17.1.3", "", {}, "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="],
+
+    "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "mongodb-memory-server-core/mongodb": ["mongodb@6.21.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^6.10.4", "mongodb-connection-string-url": "^3.0.2" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.1.0 || ^2.0.0", "gcp-metadata": "^5.2.0", "kerberos": "^2.0.1", "mongodb-client-encryption": ">=6.0.0 <7", "snappy": "^7.3.2", "socks": "^2.7.1" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+  }
+}

--- a/apps/mcp-server/bunfig.toml
+++ b/apps/mcp-server/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/test-preload.ts"]

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@terrashare/mcp-server",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "dev": "bun --watch run src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "mongoose": "^8.9.5",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "mongodb-memory-server": "^10.1.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/mcp-server/src/auth.test.ts
+++ b/apps/mcp-server/src/auth.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { verifyApiKey } from "./auth";
+
+describe("verifyApiKey (#234)", () => {
+  const original = process.env.MCP_API_KEY;
+  afterEach(() => {
+    if (original === undefined) delete process.env.MCP_API_KEY;
+    else process.env.MCP_API_KEY = original;
+  });
+
+  it("permite el acceso cuando no hay API key configurada (stdio local)", () => {
+    delete process.env.MCP_API_KEY;
+    expect(verifyApiKey(undefined)).toBe(true);
+    expect(verifyApiKey("cualquiera")).toBe(true);
+  });
+
+  it("exige coincidencia exacta cuando hay API key configurada", () => {
+    process.env.MCP_API_KEY = "secreto-123";
+    expect(verifyApiKey("secreto-123")).toBe(true);
+    expect(verifyApiKey("otro")).toBe(false);
+    expect(verifyApiKey(undefined)).toBe(false);
+  });
+});

--- a/apps/mcp-server/src/auth.ts
+++ b/apps/mcp-server/src/auth.ts
@@ -1,0 +1,31 @@
+import { config } from "./config";
+
+/**
+ * Autenticación por API key (#234). En transportes remotos (HTTP/SSE) el cliente
+ * presenta la key; el servidor la valida contra `MCP_API_KEY`. Si no hay key
+ * configurada, la autenticación está deshabilitada (uso local por stdio, donde
+ * la confianza es del proceso que lanza el servidor).
+ *
+ * Reutiliza el mismo modelo de "API key" previsto para el backend (#158/#230):
+ * los permisos por tool seguirán los helpers `can*` cuando se añadan las tools
+ * que mutan o exponen datos sensibles.
+ */
+export function verifyApiKey(provided: string | undefined): boolean {
+  const expected = config.apiKey;
+  if (!expected) return true; // auth deshabilitada
+  return typeof provided === "string" && provided === expected;
+}
+
+/**
+ * Comprobación de arranque: cuando hay `MCP_API_KEY` configurada, el proceso que
+ * lanza el servidor debe aportar la misma key en `MCP_PROVIDED_KEY`. Evita
+ * exponer el servidor por error sin credencial en un despliegue remoto.
+ */
+export function assertStartupAuth(): void {
+  if (!config.authRequired) return;
+  if (!verifyApiKey(process.env.MCP_PROVIDED_KEY)) {
+    throw new Error(
+      "MCP_API_KEY está configurada pero MCP_PROVIDED_KEY no coincide: acceso denegado.",
+    );
+  }
+}

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -1,0 +1,21 @@
+/**
+ * Configuración del servidor MCP de TerraShare (#234).
+ *
+ * Reutiliza la misma `MONGODB_URI` que el backend. La API key es opcional: si se
+ * define `MCP_API_KEY`, el servidor exige que el cliente la presente (para
+ * transportes remotos); en uso local por stdio la confianza es del proceso.
+ */
+export const config = {
+  get mongoUri(): string {
+    return process.env.MONGODB_URI || "mongodb://127.0.0.1:27017/terrashare";
+  },
+  get apiKey(): string | undefined {
+    const key = process.env.MCP_API_KEY;
+    return key && key.length > 0 ? key : undefined;
+  },
+  get authRequired(): boolean {
+    return !!config.apiKey;
+  },
+  serverName: "terrashare-mcp",
+  serverVersion: "0.1.0",
+};

--- a/apps/mcp-server/src/context.test.ts
+++ b/apps/mcp-server/src/context.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { resolveActingUser } from "./context";
+
+describe("resolveActingUser (#234)", () => {
+  const original = process.env.MCP_ACTING_USER_ID;
+  afterEach(() => {
+    if (original === undefined) delete process.env.MCP_ACTING_USER_ID;
+    else process.env.MCP_ACTING_USER_ID = original;
+  });
+
+  it("devuelve null si no hay MCP_ACTING_USER_ID", async () => {
+    delete process.env.MCP_ACTING_USER_ID;
+    expect(await resolveActingUser()).toBeNull();
+  });
+
+  it("devuelve null si el usuario configurado no existe", async () => {
+    process.env.MCP_ACTING_USER_ID = "no_existe";
+    expect(await resolveActingUser()).toBeNull();
+  });
+
+  it("resuelve el usuario admin desde Mongo con id === clerkUserId", async () => {
+    process.env.MCP_ACTING_USER_ID = "user_admin";
+    const user = await resolveActingUser();
+    expect(user).not.toBeNull();
+    expect(user!.id).toBe("user_admin");
+    expect(user!.clerkUserId).toBe("user_admin");
+    expect(user!.role).toBe("admin");
+  });
+
+  it("resuelve un usuario regular con su rol", async () => {
+    process.env.MCP_ACTING_USER_ID = "user_regular";
+    const user = await resolveActingUser();
+    expect(user!.role).toBe("user");
+    expect(user!.status).toBe("active");
+  });
+});

--- a/apps/mcp-server/src/context.ts
+++ b/apps/mcp-server/src/context.ts
@@ -1,0 +1,52 @@
+import { User } from "@backend/db/schemas";
+import type { AuthContextUser } from "@backend/types";
+
+/**
+ * Identidad y contexto de ejecución de las tools (#234).
+ *
+ * Las tools que exponen o mutan datos con permisos usan los helpers `can*` del
+ * backend, que requieren el usuario que actúa. En el transporte stdio, ese
+ * usuario se configura vía `MCP_ACTING_USER_ID` (su `clerkUserId`): el servidor
+ * MCP actúa "en nombre de" esa cuenta, y su rol/estado se resuelven desde Mongo.
+ *
+ * (Cuando exista el transporte remoto multi-cliente, la API key mapeará a un
+ * usuario por clave; este mismo `ToolContext` seguirá siendo la interfaz que ven
+ * las tools, así que no habrá que reescribirlas.)
+ */
+
+export type ActingUser = AuthContextUser;
+
+export interface ToolContext {
+  /** Usuario que actúa, o `null` si el servidor corre sin identidad (solo tools públicas). */
+  actingUser: ActingUser | null;
+}
+
+/** Resuelve el usuario que actúa desde `MCP_ACTING_USER_ID`. Requiere Mongo conectada. */
+export async function resolveActingUser(): Promise<ActingUser | null> {
+  const clerkUserId = process.env.MCP_ACTING_USER_ID;
+  if (!clerkUserId) return null;
+
+  const user = await User.findOne({ clerkUserId }).lean();
+  if (!user) return null;
+
+  // En el modelo de auth del backend, `id` === `clerkUserId` (y `Land.ownerId`
+  // apunta a ese valor), así que los helpers `can*` funcionan directamente.
+  return {
+    id: user.clerkUserId,
+    clerkUserId: user.clerkUserId,
+    email: user.email,
+    role: user.role,
+    status: user.status,
+    profile: {
+      fullName: user.profile?.fullName ?? "",
+      phone: user.profile?.phone,
+      province: user.profile?.province,
+      marketPreference: user.profile?.marketPreference,
+    },
+  };
+}
+
+/** Construye el contexto de tools resolviendo la identidad configurada. */
+export async function buildToolContext(): Promise<ToolContext> {
+  return { actingUser: await resolveActingUser() };
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,0 +1,32 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { connectMongoose } from "@backend/db/mongoose";
+import { config } from "./config";
+import { assertStartupAuth } from "./auth";
+import { createServer } from "./server";
+
+/**
+ * Entrypoint del servidor MCP de TerraShare (#234). Transporte stdio para uso
+ * local con clientes MCP (Claude Desktop/Code, etc.). Conecta a la misma
+ * MongoDB del backend y expone las tools registradas.
+ *
+ * Importante: en stdio, stdout es el canal del protocolo — el logging va a
+ * stderr para no corromper los mensajes JSON-RPC.
+ */
+async function main(): Promise<void> {
+  assertStartupAuth();
+
+  await connectMongoose();
+  console.error(`[mcp-server] Conectado a MongoDB (${config.mongoUri.replace(/\/\/[^@]*@/, "//***@")})`);
+
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  console.error(`[mcp-server] ${config.serverName} v${config.serverVersion} listo (stdio)`);
+}
+
+main().catch((err) => {
+  console.error("[mcp-server] Error fatal:", err);
+  process.exit(1);
+});

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { connectMongoose } from "@backend/db/mongoose";
 import { config } from "./config";
 import { assertStartupAuth } from "./auth";
+import { buildToolContext } from "./context";
 import { createServer } from "./server";
 
 /**
@@ -19,7 +20,14 @@ async function main(): Promise<void> {
   await connectMongoose();
   console.error(`[mcp-server] Conectado a MongoDB (${config.mongoUri.replace(/\/\/[^@]*@/, "//***@")})`);
 
-  const server = createServer();
+  const ctx = await buildToolContext();
+  console.error(
+    ctx.actingUser
+      ? `[mcp-server] Actuando como ${ctx.actingUser.clerkUserId} (rol: ${ctx.actingUser.role})`
+      : "[mcp-server] Sin identidad (MCP_ACTING_USER_ID no configurado): solo tools públicas",
+  );
+
+  const server = createServer(ctx);
   const transport = new StdioServerTransport();
   await server.connect(transport);
 

--- a/apps/mcp-server/src/permissions.ts
+++ b/apps/mcp-server/src/permissions.ts
@@ -1,0 +1,22 @@
+/**
+ * Permisos para las tools (#234). Reexporta los helpers `can*` del backend para
+ * que las tools apliquen exactamente las mismas reglas que la API REST — sin
+ * duplicar lógica. Úsalos con `ctx.actingUser`.
+ *
+ * Ejemplo en una tool:
+ *   if (!canMutateLand(ctx.actingUser!, land)) throw new ToolError("No autorizado");
+ */
+export {
+  isAdmin,
+  isOwnerOrAdmin,
+  canMutateLand,
+  canReadRentalRequest,
+  canListRentalRequests,
+  canCreateRentalRequest,
+  canTransitionRentalRequest,
+  canCreateContract,
+  canReadContract,
+  canMutateContract,
+  canInitiatePayment,
+  canReadPayment,
+} from "@backend/lib/auth-helpers";

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createServer } from "./server";
+
+/**
+ * E2E de la fundación (#234): un cliente MCP real se conecta al servidor,
+ * lista las tools y llama a search_lands contra MongoDB (sembrada en el preload).
+ */
+async function connectedClient(): Promise<Client> {
+  const server = createServer();
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+describe("MCP server E2E (#234)", () => {
+  it("un cliente MCP lista las tools e incluye search_lands", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("search_lands");
+    await client.close();
+  });
+
+  it("llamar search_lands devuelve terrenos activos desde MongoDB", async () => {
+    const client = await connectedClient();
+    const res = await client.callTool({ name: "search_lands", arguments: { province: "Chiriqui" } });
+    const structured = res.structuredContent as { items: unknown[]; pagination: { totalItems: number } };
+    expect(structured.pagination.totalItems).toBe(2);
+    expect(structured.items.length).toBe(2);
+    await client.close();
+  });
+
+  it("search_lands valida la entrada (pageSize fuera de rango -> error)", async () => {
+    const client = await connectedClient();
+    const res = await client.callTool({ name: "search_lands", arguments: { pageSize: 9999 } });
+    // El SDK marca isError cuando la validación de entrada falla.
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+});

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -9,7 +9,7 @@ import { createServer } from "./server";
  * lista las tools y llama a search_lands contra MongoDB (sembrada en el preload).
  */
 async function connectedClient(): Promise<Client> {
-  const server = createServer();
+  const server = createServer({ actingUser: null });
   const client = new Client({ name: "test-client", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,14 +1,22 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { config } from "./config";
-import { registerSearchLands } from "./tools/search-lands";
+import type { ToolContext } from "./context";
+import { registerTool } from "./tools/define-tool";
+import { searchLandsTool } from "./tools/search-lands";
 
 /**
- * Crea el servidor MCP de TerraShare y registra las tools disponibles.
- * La fundación (#234) incluye la primera tool (search_lands, #180); las demás
- * (HU-64..HU-92) se registrarán aquí a medida que se implementen.
+ * Crea el servidor MCP de TerraShare y registra las tools disponibles (#234).
+ *
+ * Para añadir una tool (HU-64..HU-92): impórtala aquí y añádela al array `TOOLS`.
+ * Ver `src/tools/_template.ts` y el README para el patrón.
  */
-export function createServer(): McpServer {
+const TOOLS = [
+  searchLandsTool,
+  // HU-64..HU-92: añadir aquí cada nueva tool.
+];
+
+export function createServer(ctx: ToolContext): McpServer {
   const server = new McpServer(
     { name: config.serverName, version: config.serverVersion },
     {
@@ -18,7 +26,9 @@ export function createServer(): McpServer {
     },
   );
 
-  registerSearchLands(server);
+  for (const tool of TOOLS) {
+    registerTool(server, ctx, tool);
+  }
 
   return server;
 }

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,0 +1,24 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { config } from "./config";
+import { registerSearchLands } from "./tools/search-lands";
+
+/**
+ * Crea el servidor MCP de TerraShare y registra las tools disponibles.
+ * La fundación (#234) incluye la primera tool (search_lands, #180); las demás
+ * (HU-64..HU-92) se registrarán aquí a medida que se implementen.
+ */
+export function createServer(): McpServer {
+  const server = new McpServer(
+    { name: config.serverName, version: config.serverVersion },
+    {
+      instructions:
+        "Servidor MCP de TerraShare: expone el dominio de terrenos/alquileres. " +
+        "Usa search_lands para buscar publicaciones activas.",
+    },
+  );
+
+  registerSearchLands(server);
+
+  return server;
+}

--- a/apps/mcp-server/src/test-preload.ts
+++ b/apps/mcp-server/src/test-preload.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 import { connectMongoose, disconnectMongoose } from "@backend/db/mongoose";
-import { Land } from "@backend/db/schemas";
+import { Land, User } from "@backend/db/schemas";
 
 const now = new Date().toISOString();
 
@@ -34,6 +34,12 @@ export const SEED_LANDS = [
   land({ id: "land_inactive", title: "Terreno inactivo", status: "inactive", location: { province: "Panama", district: "Panama" } }),
 ];
 
+export const SEED_USERS = [
+  { clerkUserId: "user_admin", email: "admin@test.com", role: "admin", status: "active", profile: { fullName: "Admin de Prueba" } },
+  { clerkUserId: "user_regular", email: "user@test.com", role: "user", status: "active", profile: { fullName: "Usuario Regular" } },
+  { clerkUserId: "user_blocked", email: "blocked@test.com", role: "user", status: "blocked", profile: { fullName: "Usuario Bloqueado" } },
+];
+
 const mongod = await MongoMemoryServer.create();
 process.env.MONGODB_URI = `${mongod.getUri()}terrashare_mcp`;
 
@@ -42,6 +48,8 @@ await connectMongoose();
 async function seed(): Promise<void> {
   await Land.deleteMany({});
   await Land.insertMany(SEED_LANDS.map((l) => ({ ...l })));
+  await User.deleteMany({});
+  await User.insertMany(SEED_USERS.map((u) => ({ ...u })));
 }
 
 await seed();

--- a/apps/mcp-server/src/test-preload.ts
+++ b/apps/mcp-server/src/test-preload.ts
@@ -1,0 +1,53 @@
+// Test preload: MongoDB en memoria + siembra de terrenos para probar las tools
+// de forma aislada, sin depender de un backend en marcha. (#234)
+import { afterAll, beforeEach } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+import { connectMongoose, disconnectMongoose } from "@backend/db/mongoose";
+import { Land } from "@backend/db/schemas";
+
+const now = new Date().toISOString();
+
+function land(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: `land_${Math.random().toString(36).slice(2, 8)}`,
+    ownerId: "user_seed",
+    title: "Terreno de prueba",
+    description: "Descripción",
+    area: 10,
+    allowedUses: ["agricultura"],
+    location: { province: "Panama", district: "Panama" },
+    availability: {},
+    priceRule: { currency: "USD", pricePerMonth: 500 },
+    status: "active",
+    operation: "alquiler",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+export const SEED_LANDS = [
+  land({ id: "land_a", title: "Finca agrícola en Chiriquí", location: { province: "Chiriqui", district: "David" }, allowedUses: ["agricultura"], priceRule: { currency: "USD", pricePerMonth: 300 } }),
+  land({ id: "land_b", title: "Potrero ganadero", location: { province: "Chiriqui", district: "Boquete" }, allowedUses: ["ganaderia"], priceRule: { currency: "USD", pricePerMonth: 800 }, operation: "venta", salePrice: 90000 }),
+  land({ id: "land_c", title: "Parcela forestal", location: { province: "Cocle", district: "Penonome" }, allowedUses: ["forestal"], priceRule: { currency: "USD", pricePerMonth: 1200 } }),
+  land({ id: "land_inactive", title: "Terreno inactivo", status: "inactive", location: { province: "Panama", district: "Panama" } }),
+];
+
+const mongod = await MongoMemoryServer.create();
+process.env.MONGODB_URI = `${mongod.getUri()}terrashare_mcp`;
+
+await connectMongoose();
+
+async function seed(): Promise<void> {
+  await Land.deleteMany({});
+  await Land.insertMany(SEED_LANDS.map((l) => ({ ...l })));
+}
+
+await seed();
+beforeEach(seed);
+
+afterAll(async () => {
+  await disconnectMongoose();
+  await mongod.stop();
+});

--- a/apps/mcp-server/src/tools/_template.ts
+++ b/apps/mcp-server/src/tools/_template.ts
@@ -1,0 +1,62 @@
+/**
+ * PLANTILLA para implementar una tool MCP (HU-64..HU-92). #234
+ *
+ * Copia este archivo a `src/tools/<mi-tool>.ts`, renómbralo y ajústalo. Luego
+ * regístralo añadiéndolo al array `TOOLS` de `src/server.ts`.
+ *
+ * Este archivo NO se registra (empieza por `_`); es solo una guía. Compila, así
+ * que puedes usarlo como referencia viva.
+ *
+ * Checklist:
+ *  1. `inputSchema`: shape Zod con `.describe()` en cada campo (usa el zod local).
+ *  2. Función pura (opcional pero recomendado) para la lógica → fácil de testear.
+ *  3. Define `requires`: "public" | "user" | "admin".
+ *  4. En el handler usa `ctx.actingUser` y los helpers de `../permissions` para
+ *     los chequeos por recurso (p. ej. `canMutateLand`). Lanza `ToolError` para
+ *     errores de negocio (se devuelven como resultado legible, sin crash).
+ *  5. Escribe un test en `<mi-tool>.test.ts` (usa el preload de Mongo en memoria).
+ */
+
+import { z } from "zod";
+
+import { Land } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { canMutateLand } from "../permissions";
+
+// 1. Entrada
+export const exampleInput = {
+  landId: z.string().min(1).describe("ID del terreno"),
+  title: z.string().min(3).optional().describe("Nuevo título"),
+};
+
+// 2. Lógica (pura, testeable). Recibe también el usuario que actúa.
+async function exampleLogic(
+  args: { landId: string; title?: string },
+  actingUserId: string,
+): Promise<Record<string, unknown>> {
+  const land = await Land.findOne({ id: args.landId }).lean();
+  if (!land) throw new ToolError("Terreno no encontrado");
+  // ... aplicar cambios, devolver un objeto plano ...
+  return { id: args.landId, ok: true, by: actingUserId };
+}
+
+// 3 + 4. Definición de la tool
+export const exampleTool: ToolDefinition<typeof exampleInput> = {
+  name: "example_tool",
+  title: "Tool de ejemplo",
+  description: "Reemplaza esto por la descripción real de la tool.",
+  inputSchema: exampleInput,
+  requires: "user", // requiere identidad configurada (MCP_ACTING_USER_ID)
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!; // garantizado por `requires: "user"`
+    const land = await Land.findOne({ id: args.landId as string }).lean();
+    if (!land) throw new ToolError("Terreno no encontrado");
+
+    // Permiso por recurso reutilizando la misma regla que la API REST.
+    if (!canMutateLand(actingUser, land as unknown as { ownerId: string })) {
+      throw new ToolError("No autorizado para modificar este terreno");
+    }
+
+    return exampleLogic(args as { landId: string; title?: string }, actingUser.id);
+  },
+};

--- a/apps/mcp-server/src/tools/define-tool.test.ts
+++ b/apps/mcp-server/src/tools/define-tool.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { z } from "zod";
+
+import type { ActingUser, ToolContext } from "../context";
+import { registerTool, ToolError, type ToolAccess } from "./define-tool";
+
+function actingUser(overrides: Partial<ActingUser>): ActingUser {
+  return {
+    id: "u1",
+    clerkUserId: "u1",
+    email: "u1@test.com",
+    role: "user",
+    status: "active",
+    profile: { fullName: "U1" },
+    ...overrides,
+  };
+}
+
+/** Cliente conectado a un servidor con una única tool de prueba y el ctx dado. */
+async function clientWithTool(
+  ctx: ToolContext,
+  opts: { requires?: ToolAccess; throws?: boolean } = {},
+): Promise<Client> {
+  const server = new McpServer({ name: "t", version: "1.0.0" });
+  registerTool(server, ctx, {
+    name: "probe",
+    title: "Probe",
+    description: "test",
+    inputSchema: { echo: z.string().optional() },
+    requires: opts.requires,
+    handler: () => {
+      if (opts.throws) throw new ToolError("fallo de negocio");
+      return { ok: true };
+    },
+  });
+  const client = new Client({ name: "c", version: "1.0.0" });
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(st), client.connect(ct)]);
+  return client;
+}
+
+async function call(client: Client): Promise<{ isError: boolean; text: string }> {
+  const res = await client.callTool({ name: "probe", arguments: {} });
+  const content = res.content as { type: string; text: string }[];
+  return { isError: res.isError === true, text: content[0]?.text ?? "" };
+}
+
+describe("registerTool / defineTool (#234)", () => {
+  it("tool pública: accesible sin identidad", async () => {
+    const r = await call(await clientWithTool({ actingUser: null }, { requires: "public" }));
+    expect(r.isError).toBe(false);
+  });
+
+  it("tool 'user': denegada sin identidad", async () => {
+    const r = await call(await clientWithTool({ actingUser: null }, { requires: "user" }));
+    expect(r.isError).toBe(true);
+    expect(r.text).toContain("MCP_ACTING_USER_ID");
+  });
+
+  it("tool 'user': denegada si el usuario está bloqueado", async () => {
+    const ctx = { actingUser: actingUser({ status: "blocked" }) };
+    const r = await call(await clientWithTool(ctx, { requires: "user" }));
+    expect(r.isError).toBe(true);
+    expect(r.text).toContain("bloqueado");
+  });
+
+  it("tool 'admin': denegada para un usuario regular", async () => {
+    const ctx = { actingUser: actingUser({ role: "user" }) };
+    const r = await call(await clientWithTool(ctx, { requires: "admin" }));
+    expect(r.isError).toBe(true);
+    expect(r.text).toContain("administrador");
+  });
+
+  it("tool 'admin': permitida para un admin", async () => {
+    const ctx = { actingUser: actingUser({ role: "admin" }) };
+    const r = await call(await clientWithTool(ctx, { requires: "admin" }));
+    expect(r.isError).toBe(false);
+  });
+
+  it("un ToolError se devuelve como resultado de error, sin crash", async () => {
+    const r = await call(await clientWithTool({ actingUser: null }, { requires: "public", throws: true }));
+    expect(r.isError).toBe(true);
+    expect(r.text).toContain("fallo de negocio");
+  });
+});

--- a/apps/mcp-server/src/tools/define-tool.ts
+++ b/apps/mcp-server/src/tools/define-tool.ts
@@ -1,0 +1,101 @@
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ZodRawShape } from "zod";
+
+import type { ToolContext } from "../context";
+
+/**
+ * Andamiaje común para definir tools MCP (#234).
+ *
+ * Estandariza para todas las tools (y para quien las implemente):
+ * - Validación de entrada con Zod (la hace el SDK a partir de `inputSchema`).
+ * - Puerta de permisos declarativa (`requires`).
+ * - Manejo de errores uniforme → resultado MCP con `isError` (nunca crash).
+ * - Formato de salida consistente: texto JSON + `structuredContent`.
+ * - Logging estructurado a stderr (stdout es el canal del protocolo).
+ *
+ * Así, añadir una tool (HU-64..HU-92) se reduce a: input Zod + handler que
+ * consulta/muta Mongo usando `ctx.actingUser` y los helpers `can*`.
+ */
+
+/** Error de negocio en una tool → se devuelve como resultado de error legible. */
+export class ToolError extends Error {}
+
+export type ToolAccess = "public" | "user" | "admin";
+
+export interface ToolDefinition<Shape extends ZodRawShape> {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Shape;
+  /** Acceso requerido: `public` (por defecto), `user` (autenticado) o `admin`. */
+  requires?: ToolAccess;
+  /** Lógica de la tool. Recibe los args validados y el contexto (usuario que actúa). */
+  handler: (args: Record<string, unknown>, ctx: ToolContext) => Promise<unknown> | unknown;
+}
+
+type ToolResult = CallToolResult;
+
+function ok(data: unknown): ToolResult {
+  const isPlainObject = data !== null && typeof data === "object" && !Array.isArray(data);
+  return {
+    content: [{ type: "text", text: JSON.stringify(data ?? null, null, 2) }],
+    ...(isPlainObject ? { structuredContent: data as Record<string, unknown> } : {}),
+  };
+}
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+/** Comprueba el acceso declarado contra el usuario que actúa. Devuelve un mensaje si falla. */
+function checkAccess(requires: ToolAccess, ctx: ToolContext): string | null {
+  if (requires === "public") return null;
+  if (!ctx.actingUser) {
+    return "Esta tool requiere un usuario autenticado. Configura MCP_ACTING_USER_ID en el servidor.";
+  }
+  if (ctx.actingUser.status === "blocked") {
+    return "El usuario configurado está bloqueado.";
+  }
+  if (requires === "admin" && ctx.actingUser.role !== "admin") {
+    return "Esta tool requiere rol de administrador.";
+  }
+  return null;
+}
+
+/** Registra una tool en el servidor MCP aplicando el andamiaje común. */
+export function registerTool<Shape extends ZodRawShape>(
+  server: McpServer,
+  ctx: ToolContext,
+  def: ToolDefinition<Shape>,
+): void {
+  const requires = def.requires ?? "public";
+
+  // El SDK ya valida los args contra `inputSchema` antes de llamar al callback;
+  // aquí los tratamos como `Record<string, unknown>` (las tools los consumen con
+  // su propio tipado). El cast salva la varianza del genérico del SDK.
+  const callback = (async (args: Record<string, unknown>): Promise<ToolResult> => {
+    try {
+      const denied = checkAccess(requires, ctx);
+      if (denied) return fail(denied);
+
+      const data = await def.handler(args, ctx);
+      return ok(data);
+    } catch (err) {
+      const message = err instanceof ToolError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : "Error interno de la tool";
+      // stderr: stdout es el canal JSON-RPC del protocolo.
+      console.error(`[mcp-server] tool '${def.name}' error:`, err);
+      return fail(message);
+    }
+  }) as unknown as ToolCallback<Shape>;
+
+  server.registerTool(
+    def.name,
+    { title: def.title, description: def.description, inputSchema: def.inputSchema },
+    callback,
+  );
+}

--- a/apps/mcp-server/src/tools/search-lands.test.ts
+++ b/apps/mcp-server/src/tools/search-lands.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+
+import { searchLands } from "./search-lands";
+
+describe("search_lands tool (HU-63 #180)", () => {
+  it("devuelve solo terrenos activos (excluye inactivos)", async () => {
+    const res = await searchLands({});
+    expect(res.items.length).toBe(3);
+    expect(res.items.some((l) => (l as { id: string }).id === "land_inactive")).toBe(false);
+  });
+
+  it("filtra por provincia", async () => {
+    const res = await searchLands({ province: "Chiriqui" });
+    expect(res.items.length).toBe(2);
+    expect(res.items.every((l) => (l as { location: { province: string } }).location.province === "Chiriqui")).toBe(true);
+  });
+
+  it("filtra por uso permitido", async () => {
+    const res = await searchLands({ use: "forestal" });
+    expect(res.items.length).toBe(1);
+    expect((res.items[0] as { id: string }).id).toBe("land_c");
+  });
+
+  it("filtra por operación (venta)", async () => {
+    const res = await searchLands({ operation: "venta" });
+    expect(res.items.length).toBe(1);
+    expect((res.items[0] as { id: string }).id).toBe("land_b");
+  });
+
+  it("filtra por rango de precio mensual", async () => {
+    const res = await searchLands({ priceMin: 400, priceMax: 1000 });
+    expect(res.items.length).toBe(1);
+    expect((res.items[0] as { id: string }).id).toBe("land_b");
+  });
+
+  it("busca por texto en el título", async () => {
+    const res = await searchLands({ q: "forestal" });
+    expect(res.items.length).toBe(1);
+    expect((res.items[0] as { id: string }).id).toBe("land_c");
+  });
+
+  it("ordena por precio ascendente", async () => {
+    const res = await searchLands({ sort: "price", order: "asc" });
+    const prices = res.items.map((l) => (l as { priceRule: { pricePerMonth: number } }).priceRule.pricePerMonth);
+    expect(prices).toEqual([...prices].sort((a, b) => a - b));
+  });
+
+  it("pagina los resultados", async () => {
+    const res = await searchLands({ pageSize: 2, page: 1 });
+    expect(res.items.length).toBe(2);
+    expect(res.pagination.totalItems).toBe(3);
+    expect(res.pagination.totalPages).toBe(2);
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const res = await searchLands({});
+    expect(res.items.every((l) => !("_id" in l) && !("__v" in l))).toBe(true);
+  });
+});

--- a/apps/mcp-server/src/tools/search-lands.ts
+++ b/apps/mcp-server/src/tools/search-lands.ts
@@ -72,8 +72,8 @@ export async function searchLands(rawInput: unknown): Promise<SearchLandsResult>
     .limit(input.pageSize)
     .lean();
 
-  const items = docs.map((d) => {
-    const { _id, __v, ...rest } = d as unknown as Record<string, unknown>;
+  const items = (docs as unknown as Record<string, unknown>[]).map((d) => {
+    const { _id, __v, ...rest } = d;
     return rest;
   });
 

--- a/apps/mcp-server/src/tools/search-lands.ts
+++ b/apps/mcp-server/src/tools/search-lands.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { Land } from "@backend/db/schemas";
+
+/**
+ * Tool HU-63 (#180): Buscar terrenos. Espeja los filtros públicos de
+ * `GET /lands` del backend (solo publicaciones activas), resueltos en la BD.
+ */
+
+// Shape de entrada (ZodRawShape) para el registro en el SDK MCP.
+export const searchLandsInput = {
+  q: z.string().optional().describe("Búsqueda por texto en título/descripción"),
+  province: z.string().optional().describe("Filtrar por provincia"),
+  district: z.string().optional().describe("Filtrar por distrito"),
+  use: z
+    .enum(["agricultura", "ganaderia", "forestal", "acuicultura", "mixto", "otro"])
+    .optional()
+    .describe("Uso permitido"),
+  operation: z.enum(["alquiler", "venta", "ambas"]).optional().describe("Tipo de operación"),
+  priceMin: z.number().nonnegative().optional().describe("Precio mensual mínimo"),
+  priceMax: z.number().nonnegative().optional().describe("Precio mensual máximo"),
+  page: z.number().int().min(1).default(1),
+  pageSize: z.number().int().min(1).max(100).default(20),
+  sort: z.enum(["createdAt", "price", "area"]).default("createdAt"),
+  order: z.enum(["asc", "desc"]).default("desc"),
+};
+
+const SearchLandsSchema = z.object(searchLandsInput);
+export type SearchLandsInput = z.infer<typeof SearchLandsSchema>;
+
+export interface SearchLandsResult {
+  items: Record<string, unknown>[];
+  pagination: { page: number; pageSize: number; totalItems: number; totalPages: number };
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Función pura de búsqueda (testeable de forma aislada). Construye la query en
+ * Mongo, pagina y ordena — sin duplicar la capa HTTP.
+ */
+export async function searchLands(rawInput: unknown): Promise<SearchLandsResult> {
+  const input = SearchLandsSchema.parse(rawInput ?? {});
+
+  const query: Record<string, unknown> = { status: "active" };
+  if (input.province) query["location.province"] = input.province;
+  if (input.district) query["location.district"] = input.district;
+  if (input.use) query.allowedUses = input.use;
+  if (input.operation) query.operation = input.operation;
+  if (input.priceMin !== undefined || input.priceMax !== undefined) {
+    query["priceRule.pricePerMonth"] = {
+      ...(input.priceMin !== undefined ? { $gte: input.priceMin } : {}),
+      ...(input.priceMax !== undefined ? { $lte: input.priceMax } : {}),
+    };
+  }
+  if (input.q) {
+    const rx = new RegExp(escapeRegex(input.q), "i");
+    query.$or = [{ title: rx }, { description: rx }];
+  }
+
+  const sortField = input.sort === "price" ? "priceRule.pricePerMonth" : input.sort === "area" ? "area" : "createdAt";
+  const sortDir = input.order === "asc" ? 1 : -1;
+
+  const totalItems = await Land.countDocuments(query);
+  const totalPages = Math.max(1, Math.ceil(totalItems / input.pageSize));
+  const docs = await Land.find(query)
+    .sort({ [sortField]: sortDir })
+    .skip((input.page - 1) * input.pageSize)
+    .limit(input.pageSize)
+    .lean();
+
+  const items = docs.map((d) => {
+    const { _id, __v, ...rest } = d as unknown as Record<string, unknown>;
+    return rest;
+  });
+
+  return {
+    items,
+    pagination: { page: input.page, pageSize: input.pageSize, totalItems, totalPages },
+  };
+}
+
+/** Registra la tool en el servidor MCP. */
+export function registerSearchLands(server: McpServer): void {
+  server.registerTool(
+    "search_lands",
+    {
+      title: "Buscar terrenos",
+      description:
+        "Busca terrenos publicados (activos) con filtros por texto, ubicación, uso, operación y precio. Devuelve resultados paginados.",
+      inputSchema: searchLandsInput,
+    },
+    async (args) => {
+      const result = await searchLands(args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/search-lands.ts
+++ b/apps/mcp-server/src/tools/search-lands.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { Land } from "@backend/db/schemas";
+import type { ToolDefinition } from "./define-tool";
 
 /**
  * Tool HU-63 (#180): Buscar terrenos. Espeja los filtros públicos de
@@ -83,27 +83,16 @@ export async function searchLands(rawInput: unknown): Promise<SearchLandsResult>
   };
 }
 
-/** Registra la tool en el servidor MCP. */
-export function registerSearchLands(server: McpServer): void {
-  server.registerTool(
-    "search_lands",
-    {
-      title: "Buscar terrenos",
-      description:
-        "Busca terrenos publicados (activos) con filtros por texto, ubicación, uso, operación y precio. Devuelve resultados paginados.",
-      inputSchema: searchLandsInput,
-    },
-    async (args) => {
-      const result = await searchLands(args);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    },
-  );
-}
+/**
+ * Definición de la tool (referencia para las demás HU-64..HU-92). Es pública
+ * (no requiere identidad): busca solo publicaciones activas.
+ */
+export const searchLandsTool: ToolDefinition<typeof searchLandsInput> = {
+  name: "search_lands",
+  title: "Buscar terrenos",
+  description:
+    "Busca terrenos publicados (activos) con filtros por texto, ubicación, uso, operación y precio. Devuelve resultados paginados.",
+  inputSchema: searchLandsInput,
+  requires: "public",
+  handler: (args) => searchLands(args),
+};

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node", "bun"],
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@terrashare/shared": ["../../packages/shared/src/index.ts"],
+      "@backend/*": ["../backend-api/src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
+}


### PR DESCRIPTION
Closes #180 · Base del épico #234 (paraguas del `track:mcp`, permanece abierto para HU-64..HU-92).

Nueva app **`apps/mcp-server`** — servidor MCP propio (Bun + SDK oficial), **lista para repartir las 30 tools** entre el equipo.

## Fundación
- **Transporte stdio**; reutiliza la capa de datos del backend (`@backend/db/*`) y las reglas `can*` (`@backend/lib/auth-helpers`) vía alias de tsconfig — sin duplicar lógica.
- **Auth por API key** (`MCP_API_KEY`) para transporte remoto futuro.

## Base para desarrollar tools en paralelo
- **Identidad**: `MCP_ACTING_USER_ID` (clerkUserId) → usuario/rol resuelto desde Mongo, expuesto como `ctx.actingUser`.
- **Permisos declarativos**: cada tool declara `requires: public | user | admin`; el andamiaje aplica la puerta y reutiliza los `can*` por recurso.
- **Andamiaje `registerTool()`**: estandariza validación (Zod), manejo de errores (`ToolError` → `isError`, sin crash), formato de salida (JSON + `structuredContent`) y logging a stderr.
- **Plantilla `_template.ts`** + guía en el README ("Cómo construir una tool").

## Tool de referencia
- `search_lands` (HU-63 #180): filtros por texto/ubicación/uso/operación/precio, paginación, solo activos.

## Verificación
- **24 tests verdes** (tool 9 · auth 2 · contexto 4 · permisos 6 · **E2E con Client MCP real** 3) · typecheck limpio · CI job *MCP Server*.
- **Boot real**: con `MCP_ACTING_USER_ID` → "Actuando como … (rol: …)"; sin él → "solo tools públicas".

## Para el equipo
Cada tool (HU-64..HU-92) = copiar `_template.ts`, definir input Zod + `handler(args, ctx)` con `can*`, registrar en el array `TOOLS` de `server.ts`, y añadir su test. Independientes entre sí (conflicto leve solo en `server.ts`/README al registrar).