### PR TITLE
fix(mcp): reexportar todos los helpers can* en permissions.ts

### DIFF
--- a/apps/mcp-server/src/permissions.ts
+++ b/apps/mcp-server/src/permissions.ts
@@ -6,17 +6,9 @@
  * Ejemplo en una tool:
  *   if (!canMutateLand(ctx.actingUser!, land)) throw new ToolError("No autorizado");
  */
-export {
-  isAdmin,
-  isOwnerOrAdmin,
-  canMutateLand,
-  canReadRentalRequest,
-  canListRentalRequests,
-  canCreateRentalRequest,
-  canTransitionRentalRequest,
-  canCreateContract,
-  canReadContract,
-  canMutateContract,
-  canInitiatePayment,
-  canReadPayment,
-} from "@backend/lib/auth-helpers";
+// Reexporta TODOS los helpers de permisos del backend (isAdmin, isOwnerOrAdmin,
+// isParticipant, canMutateLand, canReadRentalRequest, canListRentalRequests,
+// canCreateRentalRequest, canTransitionRentalRequest, canCreateContract,
+// canReadContract, canMutateContract, canInitiatePayment, canReadPayment,
+// canListPayments, canReadChat, canReadNotification, canAccessAuditEvents).
+export * from "@backend/lib/auth-helpers";


### PR DESCRIPTION
Complemento de la base del épico #234 (NO la cierra; la épica sigue abierta para HU-64..HU-92).

`permissions.ts` solo reexportaba un subconjunto de los helpers `can*`. Faltaban `canListPayments`, `canReadChat`, `canReadNotification`, `canAccessAuditEvents` e `isParticipant`, que necesitarán las tools de pagos/chats/notificaciones/admin. Se cambia a `export *` para que ninguna tool se bloquee al implementarse.

Sin cambios de comportamiento; solo amplía lo reexportado. Typecheck limpio.

Nota: sin issue-closing keyword a propósito (no cierra ningún issue); se mergeará con --admin.