### PR TITLE
fix(web): enlaces legales del landing + quitar console.log de debug (#277)

### DIFF
--- a/apps/web/src/data/province-centers.ts
+++ b/apps/web/src/data/province-centers.ts
@@ -35,9 +35,7 @@ export function getLandPosition(
       const normalized = location.province.normalize("NFD").replace(/\p{Diacritic}/gu, "");
       coords = PROVINCE_CENTERS[normalized];
     }
-    console.log("[getLandPosition]", location.province, "->", coords);
     return coords || null;
   }
-  console.log("[getLandPosition] no location:", location);
   return null;
 }

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -321,8 +321,6 @@ export default function LandingPage() {
         </div>
         <div className="lp-foot__links">
           <Link to={catalogTo}>Catálogo</Link>
-          <a href="#">Términos</a>
-          <a href="#">Privacidad</a>
         </div>
         <div className="lp-foot__copy">© {new Date().getFullYear()} TerraShare · Hecho en Panamá</div>
       </footer>


### PR DESCRIPTION
Cierra #277 (parte del epic #134).

## Cambios
- **`LandingPage.tsx`**: se eliminan los enlaces placeholder `<a href="#">Términos</a>` y `<a href="#">Privacidad</a>` del footer. No existe contenido legal público real y `/dashboard/privacy` es un panel protegido de gestión de datos (GDPR), no una página legal; por eso se **removieron** (el criterio I-10 acepta "reales **o** removidos"). El footer conserva el enlace real a "Catálogo".
- **`data/province-centers.ts`**: se eliminan los 2 `console.log("[getLandPosition]"...)` de depuración (I-11).

## Verificación
- `npm run typecheck` ✅ limpio.
- Landing en dev: footer solo con "Catálogo", **cero** anclas `href="#"` en la página (verificado en navegador).
- Sin `console.log` de debug en `apps/web/src`.

Criterios de aceptación de #277 cumplidos.