### PR TITLE
feat(lands): fotos de terrenos — subida, almacenamiento (GridFS) y galería (#148)

### DIFF
--- a/apps/backend-api/src/lib/land-photos.ts
+++ b/apps/backend-api/src/lib/land-photos.ts
@@ -1,0 +1,89 @@
+/**
+ * Almacenamiento de fotos de terrenos en MongoDB GridFS (HU-56 relacionada; #148).
+ *
+ * Guardamos los binarios en el bucket `landPhotos` de GridFS (no en el documento
+ * Land, que solo referencia las URLs). Enfoque autocontenido: sin cuentas ni
+ * SDKs externos, y 100% testeable en CI con `mongodb-memory-server`. Migrar a
+ * S3/Cloudinary después es un cambio aislado a este módulo.
+ */
+import mongooseConn from "../db/mongoose";
+
+const BUCKET_NAME = "landPhotos";
+
+export const ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+export const MAX_PHOTO_BYTES = 5 * 1024 * 1024; // 5 MB
+export const MAX_PHOTOS_PER_LAND = 10;
+
+function getBucket() {
+  const db = mongooseConn.connection.db;
+  if (!db) throw new Error("Database connection not available");
+  return new mongooseConn.mongo.GridFSBucket(db, { bucketName: BUCKET_NAME });
+}
+
+function toObjectId(id: string): InstanceType<typeof mongooseConn.mongo.ObjectId> | null {
+  try {
+    return new mongooseConn.mongo.ObjectId(id);
+  } catch {
+    return null;
+  }
+}
+
+/** Guarda un binario en GridFS y devuelve el id del archivo (hex). */
+export async function storeLandPhoto(input: {
+  landId: string;
+  buffer: Buffer;
+  contentType: string;
+  filename: string;
+}): Promise<string> {
+  const bucket = getBucket();
+  return new Promise<string>((resolve, reject) => {
+    const stream = bucket.openUploadStream(input.filename, {
+      // `contentType` está deprecado como opción del stream en el driver; lo
+      // guardamos en metadata y lo leemos de ahí al servir.
+      metadata: { landId: input.landId, contentType: input.contentType },
+    });
+    stream.on("error", reject);
+    stream.on("finish", () => resolve(String(stream.id)));
+    stream.end(input.buffer);
+  });
+}
+
+/** Lee un binario de GridFS a memoria. `null` si no existe. */
+export async function getLandPhoto(
+  fileId: string,
+): Promise<{ buffer: Buffer; contentType: string } | null> {
+  const _id = toObjectId(fileId);
+  if (!_id) return null;
+
+  const bucket = getBucket();
+  const files = await bucket.find({ _id }).toArray();
+  if (files.length === 0) return null;
+  const meta = files[0].metadata as { contentType?: string } | undefined;
+  const contentType = meta?.contentType ?? "application/octet-stream";
+
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    bucket
+      .openDownloadStream(_id)
+      .on("data", (chunk: Buffer) => chunks.push(chunk))
+      .on("error", reject)
+      .on("end", () => resolve({ buffer: Buffer.concat(chunks), contentType }));
+  });
+}
+
+/** Elimina un binario de GridFS. No lanza si ya no existe. */
+export async function deleteLandPhoto(fileId: string): Promise<void> {
+  const _id = toObjectId(fileId);
+  if (!_id) return;
+  const bucket = getBucket();
+  try {
+    await bucket.delete(_id);
+  } catch {
+    // El archivo pudo borrarse ya; la referencia se limpia igual en la ruta.
+  }
+}
+
+/** URL relativa canónica con la que el front referencia una foto. */
+export function photoUrl(landId: string, fileId: string): string {
+  return `/api/v1/lands/${landId}/photos/${fileId}`;
+}

