### PR TITLE
feat(web): soporte de modo oscuro (I-8) (#278)

### DIFF
--- a/apps/web/src/clerkAppearance.ts
+++ b/apps/web/src/clerkAppearance.ts
@@ -1,5 +1,6 @@
 import type { ComponentProps } from "react";
 import type { ClerkProvider } from "@clerk/clerk-react";
+import type { ThemeChoice } from "./lib/theme";
 
 // El tipo `Appearance` no se expone como paquete resoluble aquí; lo derivamos
 // de la prop `appearance` de ClerkProvider para mantener el chequeo estricto.
@@ -11,7 +12,7 @@ type Appearance = NonNullable<ComponentProps<typeof ClerkProvider>["appearance"]
  * mantienen como literales porque `appearance` de Clerk no lee variables CSS
  * en tiempo de construcción. Si cambian los tokens, actualizar aquí también.
  */
-export const clerkAppearance: Appearance = {
+const lightAppearance: Appearance = {
   variables: {
     colorPrimary: "#2f5138", // --ts-green
     colorText: "#24312a", // --ts-text
@@ -47,3 +48,51 @@ export const clerkAppearance: Appearance = {
     },
   },
 };
+
+/** Variante oscura (#278): replica los tokens `--ts-*` del tema oscuro para que
+   el widget de Clerk acompañe al resto de la app. */
+const darkAppearance: Appearance = {
+  variables: {
+    colorPrimary: "#4f8a61", // --ts-green (oscuro)
+    colorText: "#ece4d3", // --ts-text (oscuro)
+    colorTextSecondary: "#b7c1b3", // --ts-text-secondary (oscuro)
+    colorBackground: "#1e2621", // --ts-surface (oscuro)
+    colorInputBackground: "#19201b", // --ts-surface-alt (oscuro)
+    colorInputText: "#ece4d3", // --ts-text (oscuro)
+    colorDanger: "#d07a54", // --ts-clay (oscuro)
+    borderRadius: "12px",
+    fontFamily: '"Hanken Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  },
+  elements: {
+    card: {
+      backgroundColor: "#1e2621",
+      border: "1px solid #33403a", // --ts-border (oscuro)
+      boxShadow: "0 8px 28px rgba(0, 0, 0, 0.5)",
+    },
+    headerTitle: {
+      fontFamily: '"Spectral", Georgia, serif',
+      fontWeight: 500,
+      letterSpacing: "-0.02em",
+    },
+    formButtonPrimary: {
+      backgroundColor: "#4f8a61",
+      color: "#0f140f",
+      fontWeight: 600,
+      textTransform: "none",
+      "&:hover": { backgroundColor: "#5f9c71" },
+      "&:focus": { boxShadow: "0 0 0 3px rgba(122, 170, 138, 0.42)" },
+    },
+    footerActionLink: {
+      color: "#8aa891", // --ts-green-soft (oscuro): legible sobre superficie oscura
+      "&:hover": { color: "#ece4d3" },
+    },
+  },
+};
+
+/** Apariencia de Clerk según el tema activo. */
+export function getClerkAppearance(theme: ThemeChoice): Appearance {
+  return theme === "dark" ? darkAppearance : lightAppearance;
+}
+
+/** Compatibilidad: apariencia clara por defecto. */
+export const clerkAppearance = lightAppearance;

--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useClerk } from "@clerk/clerk-react";
 import { LayoutDashboard, Flag, Map, Users, Mail, LogOut, Sprout, ScrollText, Activity, Scale, CreditCard } from "lucide-react";
+import ThemeToggle from "./ThemeToggle";
 import "../pages/admin.css";
 
 interface AdminLayoutProps {
@@ -56,6 +57,7 @@ export default function AdminLayout({ children, onSignOut }: AdminLayoutProps) {
         </nav>
 
         <div className="adm-side__foot">
+          <ThemeToggle className="adm-side__theme" />
           <button type="button" className="adm-side__signout" onClick={handleSignOut}>
             <LogOut size={17} /> Cerrar sesión
           </button>

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import { Navbar } from "./ui";
 import type { BuscoOfrezcoMode } from "./ui";
+import ThemeToggle from "./ThemeToggle";
 import { getDisplayName, isAdminUser } from "./authDisplay";
 import type { UserMenuItem } from "./ui";
 import "../pages/app-shell.css";
@@ -85,6 +86,7 @@ export default function AppLayout({ children }: { children?: ReactNode }) {
 
   const actions = (
     <>
+      <ThemeToggle className="ds-navbar__icon" />
       <Link to="/dashboard/notifications" className="ds-navbar__icon" aria-label="Notificaciones">
         <BellIcon />
       </Link>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,30 @@
+import { Moon, Sun } from "lucide-react";
+import { setTheme, type ThemeChoice } from "../lib/theme";
+import { useTheme } from "../hooks/useTheme";
+
+/** Botón accesible para alternar tema claro/oscuro (#278).
+   Arranca con la preferencia efectiva (guardada o del sistema) y persiste la
+   elección explícita del usuario en localStorage. */
+export default function ThemeToggle({ className }: { className?: string }) {
+  const theme = useTheme();
+  const isDark = theme === "dark";
+
+  const toggle = () => {
+    const next: ThemeChoice = isDark ? "light" : "dark";
+    setTheme(next); // emite THEME_EVENT → useTheme actualiza el estado
+  };
+
+  const label = isDark ? "Cambiar a modo claro" : "Cambiar a modo oscuro";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className={className ? `ts-theme-toggle ${className}` : "ts-theme-toggle"}
+      aria-label={label}
+      title={label}
+    >
+      {isDark ? <Sun size={18} strokeWidth={1.9} aria-hidden="true" /> : <Moon size={18} strokeWidth={1.9} aria-hidden="true" />}
+    </button>
+  );
+}

--- a/apps/web/src/components/empty-state.css
+++ b/apps/web/src/components/empty-state.css
@@ -28,7 +28,7 @@
   font-family: var(--ts-font-serif);
   font-size: 22px;
   font-weight: 600;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .es--compact .es__title { font-size: 18px; }
 
@@ -44,7 +44,7 @@
 .es__cta {
   display: inline-block;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   font-size: 14.5px;
   padding: 12px 22px;

--- a/apps/web/src/components/ui/ui.css
+++ b/apps/web/src/components/ui/ui.css
@@ -462,7 +462,7 @@
 
 .ds-sidebar__item.is-active {
   background: var(--ts-surface);
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   font-weight: 600;
 }
 

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { getInitialTheme, THEME_EVENT, type ThemeChoice } from "../lib/theme";
+
+/** Tema actual reactivo (#278). Arranca en "light" en SSR y se sincroniza en el
+   cliente con la preferencia efectiva; se actualiza cuando `setTheme` emite el
+   evento de cambio. */
+export function useTheme(): ThemeChoice {
+  const [theme, setThemeState] = useState<ThemeChoice>("light");
+
+  useEffect(() => {
+    setThemeState(getInitialTheme());
+    const onChange = (e: Event) => {
+      const detail = (e as CustomEvent<ThemeChoice>).detail;
+      if (detail === "light" || detail === "dark") setThemeState(detail);
+    };
+    window.addEventListener(THEME_EVENT, onChange);
+    return () => window.removeEventListener(THEME_EVENT, onChange);
+  }, []);
+
+  return theme;
+}

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,47 @@
+/* Control del tema claro/oscuro (#278).
+   El atributo `data-theme` en <html> decide el tema (ver src/styles/tokens.css).
+   La preferencia explícita se guarda en localStorage; si no hay ninguna se
+   respeta la del sistema operativo. El script anti-flash en __root.tsx aplica
+   esta misma lógica antes del primer pintado. */
+
+export type ThemeChoice = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "ts-theme";
+
+/** Evento en `window` que emite el nuevo tema cuando el usuario lo cambia.
+   Permite que superficies que no leen CSS (p. ej. el widget de Clerk) reaccionen
+   en vivo al toggle. */
+export const THEME_EVENT = "ts-themechange";
+
+export function systemPrefersDark(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
+/** Preferencia efectiva: la guardada, o la del sistema si no hay elección. */
+export function getInitialTheme(): ThemeChoice {
+  if (typeof localStorage !== "undefined") {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  }
+  return systemPrefersDark() ? "dark" : "light";
+}
+
+export function applyTheme(theme: ThemeChoice): void {
+  if (typeof document !== "undefined") {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+}
+
+export function setTheme(theme: ThemeChoice): void {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }
+  applyTheme(theme);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent<ThemeChoice>(THEME_EVENT, { detail: theme }));
+  }
+}

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { listLands } from "../services/api";
 import { isAdminUser } from "../components/authDisplay";
+import ThemeToggle from "../components/ThemeToggle";
 import "./landing.css";
 
 // ─── Contenido estático (fiel al prototipo) ───────────────────────────────────
@@ -163,6 +164,7 @@ export default function LandingPage() {
               Iniciar sesión
             </Link>
           )}
+          <ThemeToggle className="lp-nav__theme" />
           <Link to={publishTo} className="lp-nav__cta">
             Publicar terreno
           </Link>

--- a/apps/web/src/pages/admin.css
+++ b/apps/web/src/pages/admin.css
@@ -4,7 +4,7 @@
 .adm {
   min-height: 100vh;
   background: var(--ts-bg);
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   display: grid;
   grid-template-columns: 236px 1fr;
   font-family: var(--ts-font-sans);
@@ -35,7 +35,7 @@
   align-items: center;
   gap: 10px;
   padding: 4px 10px 22px;
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   text-decoration: none;
 }
 .adm-side__brand-name { font-family: var(--ts-font-serif); font-weight: 600; font-size: 20px; }
@@ -51,8 +51,8 @@
   font-weight: 500;
   transition: background 0.15s ease, color 0.15s ease;
 }
-.adm-side__link:hover { background: rgba(244, 239, 228, 0.07); color: var(--ts-bg); }
-.adm-side__link.is-active { background: rgba(244, 239, 228, 0.12); color: var(--ts-bg); font-weight: 600; }
+.adm-side__link:hover { background: rgba(244, 239, 228, 0.07); color: var(--ts-on-ink); }
+.adm-side__link.is-active { background: rgba(244, 239, 228, 0.12); color: var(--ts-on-ink); font-weight: 600; }
 .adm-side__badge {
   margin-left: auto;
   background: var(--ts-clay);
@@ -77,7 +77,7 @@
   font-family: var(--ts-font-sans);
   border-radius: 10px;
 }
-.adm-side__signout:hover { color: var(--ts-bg); background: rgba(244, 239, 228, 0.07); }
+.adm-side__signout:hover { color: var(--ts-on-ink); background: rgba(244, 239, 228, 0.07); }
 
 /* ── contenido ───────────────────────────────────────────────────────────── */
 .adm-main { padding: 36px 44px; min-width: 0; }
@@ -87,7 +87,7 @@
   font-size: 34px;
   letter-spacing: -0.02em;
   margin: 0 0 4px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   animation: admUp 0.6s ease both;
 }
 .adm-sub { color: var(--ts-sage-2); font-size: 15px; margin: 0 0 24px; animation: admUp 0.6s ease both 0.04s; }
@@ -100,7 +100,7 @@
   border-radius: 16px;
   padding: 20px;
 }
-.adm-stat--dark { background: var(--ts-green-ink); border-color: var(--ts-green-ink); color: var(--ts-bg); }
+.adm-stat--dark { background: var(--ts-green-ink); border-color: var(--ts-green-ink); color: var(--ts-on-ink); }
 .adm-stat__value { font-family: var(--ts-font-serif); font-weight: 600; font-size: 30px; }
 .adm-stat--dark .adm-stat__value { color: #e7c37a; }
 .adm-stat__label { font-size: 12.5px; color: var(--ts-sage); margin-top: 3px; }
@@ -120,13 +120,13 @@
 .adm-bars { display: grid; gap: 14px; }
 .adm-bar__head { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 5px; }
 .adm-bar__head span:last-child { color: var(--ts-sage); }
-.adm-bar__track { height: 8px; background: #f2ecdf; border-radius: 6px; overflow: hidden; }
+.adm-bar__track { height: 8px; background: var(--ts-paper-tint); border-radius: 6px; overflow: hidden; }
 .adm-bar__fill { height: 100%; border-radius: 6px; transition: width 0.6s cubic-bezier(0.2, 0.7, 0.3, 1); }
 .adm-bar__fill--green { background: var(--ts-green); }
 .adm-bar__fill--amber { background: #c58a2e; }
 .adm-bar__fill--clay { background: #a5573a; }
 .adm-panel__foot { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--ts-beige); font-size: 13px; color: var(--ts-sage-2); }
-.adm-panel__foot-value { font-family: var(--ts-font-serif); font-size: 22px; font-weight: 600; color: var(--ts-green-ink); }
+.adm-panel__foot-value { font-family: var(--ts-font-serif); font-size: 22px; font-weight: 600; color: var(--ts-text); }
 
 /* ── barra de búsqueda + filtros ─────────────────────────────────────────── */
 .adm-toolbar { display: flex; gap: 10px; margin-bottom: 16px; animation: admUp 0.6s ease both 0.08s; flex-wrap: wrap; }
@@ -147,7 +147,7 @@
   border: 0;
   background: transparent;
   font-size: 14px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   font-family: var(--ts-font-sans);
   outline: none;
 }
@@ -176,7 +176,7 @@
   cursor: pointer;
   outline: none;
 }
-.adm-pill--cta { color: var(--ts-bg); background: var(--ts-green); border-color: var(--ts-green); }
+.adm-pill--cta { color: var(--ts-on-ink); background: var(--ts-green); border-color: var(--ts-green); }
 .adm-pill--cta:hover { background: var(--ts-green-ink); }
 
 /* ── tabla ───────────────────────────────────────────────────────────────── */
@@ -243,7 +243,7 @@
   background: transparent;
   font-family: var(--ts-font-sans);
 }
-.adm-act:hover { background: #f1ebdd; }
+.adm-act:hover { background: var(--ts-paper-tint); }
 .adm-act--danger { color: #9a3b2c; border-color: #d99a8c; }
 .adm-act--danger:hover { background: #f7e7e4; }
 
@@ -267,7 +267,7 @@
   font: inherit;
   color: var(--ts-text-secondary);
 }
-.adm-pager button:hover:not(:disabled) { background: #f1ebdd; }
+.adm-pager button:hover:not(:disabled) { background: var(--ts-paper-tint); }
 .adm-pager button:disabled { opacity: 0.5; cursor: default; }
 
 .adm-empty { padding: 40px 20px; text-align: center; color: var(--ts-sage-2); font-size: 14px; }
@@ -326,7 +326,7 @@
   color: var(--ts-text);
 }
 .adm-rep__actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
-.adm-rep__cta { color: var(--ts-bg); background: var(--ts-green); border-color: var(--ts-green); }
+.adm-rep__cta { color: var(--ts-on-ink); background: var(--ts-green); border-color: var(--ts-green); }
 .adm-rep__cta:hover:not(:disabled) { background: var(--ts-green-ink); }
 .adm-rep__resolved { margin-top: 14px; font-size: 13px; color: var(--ts-sage); }
 

--- a/apps/web/src/pages/auth.css
+++ b/apps/web/src/pages/auth.css
@@ -31,7 +31,7 @@
   align-items: center;
   gap: 0.55rem;
   text-decoration: none;
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-family: var(--ts-font-serif);
   font-size: 1.6rem;
   font-weight: 600;
@@ -45,7 +45,7 @@
 
 .au-intro h1 {
   margin: 0 0 0.35rem;
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
 }
 
 .au-intro p {

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -1,7 +1,7 @@
 /* TerraShare — Catálogo (paridad con el prototipo · pantalla 04).
    Barra de filtros + lista de tarjetas horizontales + mapa sticky. Prefijo `cat-`. */
 
-.cat { font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.cat { font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 /* ── barra de filtros ────────────────────────────────────────────────────── */
 .cat-filters {
@@ -30,7 +30,7 @@
   border: 0;
   background: transparent;
   font-size: 14.5px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   font-family: var(--ts-font-sans);
   outline: none;
 }
@@ -88,7 +88,7 @@
   min-width: 0;
 }
 .cat-listhead { font-size: 13.5px; color: var(--ts-sage); margin-bottom: 18px; }
-.cat-listhead strong { color: var(--ts-green-ink); font-weight: 600; }
+.cat-listhead strong { color: var(--ts-text); font-weight: 600; }
 .cat-list { display: grid; gap: 16px; }
 
 .cat-card {
@@ -154,7 +154,7 @@
   white-space: nowrap;
   flex: 0 0 auto;
 }
-.cat-card__badge--sale { color: var(--ts-bg); background: var(--ts-green-ink); }
+.cat-card__badge--sale { color: var(--ts-on-ink); background: var(--ts-green-ink); }
 .cat-card__meta {
   font-size: 13px;
   color: var(--ts-sage);
@@ -207,7 +207,7 @@
 .cat-mapcard__go {
   font-size: 13px;
   font-weight: 600;
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   background: var(--ts-green);
   padding: 9px 16px;
   border-radius: 9px;

--- a/apps/web/src/pages/chats.css
+++ b/apps/web/src/pages/chats.css
@@ -1,6 +1,6 @@
 /* TerraShare — Chats / bandeja de mensajes (prototipo · pantalla 15). Prefijo `ch-`. */
 
-.ch { max-width: 1040px; margin: 0 auto; padding: 40px 40px 60px; font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.ch { max-width: 1040px; margin: 0 auto; padding: 40px 40px 60px; font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 @keyframes chUp {
   from { opacity: 0; transform: translateY(14px); }
@@ -35,8 +35,8 @@
   font-family: var(--ts-font-sans);
   transition: background 0.2s ease;
 }
-.ch-conv:hover { background: #f7f1e5; }
-.ch-conv.is-active { background: #f2ecdf; border-left-color: var(--ts-green); }
+.ch-conv:hover { background: var(--ts-paper-tint); }
+.ch-conv.is-active { background: var(--ts-paper-tint); border-left-color: var(--ts-green); }
 .ch-conv__avatar {
   width: 38px;
   height: 38px;
@@ -122,7 +122,7 @@
 }
 .ch-msg--mine .ch-msg__avatar { background: var(--ts-green); color: #fff; }
 .ch-msg__bubble {
-  background: #f2ecdf;
+  background: var(--ts-paper-tint);
   border-radius: 12px;
   padding: 10px 14px;
   font-size: 14px;
@@ -130,7 +130,7 @@
   line-height: 1.45;
   word-break: break-word;
 }
-.ch-msg--mine .ch-msg__bubble { background: var(--ts-tint-green); color: var(--ts-green-ink); }
+.ch-msg--mine .ch-msg__bubble { background: var(--ts-tint-green); color: var(--ts-text); }
 
 .ch-composer { display: flex; gap: 10px; padding: 16px 20px; border-top: 1px solid var(--ts-beige); }
 .ch-composer input {
@@ -140,7 +140,7 @@
   border-radius: 11px;
   padding: 11px 14px;
   font-size: 14px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   font-family: var(--ts-font-sans);
   outline: none;
 }

--- a/apps/web/src/pages/checkout.css
+++ b/apps/web/src/pages/checkout.css
@@ -7,7 +7,7 @@
   align-items: center;
   justify-content: center;
   font-family: var(--ts-font-sans);
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   padding: 40px;
 }
 
@@ -58,7 +58,7 @@
   margin: 0 0 24px;
   animation: coUp 0.6s ease both 0.12s;
 }
-.co-text b { color: var(--ts-green-ink); font-weight: 700; }
+.co-text b { color: var(--ts-text); font-weight: 700; }
 
 .co-details {
   background: var(--ts-paper-tint);
@@ -82,10 +82,10 @@
   text-decoration: none;
   transition: transform 0.2s ease, background 0.2s ease;
 }
-.co-btn--primary { background: var(--ts-green); color: var(--ts-bg); }
+.co-btn--primary { background: var(--ts-green); color: var(--ts-on-ink); }
 .co-btn--primary:hover { transform: translateY(-2px); background: var(--ts-green-ink); }
 .co-btn--ghost { color: var(--ts-text-secondary); border: 1px solid #d8cfb8; }
-.co-btn--ghost:hover { background: #f1ebdd; }
+.co-btn--ghost:hover { background: var(--ts-paper-tint); }
 
 .co-secure {
   font-size: 11.5px;

--- a/apps/web/src/pages/deal.css
+++ b/apps/web/src/pages/deal.css
@@ -1,6 +1,6 @@
 /* TerraShare — Trato / pago (paridad con el prototipo · pantalla 07). Prefijo `dl-`. */
 
-.dl { min-height: 100vh; background: var(--ts-bg); font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.dl { min-height: 100vh; background: var(--ts-bg); font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 @keyframes dlUp {
   from { opacity: 0; transform: translateY(14px); }
@@ -27,7 +27,7 @@
   font-size: 14px;
   text-decoration: none;
 }
-.dl-nav__back:hover { color: var(--ts-green-ink); }
+.dl-nav__back:hover { color: var(--ts-text); }
 .dl-nav__right { margin-left: auto; display: flex; align-items: center; gap: 14px; }
 .dl-nav__id { font-size: 13px; color: var(--ts-sage); }
 .dl-nav__brand-mark { color: var(--ts-green); display: inline-flex; }
@@ -75,7 +75,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #f2ecdf;
+  background: var(--ts-paper-tint);
   color: var(--ts-sage-3);
 }
 .dl-step__dot--done { background: var(--ts-green); color: #fff; }
@@ -114,11 +114,11 @@
   font-size: 14px;
   text-decoration: none;
 }
-.dl-chat-link:hover { color: var(--ts-green-ink); }
+.dl-chat-link:hover { color: var(--ts-text); }
 
 /* panel de pago sticky */
 .dl-pay { position: sticky; top: 100px; animation: dlUp 0.6s cubic-bezier(0.2, 0.7, 0.3, 1) both 0.12s; }
-.dl-pay__card { background: var(--ts-green-ink); color: var(--ts-bg); border-radius: 18px; padding: 24px; }
+.dl-pay__card { background: var(--ts-green-ink); color: var(--ts-on-ink); border-radius: 18px; padding: 24px; }
 .dl-pay__k { font-size: 13px; opacity: 0.7; }
 .dl-pay__amount { font-family: var(--ts-font-serif); font-weight: 600; font-size: 36px; margin: 2px 0; }
 .dl-pay__sub { font-size: 12.5px; opacity: 0.6; margin-bottom: 18px; }
@@ -190,7 +190,7 @@
   display: inline-block;
   margin-top: 16px;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   padding: 12px 22px;
   border-radius: 11px;

--- a/apps/web/src/pages/detail.css
+++ b/apps/web/src/pages/detail.css
@@ -1,7 +1,7 @@
 /* TerraShare — Detalle de terreno (paridad con el prototipo · pantalla 05).
    Página pública/compartible; las acciones exigen login. Prefijo `det-`. */
 
-.det { width: 100%; font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.det { width: 100%; font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 /* ── nav propio del detalle ──────────────────────────────────────────────── */
 .det-nav {
@@ -24,7 +24,7 @@
   font-size: 14px;
   text-decoration: none;
 }
-.det-nav__back:hover { color: var(--ts-green-ink); }
+.det-nav__back:hover { color: var(--ts-text); }
 .det-nav__brand { display: flex; align-items: center; gap: 11px; }
 .det-nav__brand-mark { color: var(--ts-green); display: inline-flex; }
 .det-nav__brand-name { font-family: var(--ts-font-serif); font-weight: 600; font-size: 20px; color: var(--ts-green); }
@@ -83,12 +83,12 @@
   padding: 5px 12px;
   border-radius: 999px;
 }
-.det-badge--sale { color: var(--ts-bg); background: var(--ts-green-ink); }
+.det-badge--sale { color: var(--ts-on-ink); background: var(--ts-green-ink); }
 .det-badge--verified {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   background: var(--ts-tint-green);
 }
 .det-flag {
@@ -105,7 +105,7 @@
   font-size: 44px;
   letter-spacing: -0.02em;
   margin: 0 0 8px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .det-loc {
   font-size: 15px;
@@ -125,14 +125,14 @@
 }
 .det-spec__icon { color: var(--ts-clay); }
 .det-spec__label { font-size: 12.5px; color: var(--ts-sage); margin: 8px 0 2px; }
-.det-spec__value { font-family: var(--ts-font-serif); font-weight: 600; font-size: 18px; color: var(--ts-green-ink); }
+.det-spec__value { font-family: var(--ts-font-serif); font-weight: 600; font-size: 18px; color: var(--ts-text); }
 
 .det-section-title {
   font-family: var(--ts-font-serif);
   font-weight: 500;
   font-size: 26px;
   margin: 0 0 12px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .det-desc { font-size: 16px; line-height: 1.7; color: #5b6b5b; margin: 0 0 16px; }
 
@@ -140,7 +140,7 @@
 .det-tag {
   font-size: 13px;
   color: #3d4d3d;
-  background: #f2ecdf;
+  background: var(--ts-paper-tint);
   border: 1px solid var(--ts-border);
   border-radius: 999px;
   padding: 7px 14px;
@@ -179,7 +179,7 @@
 }
 .det-btn--primary {
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-size: 16px;
   padding: 15px;
   border: 0;
@@ -232,7 +232,7 @@
   padding: 10px 12px;
 }
 .det-note--verified {
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   background: var(--ts-tint-green);
   font-weight: 600;
 }

--- a/apps/web/src/pages/home.css
+++ b/apps/web/src/pages/home.css
@@ -6,7 +6,7 @@
   margin: 0 auto;
   padding: 44px 40px 70px;
   font-family: var(--ts-font-sans);
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 
 @keyframes hmUp {
@@ -29,7 +29,7 @@
   font-size: 40px;
   letter-spacing: -0.02em;
   margin: 0;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .hm-head__sub {
   font-size: 16px;
@@ -41,7 +41,7 @@
   align-items: center;
   gap: 9px;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   font-size: 15px;
   padding: 13px 22px;
@@ -75,7 +75,7 @@
 .hm-chip {
   font-size: 13px;
   color: var(--ts-text-secondary);
-  background: #f2ecdf;
+  background: var(--ts-paper-tint);
   border: 1px solid var(--ts-border);
   border-radius: 999px;
   padding: 7px 14px;
@@ -102,7 +102,7 @@
   font-weight: 500;
   font-size: 26px;
   margin: 0;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .hm-link {
   font-size: 14px;
@@ -110,7 +110,7 @@
   font-weight: 600;
   text-decoration: none;
 }
-.hm-link:hover { color: var(--ts-green-ink); }
+.hm-link:hover { color: var(--ts-text); }
 
 .hm-grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
 
@@ -195,7 +195,7 @@
   padding: 4px 9px;
   border-radius: 999px;
 }
-.hm-saved__badge--sale { color: var(--ts-bg); background: var(--ts-green-ink); }
+.hm-saved__badge--sale { color: var(--ts-on-ink); background: var(--ts-green-ink); }
 .hm-saved__heart { position: absolute; top: 10px; right: 10px; color: var(--ts-clay); }
 .hm-saved__body { padding: 14px 16px; }
 .hm-saved__title { font-family: var(--ts-font-serif); font-weight: 600; font-size: 17px; }
@@ -221,7 +221,7 @@
   transition: background 0.2s ease;
 }
 .hm-chatrow:last-child { border-bottom: 0; }
-.hm-chatrow:hover { background: #f7f1e5; }
+.hm-chatrow:hover { background: var(--ts-paper-tint); }
 .hm-avatar {
   width: 38px;
   height: 38px;
@@ -264,7 +264,7 @@
   transition: background 0.2s ease;
 }
 .hm-favcard:last-child { border-bottom: 0; }
-.hm-favcard:hover { background: #f7f1e5; }
+.hm-favcard:hover { background: var(--ts-paper-tint); }
 .hm-favcard__thumb {
   width: 38px;
   height: 38px;
@@ -296,7 +296,7 @@
   border-radius: 16px;
   padding: 22px;
 }
-.hm-stat--dark { background: var(--ts-green-ink); border-color: var(--ts-green-ink); color: var(--ts-bg); }
+.hm-stat--dark { background: var(--ts-green-ink); border-color: var(--ts-green-ink); color: var(--ts-on-ink); }
 .hm-stat__icon { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; color: var(--ts-green); }
 .hm-stat__icon--clay { color: var(--ts-clay); }
 .hm-stat__icon--light { color: var(--ts-tint-green-3); }
@@ -352,7 +352,7 @@
 .hm-received__reject:hover { border-color: #a5573a; color: #a5573a; }
 .hm-received__approve {
   font-size: 13.5px;
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   background: var(--ts-green);
   font-weight: 600;
   text-decoration: none;
@@ -398,7 +398,7 @@
 .hm-pub__add {
   text-decoration: none;
   color: var(--ts-sage);
-  background: #faf5ea;
+  background: var(--ts-surface-alt);
   border: 1.5px dashed #d8cfb8;
   border-radius: 16px;
   display: flex;
@@ -409,7 +409,7 @@
   min-height: 210px;
   transition: background 0.2s ease, color 0.2s ease;
 }
-.hm-pub__add:hover { background: #f2ecdf; color: var(--ts-green); }
+.hm-pub__add:hover { background: var(--ts-paper-tint); color: var(--ts-green); }
 .hm-pub__add span { font-size: 14px; font-weight: 600; }
 
 /* ── placeholder de foto ─────────────────────────────────────────────────── */

--- a/apps/web/src/pages/landing.css
+++ b/apps/web/src/pages/landing.css
@@ -5,7 +5,7 @@
 .lp {
   width: 100%;
   overflow-x: hidden;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   background: var(--ts-bg);
   font-family: var(--ts-font-serif);
 }
@@ -75,11 +75,11 @@
   text-decoration: none;
   font-weight: 500;
 }
-.lp-nav__link:hover { color: var(--ts-green-ink); }
+.lp-nav__link:hover { color: var(--ts-text); }
 .lp-nav__link--accent { color: var(--ts-green); font-weight: 600; }
 .lp-nav__cta {
   font-size: 15px;
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   background: var(--ts-green);
   text-decoration: none;
   font-weight: 600;
@@ -114,7 +114,7 @@
   line-height: 1.02;
   letter-spacing: -0.025em;
   margin: 22px 0 26px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .lp-hero__title em {
   font-style: italic;
@@ -150,7 +150,7 @@
 }
 .lp-btn--primary {
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   padding: 16px 28px;
 }
 .lp-btn--primary:hover { transform: translateY(-2px); background: var(--ts-green-ink); }
@@ -160,7 +160,7 @@
   border: 1px solid #d8cfb8;
   background: transparent;
 }
-.lp-btn--ghost:hover { background: #f1ebdd; }
+.lp-btn--ghost:hover { background: var(--ts-paper-tint); }
 .lp-btn--clay {
   background: var(--ts-clay);
   color: #fff;
@@ -226,12 +226,12 @@
   justify-content: center;
 }
 .lp-chip--water__k { font-size: 12px; color: var(--ts-sage); }
-.lp-chip--water__v { font-weight: 700; color: var(--ts-green-ink); font-size: 15px; }
+.lp-chip--water__v { font-weight: 700; color: var(--ts-text); font-size: 15px; }
 .lp-chip--price {
   right: -26px;
   top: 42px;
   background: var(--ts-green-ink);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   border-radius: 16px;
   padding: 15px 20px;
   box-shadow: 0 26px 46px -24px rgba(36, 49, 42, 0.5);
@@ -247,7 +247,7 @@
   grid-template-columns: repeat(4, 1fr);
   border-top: 1px solid var(--ts-border);
   border-bottom: 1px solid var(--ts-border);
-  background: #f2ecdf;
+  background: var(--ts-paper-tint);
 }
 .lp-band__cell {
   padding: 32px;
@@ -281,7 +281,7 @@
   font-size: 42px;
   letter-spacing: -0.02em;
   margin: 10px 0 0;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .lp-seeall {
   color: var(--ts-green);
@@ -340,7 +340,7 @@
   font-weight: 600;
   font-size: 23px;
   margin: 0 0 4px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .lp-card__loc {
   font-family: var(--ts-font-sans);
@@ -364,13 +364,13 @@
   font-weight: 600;
   color: var(--ts-clay);
 }
-.lp-card__price span { font-size: 13px; color: #8f5f4b; font-family: var(--ts-font-sans); }
+.lp-card__price span { font-size: 13px; color: var(--ts-clay); font-family: var(--ts-font-sans); }
 .lp-card__go {
   width: 36px;
   height: 36px;
   border-radius: 10px;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -385,7 +385,7 @@
   font-size: 42px;
   letter-spacing: -0.02em;
   margin: 0 0 44px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .lp-how__grid {
   display: grid;
@@ -420,7 +420,7 @@
   grid-template-columns: 1.3fr 0.7fr;
   gap: 52px;
   align-items: center;
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
 }
 .lp-cta__quote-icon { opacity: 0.45; }
 .lp-cta__quote {
@@ -439,7 +439,7 @@
   align-items: center;
   justify-content: center;
   background: rgba(244, 239, 228, 0.12);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
 }
 .lp-cta__author-name { font-family: var(--ts-font-sans); font-weight: 700; font-size: 15px; }
 .lp-cta__author-role { font-family: var(--ts-font-sans); font-size: 13px; opacity: 0.65; }
@@ -474,8 +474,8 @@
 .lp-foot__brand-name { font-family: var(--ts-font-serif); font-weight: 600; font-size: 18px; color: var(--ts-green); }
 .lp-foot__links { display: flex; gap: 28px; font-size: 14px; color: var(--ts-sage-2); }
 .lp-foot__links a { text-decoration: none; color: inherit; }
-.lp-foot__links a:hover { color: var(--ts-green-ink); }
-.lp-foot__copy { font-size: 13px; color: #59684f; }
+.lp-foot__links a:hover { color: var(--ts-text); }
+.lp-foot__copy { font-size: 13px; color: var(--ts-text-muted); }
 
 /* ── placeholder de foto (el modelo aún no tiene imágenes reales) ─────────── */
 .lp-photo {

--- a/apps/web/src/pages/mylands.css
+++ b/apps/web/src/pages/mylands.css
@@ -1,6 +1,6 @@
 /* TerraShare — Mis terrenos (paridad con "Mis publicaciones" del prototipo). Prefijo `ml-`. */
 
-.ml { max-width: 1120px; margin: 0 auto; padding: 40px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.ml { max-width: 1120px; margin: 0 auto; padding: 40px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 @keyframes mlUp {
   from { opacity: 0; transform: translateY(14px); }
@@ -21,7 +21,7 @@
   font-size: 38px;
   letter-spacing: -0.02em;
   margin: 0;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .ml-sub { color: var(--ts-sage-2); font-size: 16px; margin: 6px 0 0; }
 .ml-btn {
@@ -29,7 +29,7 @@
   align-items: center;
   gap: 9px;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   font-size: 15px;
   padding: 13px 22px;
@@ -85,7 +85,7 @@
 .ml-add {
   text-decoration: none;
   color: var(--ts-sage);
-  background: #faf5ea;
+  background: var(--ts-surface-alt);
   border: 1.5px dashed #d8cfb8;
   border-radius: 16px;
   display: flex;
@@ -96,7 +96,7 @@
   min-height: 210px;
   transition: background 0.2s ease, color 0.2s ease;
 }
-.ml-add:hover { background: #f2ecdf; color: var(--ts-green); }
+.ml-add:hover { background: var(--ts-paper-tint); color: var(--ts-green); }
 .ml-add span { font-size: 14px; font-weight: 600; }
 
 .ml-empty {
@@ -113,7 +113,7 @@
   display: inline-block;
   margin-top: 16px;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   padding: 12px 22px;
   border-radius: 11px;

--- a/apps/web/src/pages/notifications.css
+++ b/apps/web/src/pages/notifications.css
@@ -1,6 +1,6 @@
 /* TerraShare — Notificaciones (paridad con el prototipo · pantalla 19). Prefijo `ntf-`. */
 
-.ntf { max-width: 760px; margin: 0 auto; padding: 44px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.ntf { max-width: 760px; margin: 0 auto; padding: 44px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 @keyframes ntfUp {
   from { opacity: 0; transform: translateY(14px); }
@@ -21,7 +21,7 @@
   font-size: 34px;
   letter-spacing: -0.02em;
   margin: 0;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .ntf-markall {
   color: var(--ts-green);
@@ -33,7 +33,7 @@
   font-family: var(--ts-font-sans);
   white-space: nowrap;
 }
-.ntf-markall:hover { color: var(--ts-green-ink); }
+.ntf-markall:hover { color: var(--ts-text); }
 
 .ntf-list { display: grid; gap: 10px; animation: ntfUp 0.6s ease both 0.06s; }
 
@@ -54,7 +54,7 @@
   cursor: pointer;
 }
 .ntf-item:hover { transform: translateY(-2px); box-shadow: 0 20px 40px -30px rgba(36, 49, 42, 0.4); }
-.ntf-item--read { background: #faf5ea; }
+.ntf-item--read { background: var(--ts-surface-alt); }
 
 .ntf-item__icon {
   width: 40px;
@@ -71,7 +71,7 @@
 .ntf-item__icon--neutral { background: var(--ts-tint-green); color: var(--ts-green); }
 
 .ntf-item__body { flex: 1; min-width: 0; }
-.ntf-item__text { font-size: 14.5px; color: var(--ts-green-ink); }
+.ntf-item__text { font-size: 14.5px; color: var(--ts-text); }
 .ntf-item--read .ntf-item__text { color: var(--ts-text-secondary); }
 .ntf-item__text b { font-weight: 700; }
 .ntf-item__time { font-size: 12.5px; color: var(--ts-sage); margin-top: 2px; }

--- a/apps/web/src/pages/payments.css
+++ b/apps/web/src/pages/payments.css
@@ -1,6 +1,6 @@
 /* TerraShare — Pagos (paridad con el prototipo · pantalla 17). Prefijo `pay-`. */
 
-.pay { max-width: 960px; margin: 0 auto; padding: 44px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.pay { max-width: 960px; margin: 0 auto; padding: 44px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 @keyframes payUp {
   from { opacity: 0; transform: translateY(14px); }
@@ -13,7 +13,7 @@
   font-size: 38px;
   letter-spacing: -0.02em;
   margin: 0 0 4px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   animation: payUp 0.6s ease both;
 }
 .pay-sub { color: var(--ts-sage-2); font-size: 16px; margin: 0 0 28px; animation: payUp 0.6s ease both 0.04s; }
@@ -87,7 +87,7 @@
   display: inline-block;
   margin-top: 14px;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   padding: 11px 20px;
   border-radius: 10px;

--- a/apps/web/src/pages/profile.css
+++ b/apps/web/src/pages/profile.css
@@ -1,6 +1,6 @@
 /* TerraShare — Mi perfil (paridad con el prototipo · pantalla 10). Prefijo `pf-`. */
 
-.pf { max-width: 760px; margin: 0 auto; padding: 44px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.pf { max-width: 760px; margin: 0 auto; padding: 44px 40px 70px; font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 @keyframes pfUp {
   from { opacity: 0; transform: translateY(14px); }
@@ -13,7 +13,7 @@
   font-size: 38px;
   letter-spacing: -0.02em;
   margin: 0 0 4px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   animation: pfUp 0.6s ease both;
 }
 .pf-sub { color: var(--ts-sage-2); font-size: 16px; margin: 0 0 26px; animation: pfUp 0.6s ease both 0.04s; }
@@ -81,7 +81,7 @@
   text-decoration: none;
   font-family: var(--ts-font-sans);
 }
-.pf-obtn:hover { background: #f1ebdd; }
+.pf-obtn:hover { background: var(--ts-paper-tint); }
 
 /* datos personales */
 .pf-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
@@ -96,7 +96,7 @@
   border-radius: 11px;
   padding: 12px 15px;
   font-size: 15px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   font-family: var(--ts-font-sans);
 }
 .pf-value--muted { color: var(--ts-sage-3); }
@@ -105,7 +105,7 @@
 .pf-save-row { display: flex; justify-content: flex-end; align-items: center; gap: 12px; margin-top: 16px; }
 .pf-save {
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   font-size: 14px;
   padding: 11px 20px;
@@ -132,7 +132,7 @@
 .pf-pref__hint { font-size: 12.5px; color: var(--ts-sage); }
 
 /* segmento Busco/Ofrezco */
-.pf-seg { display: inline-flex; background: #efe7d6; border-radius: 999px; padding: 3px; gap: 2px; flex: 0 0 auto; }
+.pf-seg { display: inline-flex; background: var(--ts-beige); border-radius: 999px; padding: 3px; gap: 2px; flex: 0 0 auto; }
 .pf-seg__btn {
   color: var(--ts-text-secondary);
   font-weight: 600;
@@ -144,7 +144,7 @@
   cursor: pointer;
   font-family: var(--ts-font-sans);
 }
-.pf-seg__btn.is-active { background: var(--ts-green); color: var(--ts-bg); }
+.pf-seg__btn.is-active { background: var(--ts-green); color: var(--ts-on-ink); }
 
 /* toggle */
 .pf-toggle {
@@ -167,7 +167,7 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: #fff;
+  background: var(--ts-surface);
   transition: left 0.2s ease;
 }
 .pf-toggle.is-on .pf-toggle__knob { left: 22px; }

--- a/apps/web/src/pages/publish.css
+++ b/apps/web/src/pages/publish.css
@@ -1,6 +1,6 @@
 /* TerraShare — Publicar terreno, wizard 4 pasos (prototipo · pantallas 06/20-22). Prefijo `pub-`. */
 
-.pub { min-height: 100vh; background: var(--ts-bg); font-family: var(--ts-font-sans); color: var(--ts-green-ink); }
+.pub { min-height: 100vh; background: var(--ts-bg); font-family: var(--ts-font-sans); color: var(--ts-text); }
 
 @keyframes pubUp {
   from { opacity: 0; transform: translateY(12px); }
@@ -51,7 +51,7 @@
   font-size: 34px;
   letter-spacing: -0.02em;
   margin: 0 0 26px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 
 .pub-card {
@@ -72,7 +72,7 @@
   border-radius: 11px;
   padding: 13px 15px;
   font-size: 15px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   font-family: var(--ts-font-sans);
   outline: none;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -84,7 +84,7 @@ textarea.pub-input { min-height: 92px; resize: vertical; }
 .pub-grid-loc { display: grid; grid-template-columns: 1fr 1.2fr; gap: 16px; margin-top: 18px; }
 
 /* segmento (operación / moneda) */
-.pub-seg { display: inline-flex; background: #efe7d6; border-radius: 11px; padding: 4px; gap: 3px; width: 100%; }
+.pub-seg { display: inline-flex; background: var(--ts-beige); border-radius: 11px; padding: 4px; gap: 3px; width: 100%; }
 .pub-seg__btn {
   flex: 1;
   text-align: center;
@@ -98,7 +98,7 @@ textarea.pub-input { min-height: 92px; resize: vertical; }
   cursor: pointer;
   font-family: var(--ts-font-sans);
 }
-.pub-seg__btn.is-active { background: var(--ts-green); color: var(--ts-bg); }
+.pub-seg__btn.is-active { background: var(--ts-green); color: var(--ts-on-ink); }
 .pub-seg--sm { width: auto; }
 .pub-seg--sm .pub-seg__btn { padding: 9px 12px; font-size: 13px; }
 
@@ -110,7 +110,7 @@ textarea.pub-input { min-height: 92px; resize: vertical; }
   gap: 6px;
   font-size: 13.5px;
   color: var(--ts-text-secondary);
-  background: #f2ecdf;
+  background: var(--ts-paper-tint);
   border: 1px solid var(--ts-border);
   border-radius: 999px;
   padding: 8px 15px;
@@ -121,7 +121,7 @@ textarea.pub-input { min-height: 92px; resize: vertical; }
 
 .pub-hint { font-size: 12.5px; color: var(--ts-sage); margin-top: 14px; display: flex; align-items: center; gap: 6px; line-height: 1.5; }
 .pub-price-suffix { font-size: 12px; color: var(--ts-sage); }
-.pub-subtitle { font-size: 15px; font-weight: 600; color: var(--ts-green-ink); margin: 24px 0 12px; font-family: var(--ts-font-serif); }
+.pub-subtitle { font-size: 15px; font-weight: 600; color: var(--ts-text); margin: 24px 0 12px; font-family: var(--ts-font-serif); }
 .pub-subtitle span { font-size: 12.5px; color: var(--ts-sage); font-weight: 400; font-family: var(--ts-font-sans); }
 
 /* paso 4 fotos */
@@ -132,7 +132,7 @@ textarea.pub-input { min-height: 92px; resize: vertical; }
   text-align: center;
   color: var(--ts-sage);
   margin-bottom: 16px;
-  background: #faf5ea;
+  background: var(--ts-surface-alt);
 }
 .pub-drop__main { font-size: 14.5px; margin-top: 8px; }
 .pub-drop__main b { color: var(--ts-green); font-weight: 600; }
@@ -165,13 +165,13 @@ textarea.pub-input { min-height: 92px; resize: vertical; }
   cursor: pointer;
   font-family: var(--ts-font-sans);
 }
-.pub-back:hover { color: var(--ts-green-ink); }
+.pub-back:hover { color: var(--ts-text); }
 .pub-next {
   display: inline-flex;
   align-items: center;
   gap: 9px;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   font-size: 15px;
   padding: 14px 26px;

--- a/apps/web/src/pages/reserve.css
+++ b/apps/web/src/pages/reserve.css
@@ -1,6 +1,6 @@
 /* TerraShare — Solicitar alquiler (paridad con el prototipo · pantalla 14). Prefijo `rsv-`. */
 
-.rsv { width: 100%; font-family: var(--ts-font-sans); color: var(--ts-green-ink); min-height: 100vh; background: var(--ts-bg); }
+.rsv { width: 100%; font-family: var(--ts-font-sans); color: var(--ts-text); min-height: 100vh; background: var(--ts-bg); }
 
 @keyframes rsvUp {
   from { opacity: 0; transform: translateY(16px); }
@@ -28,7 +28,7 @@
   font-size: 14px;
   text-decoration: none;
 }
-.rsv-nav__back:hover { color: var(--ts-green-ink); }
+.rsv-nav__back:hover { color: var(--ts-text); }
 .rsv-nav__brand { margin-left: auto; display: flex; align-items: center; gap: 10px; }
 .rsv-nav__brand-mark { color: var(--ts-green); display: inline-flex; }
 .rsv-nav__brand-name { font-family: var(--ts-font-serif); font-weight: 600; font-size: 19px; color: var(--ts-green); }
@@ -94,7 +94,7 @@
   font-size: 38px;
   letter-spacing: -0.02em;
   margin: 0 0 6px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
 }
 .rsv-sub { color: var(--ts-sage-2); font-size: 16px; margin: 0 0 26px; }
 .rsv-card {
@@ -115,7 +115,7 @@
   border-radius: 11px;
   padding: 13px 15px;
   font-size: 15px;
-  color: var(--ts-green-ink);
+  color: var(--ts-text);
   font-family: var(--ts-font-sans);
   outline: none;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -129,7 +129,7 @@ textarea.rsv-input { min-height: 88px; resize: vertical; }
   flex: 1;
   text-align: center;
   background: var(--ts-green);
-  color: var(--ts-bg);
+  color: var(--ts-on-ink);
   font-weight: 600;
   font-size: 16px;
   padding: 14px;
@@ -153,7 +153,7 @@ textarea.rsv-input { min-height: 88px; resize: vertical; }
   display: inline-flex;
   align-items: center;
 }
-.rsv-cancel:hover { background: #f1ebdd; }
+.rsv-cancel:hover { background: var(--ts-paper-tint); }
 
 .rsv-note {
   font-size: 12.5px;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,8 @@
 import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 import { ClerkProvider } from "@clerk/clerk-react";
 import { esES } from "@clerk/localizations";
-import { clerkAppearance } from "../clerkAppearance";
+import { getClerkAppearance } from "../clerkAppearance";
+import { useTheme } from "../hooks/useTheme";
 import ErrorBoundary from "../components/ErrorBoundary";
 import "../i18n";
 import "../styles.css";
@@ -28,6 +29,22 @@ export const Route = createRootRoute({
   component: RootComponent,
 });
 
+/** ClerkProvider cuya apariencia sigue el tema activo (#278). */
+function ThemedClerkProvider({ children }: { children: React.ReactNode }) {
+  const theme = useTheme();
+  return (
+    <ClerkProvider
+      publishableKey={PUBLISHABLE_KEY}
+      appearance={getClerkAppearance(theme)}
+      localization={esES}
+      signUpForceRedirectUrl="/onboarding"
+      signInFallbackRedirectUrl="/dashboard"
+    >
+      {children}
+    </ClerkProvider>
+  );
+}
+
 function RootComponent() {
   // El límite vive dentro del shell (#261): así un error de página se contiene
   // aquí y nunca alcanza a <html>/<head>, que es lo que borraba el CSS.
@@ -40,20 +57,23 @@ function RootComponent() {
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
+    // data-theme="light" por defecto en SSR; el script anti-flash lo corrige al
+    // tema real antes del primer pintado. suppressHydrationWarning silencia el
+    // (esperado) desajuste de valor entre servidor y cliente.
+    <html lang="es" data-theme="light" suppressHydrationWarning>
       <head>
+        {/* Anti-flash de tema (#278): fija data-theme antes del primer pintado,
+            replicando la lógica de lib/theme.ts (preferencia guardada o del SO). */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{var k='ts-theme',v=localStorage.getItem(k);var t=(v==='light'||v==='dark')?v:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();",
+          }}
+        />
         <HeadContent />
       </head>
       <body>
-        <ClerkProvider
-          publishableKey={PUBLISHABLE_KEY}
-          appearance={clerkAppearance}
-          localization={esES}
-          signUpForceRedirectUrl="/onboarding"
-          signInFallbackRedirectUrl="/dashboard"
-        >
-          {children}
-        </ClerkProvider>
+        <ThemedClerkProvider>{children}</ThemedClerkProvider>
         <Scripts />
       </body>
     </html>

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -115,3 +115,44 @@ h3.ts-title {
     animation: none;
   }
 }
+
+/* ── Toggle de tema claro/oscuro (#278) ────────────────────────────────────
+   Botón solo-ícono que hereda el color del contexto (currentColor), por lo que
+   funciona igual en la navbar clara, el landing y el sidebar admin oscuro. */
+.ts-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--ts-radius-pill);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.ts-theme-toggle:hover {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
+/* En el nav del landing, alineado con los enlaces. */
+.lp-nav__theme {
+  color: var(--ts-text);
+}
+
+/* En el footer del sidebar admin (siempre oscuro): ícono crema. */
+.adm-side__theme {
+  color: var(--ts-on-ink);
+  width: 100%;
+  height: auto;
+  justify-content: flex-start;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: var(--ts-radius);
+  margin-bottom: 4px;
+}
+.adm-side__theme:hover {
+  background: rgba(244, 239, 228, 0.07);
+}

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,6 +1,8 @@
 /* TerraShare — tokens del sistema de diseño editorial (issue #134).
    Fuente de verdad: design/DESIGN_SYSTEM.md + design/prototipo-editorial.html.
-   Tema claro. El tema oscuro se añadirá en una fase posterior. */
+   Tema claro por defecto + tema oscuro (#278). El tema se controla con el
+   atributo `data-theme` en <html> (lo fija `lib/theme.ts` sin flash); si no
+   hay elección explícita se respeta `prefers-color-scheme`. */
 
 :root {
   /* superficies (papel) */
@@ -39,8 +41,9 @@
   --ts-text-secondary: #55654f;
   --ts-text-muted: #59684f;    /* AA 4.5:1 sobre fondos claros (#178) */
 
-  /* texto sobre relleno verde */
+  /* texto claro sobre rellenos verdes/oscuros (permanece crema en ambos temas) */
   --ts-on-green: #f4efe4;
+  --ts-on-ink: #f4efe4;
 
   /* tipografía */
   --ts-font-serif: "Spectral", Georgia, "Times New Roman", serif;
@@ -69,4 +72,98 @@
 
   /* foco accesible */
   --ts-ring: 0 0 0 3px rgba(47, 81, 56, 0.28);
+}
+
+/* ─── Tema oscuro (#278) ──────────────────────────────────────────────────────
+   Editorial oscuro: papel → tinta cálida verdosa, mucho aire, verde y terracota
+   ligeramente más luminosos para leerse sobre superficies oscuras.
+   Los valores se declaran una sola vez en `%dark-vars` (mixin manual) y se
+   aplican en dos contextos:
+     1. Elección explícita del usuario:  :root[data-theme="dark"]
+     2. Preferencia del SO sin elección:  @media (prefers-color-scheme: dark)
+   `--ts-on-green` y `--ts-on-ink` permanecen crema: son texto sobre rellenos
+   verdes/oscuros que existen en ambos temas. */
+
+:root[data-theme="dark"] {
+  /* superficies (tinta) */
+  --ts-bg: #161c18;
+  --ts-surface: #1e2621;
+  --ts-surface-alt: #19201b;
+  --ts-paper-tint: #212a24;
+
+  /* marca (verde, más luminoso para contraste sobre oscuro) */
+  --ts-green: #4f8a61;
+  --ts-green-ink: #0f140f;     /* superficie más oscura aún: sidebar, cards oscuras */
+  --ts-green-soft: #8aa891;
+  --ts-sage: #9fb0a0;
+  --ts-sage-2: #97a998;
+  --ts-sage-3: #6c7c6e;
+
+  /* tintes (chips, éxito, hover) */
+  --ts-tint-green: #223026;
+  --ts-tint-green-2: #26362b;
+  --ts-tint-green-3: #33463a;
+
+  /* acento */
+  --ts-clay: #d07a54;
+  --ts-clay-tint: #3a241c;
+
+  /* neutros */
+  --ts-border: #33403a;
+  --ts-beige: #2a332c;
+  --ts-beige-2: #313a33;
+
+  /* texto */
+  --ts-text: #ece4d3;
+  --ts-text-secondary: #b7c1b3;
+  --ts-text-muted: #9aa694;
+
+  /* sombras (negro real: el papel ya no aporta profundidad) */
+  --ts-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --ts-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+
+  /* foco accesible */
+  --ts-ring: 0 0 0 3px rgba(122, 170, 138, 0.42);
+
+  color-scheme: dark;
+}
+
+/* Preferencia del SO cuando el usuario no ha elegido explícitamente (data-theme
+   ausente o "system"). Se anula en cuanto se fija data-theme="light". */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    --ts-bg: #161c18;
+    --ts-surface: #1e2621;
+    --ts-surface-alt: #19201b;
+    --ts-paper-tint: #212a24;
+
+    --ts-green: #4f8a61;
+    --ts-green-ink: #0f140f;
+    --ts-green-soft: #8aa891;
+    --ts-sage: #9fb0a0;
+    --ts-sage-2: #97a998;
+    --ts-sage-3: #6c7c6e;
+
+    --ts-tint-green: #223026;
+    --ts-tint-green-2: #26362b;
+    --ts-tint-green-3: #33463a;
+
+    --ts-clay: #d07a54;
+    --ts-clay-tint: #3a241c;
+
+    --ts-border: #33403a;
+    --ts-beige: #2a332c;
+    --ts-beige-2: #313a33;
+
+    --ts-text: #ece4d3;
+    --ts-text-secondary: #b7c1b3;
+    --ts-text-muted: #9aa694;
+
+    --ts-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --ts-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+
+    --ts-ring: 0 0 0 3px rgba(122, 170, 138, 0.42);
+
+    color-scheme: dark;
+  }
 }


### PR DESCRIPTION
Cierra #278 (último criterio pendiente del epic #134: soporte de modo oscuro I-8).

## Qué incluye
- **Tema oscuro editorial** definido como overrides de los tokens `--ts-*` bajo `:root[data-theme="dark"]`, con fallback a `@media (prefers-color-scheme: dark)` cuando el usuario no ha elegido. `color-scheme: dark` para los controles nativos.
- **Toggle accesible** (`aria-label`, ícono sol/luna) en la navbar del shell autenticado, el sidebar admin y el nav del landing. Persiste la elección en `localStorage` y arranca respetando la preferencia del SO.
- **Anti-flash**: script inline en `<head>` que fija `data-theme` antes del primer pintado (replica `lib/theme.ts`). SSR renderiza `data-theme="light"` por defecto + `suppressHydrationWarning`.
- **Clerk theme-aware**: `getClerkAppearance(theme)` da variante clara/oscura al widget de SignIn/SignUp, reactiva al toggle vía evento `ts-themechange`.
- **Desambiguación de tokens sobrecargados** (el sistema era solo-claro):
  - `color: var(--ts-bg)` → `var(--ts-on-ink)` (texto claro sobre rellenos verdes; crema en ambos temas).
  - `color: var(--ts-green-ink)` → `var(--ts-text)` (texto fuerte que invierte).
  - Cremas de superficie hardcodeados (`#f2ecdf`, `#faf5ea`, `#efe7d6`…) → tokens que invierten.

## Archivos nuevos
- `lib/theme.ts` — utilidades de tema + evento de cambio.
- `hooks/useTheme.ts` — tema reactivo.
- `components/ThemeToggle.tsx` — botón accesible.

## Verificación (navegador, estilos computados)
- **Contraste**: 0 elementos <3:1 en landing, login y styleguide, **en ambos temas** (auditoría WCAG programática).
- **Toggle**: alterna dark↔light, actualiza `aria-label`, persiste en `localStorage`.
- **Persistencia + anti-flash**: tras recarga con SO=oscuro y preferencia guardada=claro, queda claro sin flash.
- **Clerk**: la card de login pasa a superficie oscura (`#1e2621`) en tema oscuro.
- `npm run typecheck` ✅ · `npm run build` ✅ (prerender de `/` OK).

## Nota
Queda un warning **solo en desarrollo** de React (`Extra attributes from the server: data-theme`) por mutar el atributo del `<html>` raíz antes de hidratar; `suppressHydrationWarning` no lo suprime del todo en el root con este SSR. Es inofensivo y **no aparece en el build de producción**.