--- a/apps/backend-api/src/routes/lands-photos.test.ts
+++ b/apps/backend-api/src/routes/lands-photos.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+
+import { createApp } from "../app";
+import { requestJson } from "../lib/http-test-utils";
+
+// PNG 1x1 transparente válido.
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const OWNER = { "x-dev-user-id": "photo_owner", "x-dev-role": "user" };
+const OTHER = { "x-dev-user-id": "photo_intruder", "x-dev-role": "user" };
+
+/** Crea un terreno en borrador propiedad del usuario `headers` y devuelve su id. */
+async function createLand(headers: Record<string, string>): Promise<string> {
+  const { response, payload } = await requestJson("/api/v1/lands", {
+    method: "POST",
+    headers,
+    body: {
+      title: "Finca con fotos",
+      area: 2,
+      allowedUses: ["agricultura"],
+      location: { province: "Los Santos", district: "Guararé" },
+      priceRule: { currency: "USD", pricePerMonth: 300 },
+    },
+  });
+  expect(response.status).toBe(201);
+  return payload.data.id;
+}
+
+/** Sube un archivo multipart a la ruta de fotos. */
+async function uploadPhoto(
+  landId: string,
+  file: File,
+  headers: Record<string, string>,
+) {
+  const fd = new FormData();
+  fd.append("file", file);
+  const app = createApp();
+  const response = await app.request(`/api/v1/lands/${landId}/photos`, {
+    method: "POST",
+    headers, // FormData fija su propio content-type con boundary.
+    body: fd,
+  });
+  const payload = response.headers.get("content-type")?.includes("application/json")
+    ? await response.json()
+    : null;
+  return { response, payload };
+}
+
+function pngFile(name = "foto.png"): File {
+  return new File([new Uint8Array(PNG_1X1)], name, { type: "image/png" });
+}
+
+describe("Fotos de terrenos — GridFS (#148)", () => {
+  it("el dueño sube una foto, se sirve el binario y se puede borrar", async () => {
+    const landId = await createLand(OWNER);
+
+    const up = await uploadPhoto(landId, pngFile(), OWNER);
+    expect(up.response.status).toBe(201);
+    expect(up.payload.data.photos).toHaveLength(1);
+    const url: string = up.payload.data.url;
+    expect(url).toBe(up.payload.data.photos[0]);
+    expect(url).toStartWith(`/api/v1/lands/${landId}/photos/`);
+
+    // El terreno ahora expone la foto en su DTO.
+    const detail = await requestJson(`/api/v1/lands/${landId}`);
+    // status draft: el dueño lo creó en borrador, el GET público lo devuelve
+    // salvo inactive; en borrador sigue accesible por id.
+    expect(detail.payload.data.photos).toEqual([url]);
+
+    // Servir el binario: 200 + content-type + bytes correctos.
+    const app = createApp();
+    const img = await app.request(url);
+    expect(img.status).toBe(200);
+    expect(img.headers.get("content-type")).toBe("image/png");
+    const bytes = Buffer.from(await img.arrayBuffer());
+    expect(bytes.length).toBe(PNG_1X1.length);
+    expect(bytes.equals(PNG_1X1)).toBe(true);
+
+    // Borrar (dueño): la referencia desaparece y el binario deja de servirse.
+    const fileId = url.split("/").pop()!;
+    const del = await requestJson(`/api/v1/lands/${landId}/photos/${fileId}`, {
+      method: "DELETE",
+      headers: OWNER,
+    });
+    expect(del.response.status).toBe(200);
+    expect(del.payload.data.photos).toEqual([]);
+
+    const gone = await app.request(url);
+    expect(gone.status).toBe(404);
+  });
+
+  it("rechaza subir a un terreno ajeno (403)", async () => {
+    const landId = await createLand(OWNER);
+    const up = await uploadPhoto(landId, pngFile(), OTHER);
+    expect(up.response.status).toBe(403);
+  });
+
+  it("rechaza tipos no permitidos (400)", async () => {
+    const landId = await createLand(OWNER);
+    const txt = new File([new Uint8Array([1, 2, 3])], "nota.txt", { type: "text/plain" });
+    const up = await uploadPhoto(landId, txt, OWNER);
+    expect(up.response.status).toBe(400);
+  });
+
+  it("404 al servir un fileId inexistente", async () => {
+    const landId = await createLand(OWNER);
+    const app = createApp();
+    const res = await app.request(`/api/v1/lands/${landId}/photos/deadbeefdeadbeefdeadbeef`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -9,6 +9,15 @@ import { requireAuth } from "../middleware/require-auth";
 import { rateLimitByUser } from "../middleware/rate-limit";
 import { createAuditEvent as createAudit } from "../store/audit";
 import { Land } from "../db/schemas";
+import {
+  ALLOWED_CONTENT_TYPES,
+  MAX_PHOTO_BYTES,
+  MAX_PHOTOS_PER_LAND,
+  deleteLandPhoto,
+  getLandPhoto,
+  photoUrl,
+  storeLandPhoto,
+} from "../lib/land-photos";
 import type { LandRecord } from "../store/types";
 import type { AppEnv } from "../types";
 
@@ -222,6 +231,113 @@ landRoutes.post("/lands", requireAuth, rateLimitByUser(200), async (c) => {
   });
 
   return success(c, land, 201);
+});
+
+// ─── Fotos de terrenos (GridFS, #148) ─────────────────────────────────────────
+
+/** Sirve el binario de una foto. Público: los terrenos activos son públicos. */
+landRoutes.get("/lands/:landId/photos/:fileId", async (c) => {
+  const photo = await getLandPhoto(c.req.param("fileId"));
+  if (!photo) {
+    return failure(c, 404, "NOT_FOUND", "Photo not found");
+  }
+  // Las imágenes se embeben desde la web (otro origen en dev y en prod), así que
+  // relajamos el CORP global (same-origin) a cross-origin solo para este binario.
+  c.header("Cross-Origin-Resource-Policy", "cross-origin");
+  return new Response(new Uint8Array(photo.buffer), {
+    status: 200,
+    headers: {
+      "Content-Type": photo.contentType,
+      "Content-Length": String(photo.buffer.length),
+      // Las URLs son inmutables (id de archivo por foto): caché agresiva.
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Cross-Origin-Resource-Policy": "cross-origin",
+    },
+  });
+});
+
+/** Sube una foto (multipart, campo `file`) a un terreno del que se es dueño. */
+landRoutes.post("/lands/:landId/photos", requireAuth, rateLimitByUser(200), async (c) => {
+  const authUser = c.get("authUser");
+  const landId = c.req.param("landId");
+
+  const current = clean<LandRecord>(
+    (await Land.findOne({ id: landId }).lean()) as Record<string, unknown> | null,
+  );
+  if (!current) {
+    return failure(c, 404, "NOT_FOUND", "Land not found");
+  }
+  if (!canMutateLand(authUser, current)) {
+    return failure(c, 403, "FORBIDDEN", "Only owner or admin can add photos to this land");
+  }
+
+  const existing = current.photos ?? [];
+  if (existing.length >= MAX_PHOTOS_PER_LAND) {
+    return failure(
+      c,
+      422,
+      "BUSINESS_RULE_VIOLATION",
+      `A land can have at most ${MAX_PHOTOS_PER_LAND} photos`,
+    );
+  }
+
+  const body = await c.req.parseBody();
+  const file = body["file"];
+  if (!(file instanceof File)) {
+    return failure(c, 400, "VALIDATION_ERROR", "Missing 'file' in multipart body");
+  }
+  if (!(ALLOWED_CONTENT_TYPES as readonly string[]).includes(file.type)) {
+    return failure(
+      c,
+      400,
+      "VALIDATION_ERROR",
+      `Unsupported image type: ${file.type || "unknown"}. Allowed: ${ALLOWED_CONTENT_TYPES.join(", ")}`,
+    );
+  }
+  if (file.size > MAX_PHOTO_BYTES) {
+    return failure(c, 422, "BUSINESS_RULE_VIOLATION", "Image exceeds the 5 MB limit");
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const fileId = await storeLandPhoto({
+    landId,
+    buffer,
+    contentType: file.type,
+    filename: file.name || "photo",
+  });
+  const url = photoUrl(landId, fileId);
+  const photos = [...existing, url];
+
+  await Land.updateOne({ id: landId }, { $set: { photos, updatedAt: new Date().toISOString() } });
+  await createAudit({ actor: authUser, entity: "land", action: "updated", entityId: landId });
+
+  return success(c, { url, photos }, 201);
+});
+
+/** Elimina una foto de un terreno del que se es dueño. */
+landRoutes.delete("/lands/:landId/photos/:fileId", requireAuth, rateLimitByUser(200), async (c) => {
+  const authUser = c.get("authUser");
+  const landId = c.req.param("landId");
+  const fileId = c.req.param("fileId");
+
+  const current = clean<LandRecord>(
+    (await Land.findOne({ id: landId }).lean()) as Record<string, unknown> | null,
+  );
+  if (!current) {
+    return failure(c, 404, "NOT_FOUND", "Land not found");
+  }
+  if (!canMutateLand(authUser, current)) {
+    return failure(c, 403, "FORBIDDEN", "Only owner or admin can remove photos from this land");
+  }
+
+  await deleteLandPhoto(fileId);
+  const url = photoUrl(landId, fileId);
+  const photos = (current.photos ?? []).filter((p) => p !== url);
+
+  await Land.updateOne({ id: landId }, { $set: { photos, updatedAt: new Date().toISOString() } });
+  await createAudit({ actor: authUser, entity: "land", action: "updated", entityId: landId });
+
+  return success(c, { photos });
 });
 
 landRoutes.patch("/lands/:landId", requireAuth, rateLimitByUser(200), async (c) => {

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { LandDto } from "@terrashare/shared";
 import { Search, Sprout, MapPin, DollarSign, Tag, ChevronDown, ImageIcon, SearchX, Heart } from "lucide-react";
-import { listLands } from "../services/api";
+import { listLands, photoSrc } from "../services/api";
 import PanamaMap from "../components/PanamaMap";
 import EmptyState from "../components/EmptyState";
 import { useFavorites } from "../hooks/useFavorites";
@@ -223,8 +223,16 @@ export default function CatalogPage() {
                     onClick={() => setSelectedId(land.id)}
                     onDoubleClick={() => navigate({ to: "/lands/$id", params: { id: land.id } })}
                   >
-                    <div className="cat-card__thumb" aria-hidden="true">
-                      <ImageIcon size={24} strokeWidth={1.5} />
+                    <div className="cat-card__thumb">
+                      {land.photos?.[0] ? (
+                        <img
+                          src={photoSrc(land.photos[0])}
+                          alt={land.title ?? "Terreno"}
+                          loading="lazy"
+                        />
+                      ) : (
+                        <ImageIcon size={24} strokeWidth={1.5} aria-hidden="true" />
+                      )}
                     </div>
                     <span
                       role="button"

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -17,7 +17,7 @@ import {
   Heart,
   MessageCircle,
 } from "lucide-react";
-import { getChats, getMyFavorites, getMyLands, listRentalRequests } from "../services/api";
+import { getChats, getMyFavorites, getMyLands, listRentalRequests, photoSrc } from "../services/api";
 import { getDisplayName } from "../components/authDisplay";
 import { useAppMode } from "../components/AppLayout";
 import EmptyState from "../components/EmptyState";
@@ -220,7 +220,11 @@ function BuscoHome({ name }: { name: string }) {
                   className="hm-favcard"
                 >
                   <span className="hm-favcard__thumb" aria-hidden="true">
-                    <Heart size={16} />
+                    {land.photos?.[0] ? (
+                      <img src={photoSrc(land.photos[0])} alt="" />
+                    ) : (
+                      <Heart size={16} />
+                    )}
                   </span>
                   <span className="hm-favcard__body">
                     <span className="hm-favcard__title">{land.title}</span>

--- a/apps/web/src/pages/LandDetailPage.tsx
+++ b/apps/web/src/pages/LandDetailPage.tsx
@@ -19,7 +19,7 @@ import {
   User,
   Flag,
 } from "lucide-react";
-import { createChat, getLandById, createReport, getOwnerPublicProfile } from "../services/api";
+import { createChat, getLandById, createReport, getOwnerPublicProfile, photoSrc } from "../services/api";
 import type { ReportReason } from "../services/api";
 import { useFavorites } from "../hooks/useFavorites";
 import "./detail.css";
@@ -348,18 +348,40 @@ export default function LandDetailPage() {
 
       <main id="contenido" className="det-wrap">
         {/* galería */}
-        <div className="det-gallery" aria-hidden="true">
-          <div className="det-photo det-photo--main">
-            <ImageIcon size={40} strokeWidth={1.4} />
-            <span>Foto principal — vista del terreno</span>
+        {land.photos && land.photos.length > 0 ? (
+          <div className="det-gallery">
+            <div className="det-photo det-photo--main det-photo--img">
+              <img src={photoSrc(land.photos[0])} alt={`${land.title} — foto principal`} />
+            </div>
+            <div className="det-photo det-photo--img">
+              {land.photos[1] ? (
+                <img src={photoSrc(land.photos[1])} alt={`${land.title} — foto 2`} />
+              ) : (
+                <ImageIcon size={24} strokeWidth={1.4} aria-hidden="true" />
+              )}
+            </div>
+            <div className="det-photo det-photo--img det-gallery__hide-sm">
+              {land.photos[2] ? (
+                <img src={photoSrc(land.photos[2])} alt={`${land.title} — foto 3`} />
+              ) : (
+                <ImageIcon size={24} strokeWidth={1.4} aria-hidden="true" />
+              )}
+            </div>
           </div>
-          <div className="det-photo">
-            <ImageIcon size={24} strokeWidth={1.4} />
+        ) : (
+          <div className="det-gallery" aria-hidden="true">
+            <div className="det-photo det-photo--main">
+              <ImageIcon size={40} strokeWidth={1.4} />
+              <span>Foto principal — vista del terreno</span>
+            </div>
+            <div className="det-photo">
+              <ImageIcon size={24} strokeWidth={1.4} />
+            </div>
+            <div className="det-photo det-gallery__hide-sm">
+              <ImageIcon size={24} strokeWidth={1.4} />
+            </div>
           </div>
-          <div className="det-photo det-gallery__hide-sm">
-            <ImageIcon size={24} strokeWidth={1.4} />
-          </div>
-        </div>
+        )}
 
         <div className="det-body">
           {/* columna izquierda */}

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -14,7 +14,7 @@ import {
   Quote,
   ImageIcon,
 } from "lucide-react";
-import { listLands } from "../services/api";
+import { listLands, photoSrc } from "../services/api";
 import { isAdminUser } from "../components/authDisplay";
 import ThemeToggle from "../components/ThemeToggle";
 import "./landing.css";
@@ -52,6 +52,7 @@ type FeaturedCard = {
   province: string;
   price: number | null;
   to: string;
+  cover?: string;
 };
 
 const SAMPLE_FEATURED: FeaturedCard[] = [
@@ -69,6 +70,7 @@ function toFeatured(land: LandDto): FeaturedCard {
     province: land.location?.province ?? "Panamá",
     price: land.priceRule?.pricePerMonth ?? null,
     to: `/lands/${land.id}`,
+    cover: land.photos?.[0] ? photoSrc(land.photos[0]) : undefined,
   };
 }
 
@@ -84,7 +86,13 @@ function PhotoPlaceholder({ label, className }: { label: string; className: stri
 function LandCard({ card }: { card: FeaturedCard }) {
   return (
     <Link to={card.to} className="lp-card">
-      <PhotoPlaceholder label="Foto terreno" className="lp-photo lp-card__photo" />
+      {card.cover ? (
+        <div className="lp-photo lp-card__photo lp-photo--img">
+          <img src={card.cover} alt={card.title} loading="lazy" />
+        </div>
+      ) : (
+        <PhotoPlaceholder label="Foto terreno" className="lp-photo lp-card__photo" />
+      )}
       <div className="lp-card__body">
         <div className="lp-card__top">
           <span className="lp-card__badge">{card.use}</span>

--- a/apps/web/src/pages/PublishLandPage.tsx
+++ b/apps/web/src/pages/PublishLandPage.tsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { CreateLandDto, LandUse } from "@terrashare/shared";
-import { X, Sprout, ArrowLeft, ArrowRight, Check, MapPin, Info, CloudUpload } from "lucide-react";
-import { createLand } from "../services/api";
+import { X, Sprout, ArrowLeft, ArrowRight, Check, MapPin, Info, CloudUpload, Star, Trash2 } from "lucide-react";
+import { createLand, uploadLandPhoto } from "../services/api";
 import "./publish.css";
+
+const MAX_PHOTOS = 10;
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
 type Operation = "alquiler" | "venta" | "ambas";
 type Currency = "USD" | "PAB";
@@ -57,8 +61,46 @@ export default function PublishLandPage() {
   const navigate = useNavigate();
   const [step, setStep] = useState(1);
   const [form, setForm] = useState<Form>(EMPTY);
+  const [photos, setPhotos] = useState<File[]>([]);
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  const addFiles = (files: FileList | null) => {
+    if (!files) return;
+    setError("");
+    const incoming = Array.from(files);
+    const errors: string[] = [];
+    const valid = incoming.filter((f) => {
+      if (!ACCEPTED_TYPES.includes(f.type)) {
+        errors.push(`${f.name}: formato no admitido`);
+        return false;
+      }
+      if (f.size > MAX_PHOTO_BYTES) {
+        errors.push(`${f.name}: supera 5 MB`);
+        return false;
+      }
+      return true;
+    });
+    setPhotos((prev) => {
+      const next = [...prev, ...valid].slice(0, MAX_PHOTOS);
+      if (prev.length + valid.length > MAX_PHOTOS) {
+        errors.push(`Máximo ${MAX_PHOTOS} fotos.`);
+      }
+      return next;
+    });
+    if (errors.length) setError(errors.join(" · "));
+  };
+
+  const removePhoto = (index: number) =>
+    setPhotos((prev) => prev.filter((_, i) => i !== index));
+
+  const makeCover = (index: number) =>
+    setPhotos((prev) => {
+      if (index === 0) return prev;
+      const next = [...prev];
+      const [chosen] = next.splice(index, 1);
+      return [chosen, ...next];
+    });
 
   const set = <K extends keyof Form>(key: K, value: Form[K]) => {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -103,8 +145,8 @@ export default function PublishLandPage() {
     setSubmitting(true);
     setError("");
     try {
-      // Nota: operación/precio de venta (#140) y fotos (#148) aún no se persisten
-      // en el backend; se envía lo que soporta CreateLandDto.
+      // Nota: operación/precio de venta (#140) aún no se persisten vía
+      // CreateLandDto; las fotos (#148) sí, subiéndolas tras crear el terreno.
       const dto: CreateLandDto = {
         title: form.title.trim(),
         description: form.description.trim() || undefined,
@@ -125,7 +167,16 @@ export default function PublishLandPage() {
           pricePerMonth: Number(form.pricePerMonth) || 0,
         },
       };
-      await createLand(dto);
+      const land = await createLand(dto);
+      // Subimos las fotos en orden (la primera es la portada). Un fallo de foto
+      // no descarta la publicación ya creada: avisamos pero seguimos.
+      for (const file of photos) {
+        try {
+          await uploadLandPhoto(land.id, file);
+        } catch {
+          setError("El terreno se publicó, pero alguna foto no se pudo subir. Podrás reintentarlo al editarlo.");
+        }
+      }
       navigate({ to: "/dashboard/lands", replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : "No se pudo publicar el terreno.");
@@ -325,16 +376,58 @@ export default function PublishLandPage() {
             <div className="pub-step">
               <div style={{ fontFamily: "var(--ts-font-serif)", fontSize: "19px", fontWeight: 600 }}>Fotos del terreno</div>
               <p style={{ color: "var(--ts-sage-2)", fontSize: "14px", margin: "3px 0 18px" }}>
-                Sube hasta 10 fotos. La primera será la portada.
+                Sube hasta {MAX_PHOTOS} fotos (JPG, PNG o WebP · máx. 5 MB). La primera será la portada.
               </p>
-              {/* TODO(#148): la subida de fotos aún no tiene backend; se publica sin fotos. */}
-              <div className="pub-drop">
-                <CloudUpload size={34} strokeWidth={1.6} />
-                <div className="pub-drop__main">
-                  Carga de fotos <b>próximamente</b>
+
+              {photos.length < MAX_PHOTOS && (
+                <label
+                  className="pub-drop"
+                  style={{ cursor: "pointer", display: "block" }}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    addFiles(e.dataTransfer.files);
+                  }}
+                >
+                  <CloudUpload size={34} strokeWidth={1.6} />
+                  <div className="pub-drop__main">
+                    Arrastra tus fotos o <b>haz clic para elegir</b>
+                  </div>
+                  <div className="pub-drop__sub">{photos.length}/{MAX_PHOTOS} añadidas</div>
+                  <input
+                    type="file"
+                    accept={ACCEPTED_TYPES.join(",")}
+                    multiple
+                    hidden
+                    onChange={(e) => {
+                      addFiles(e.target.files);
+                      e.target.value = "";
+                    }}
+                  />
+                </label>
+              )}
+
+              {photos.length > 0 && (
+                <div className="pub-thumbs">
+                  {photos.map((file, i) => (
+                    <div key={`${file.name}-${i}`} className={`pub-thumb ${i === 0 ? "is-cover" : ""}`}>
+                      <img src={URL.createObjectURL(file)} alt={`Foto ${i + 1}`} />
+                      {i === 0 && <span className="pub-thumb__cover">Portada</span>}
+                      <div className="pub-thumb__actions">
+                        {i !== 0 && (
+                          <button type="button" title="Hacer portada" onClick={() => makeCover(i)}>
+                            <Star size={14} />
+                          </button>
+                        )}
+                        <button type="button" title="Quitar" onClick={() => removePhoto(i)}>
+                          <Trash2 size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-                <div className="pub-drop__sub">Podrás añadirlas al editar tu publicación (pendiente #148).</div>
-              </div>
+              )}
+
               <div className="pub-note">
                 <Check size={20} />
                 <div>

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -138,7 +138,10 @@
   justify-content: center;
   background: linear-gradient(135deg, #e9e3d3, #dfe4d6);
   color: var(--ts-sage-3);
+  overflow: hidden;
 }
+/* Foto de portada real (#148). */
+.cat-card__thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .cat-card__body { flex: 1; min-width: 0; }
 .cat-card__top { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; }
 .cat-card__title { font-family: var(--ts-font-serif); font-weight: 600; font-size: 20px; }

--- a/apps/web/src/pages/detail.css
+++ b/apps/web/src/pages/detail.css
@@ -69,6 +69,9 @@
   padding: 12px;
 }
 .det-photo--main { grid-row: span 2; }
+/* Fotos reales (#148): la imagen cubre el tile sin el padding del placeholder. */
+.det-photo--img { padding: 0; overflow: hidden; }
+.det-photo--img img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
 .det-body { display: grid; grid-template-columns: 1.5fr 0.9fr; gap: 44px; align-items: start; }
 

--- a/apps/web/src/pages/home.css
+++ b/apps/web/src/pages/home.css
@@ -275,7 +275,9 @@
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
+  overflow: hidden;
 }
+.hm-favcard__thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .hm-favcard__body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .hm-favcard__title {
   font-size: 14px;

--- a/apps/web/src/pages/landing.css
+++ b/apps/web/src/pages/landing.css
@@ -492,6 +492,9 @@
 }
 .lp-photo--hero { border-radius: 20px; }
 .lp-photo svg { opacity: 0.5; }
+/* Foto de portada real en las cards destacadas (#148). */
+.lp-photo--img { overflow: hidden; padding: 0; }
+.lp-photo--img img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
 /* ── responsive ──────────────────────────────────────────────────────────── */
 @media (max-width: 1040px) {

--- a/apps/web/src/pages/publish.css
+++ b/apps/web/src/pages/publish.css
@@ -134,9 +134,59 @@ textarea.pub-input { min-height: 92px; resize: vertical; }
   margin-bottom: 16px;
   background: var(--ts-surface-alt);
 }
+.pub-drop:hover { border-color: var(--ts-green); }
 .pub-drop__main { font-size: 14.5px; margin-top: 8px; }
 .pub-drop__main b { color: var(--ts-green); font-weight: 600; }
 .pub-drop__sub { font-size: 12.5px; margin-top: 2px; }
+
+/* Miniaturas de fotos subidas (#148). */
+.pub-thumbs {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+  margin: 4px 0 8px;
+}
+.pub-thumb {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--ts-beige);
+  background: var(--ts-surface-alt);
+}
+.pub-thumb.is-cover { border-color: var(--ts-green); box-shadow: 0 0 0 2px var(--ts-green); }
+.pub-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.pub-thumb__cover {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: var(--ts-green);
+  color: var(--ts-on-ink, #fff);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.pub-thumb__actions {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 5px;
+}
+.pub-thumb__actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(20, 20, 18, 0.62);
+  color: #fff;
+  cursor: pointer;
+}
+.pub-thumb__actions button:hover { background: rgba(20, 20, 18, 0.85); }
 .pub-note {
   margin-top: 18px;
   background: var(--ts-tint-green);

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -168,6 +168,46 @@ export const createLand = async (dto: CreateLandDto): Promise<LandDto> => {
   return res.data;
 };
 
+// ─── Fotos de terrenos (#148) ─────────────────────────────────────────────────
+
+/** Convierte una URL relativa de foto (`/api/v1/lands/…`) en absoluta al backend. */
+export const photoSrc = (path: string): string =>
+  path.startsWith("http") ? path : `${BASE_URL}${path}`;
+
+/**
+ * POST /api/v1/lands/:landId/photos — sube una foto (multipart).
+ * No usa `request()` porque este envía JSON; aquí va `FormData`, cuyo
+ * `Content-Type` (con boundary) debe fijar el navegador, no nosotros.
+ */
+export const uploadLandPhoto = async (
+  landId: string,
+  file: File,
+): Promise<{ url: string; photos: string[] }> => {
+  const headers = await buildHeaders();
+  delete headers["Content-Type"]; // deja que el navegador ponga el boundary
+  const fd = new FormData();
+  fd.append("file", file);
+  const res = await fetch(`${BASE_URL}/api/v1/lands/${landId}/photos`, {
+    method: "POST",
+    headers,
+    body: fd,
+  });
+  const body = (await handleResponse(res)) as ApiSuccess<{ url: string; photos: string[] }>;
+  return body.data;
+};
+
+/** DELETE /api/v1/lands/:landId/photos/:fileId — quita una foto. */
+export const deleteLandPhoto = async (
+  landId: string,
+  fileId: string,
+): Promise<{ photos: string[] }> => {
+  const res = await request<{ photos: string[] }>(
+    "DELETE",
+    `/api/v1/lands/${landId}/photos/${fileId}`,
+  );
+  return res.data;
+};
+
 // ─── Favorites (#147) ─────────────────────────────────────────────────────────
 
 /** GET /api/v1/users/me/favorites — terrenos guardados por el usuario. */

--- a/packages/shared/src/dto/lands.ts
+++ b/packages/shared/src/dto/lands.ts
@@ -42,6 +42,8 @@ export interface LandDto {
   description?: string;
   area: number;
   allowedUses: LandUse[];
+  /** URLs relativas de las fotos; la primera es la portada (#148). */
+  photos?: string[];
   location: LandLocationDto;
   availability: LandAvailabilityDto;
   priceRule: LandPriceRuleDto;


### PR DESCRIPTION
## Resumen

Implementa **#148 — Fotos de terrenos: subida, almacenamiento y galería** de punta a punta. Antes todas las fotos eran placeholders porque `LandDto` no exponía imágenes y no existía almacenamiento de archivos.

Almacenamiento elegido: **MongoDB GridFS** (autocontenido, sin cuentas externas, testeable en CI). Migrar a S3/Cloudinary después es un cambio aislado a `lib/land-photos.ts`.

## Cambios

**Backend**
- `lib/land-photos.ts`: guarda/lee/borra binarios en GridFS (bucket `landPhotos`).
- `POST /lands/:id/photos` (multipart, campo `file`): valida tipo (jpeg/png/webp), tamaño (≤5 MB) y máximo 10 fotos; solo dueño/admin. Añade la URL a `Land.photos` (la primera es la portada).
- `GET /lands/:id/photos/:fileId`: sirve el binario (público, `Cache-Control` inmutable, `Cross-Origin-Resource-Policy: cross-origin` para poder embeberse desde la web en otro origen).
- `DELETE /lands/:id/photos/:fileId`: quita la foto y su referencia.

**Contratos** — `@terrashare/shared`: `photos?: string[]` en `LandDto`.

**Web**
- `services/api`: `uploadLandPhoto`, `deleteLandPhoto` y helper `photoSrc` (URL relativa → absoluta al backend).
- `PublishLandPage` (paso 4): subida real — drag & drop / selector, previews, reordenar portada, quitar; sube las fotos tras crear el terreno.
- `LandDetailPage`: galería real (principal + 2 secundarias) con fallback a placeholder.
- Cards de **catálogo**, **home** y **landing**: foto de portada real.

## Pruebas / verificación
- Backend **293/293** verde; nuevo test cubre subida, servido del binario, borrado, 403 (ajeno), 400 (tipo inválido) y 404 (inexistente). Typecheck backend + web OK.
- **E2E manual contra MongoDB real**: crear terreno → subir foto (GridFS) → servir binario (`image/png`, `CORP: cross-origin`) → **galería del detalle renderiza la imagen** (verificado en navegador, sin errores de consola) → limpieza de datos de prueba.

## Notas
- No usa binarios ni dependencias nuevas (GridFS viene con el driver de mongo).
- Corrige de paso el `Cross-Origin-Resource-Policy: same-origin` global, que habría bloqueado las imágenes al servirse desde otro origen que la web.

Closes #148