### PR TITLE
feat(mcp): tool create_land para publicar terrenos (HU-65 #182)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -105,6 +105,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | Tool | HU | Issue | Estado |
 |------|-----|-------|--------|
 | `search_lands` | HU-63 | #180 | ✅ implementada |
+| `create_land` | HU-65 | #182 | ✅ implementada |
 | `create_payment_session` | HU-77 | #194 | ✅ implementada |
 | `refund_payment` | HU-80 | #197 | ✅ implementada |
 
@@ -115,6 +116,22 @@ Ejemplo de argumentos:
 
 ```json
 { "province": "Chiriqui", "use": "agricultura", "priceMax": 1000, "pageSize": 10 }
+```
+
+`create_land` (`requires: user`): crea un terreno en `draft` a nombre del dueño
+autenticado (`MCP_ACTING_USER_ID`). Valida con el mismo `CreateLandSchema`
+compartido que la API REST y registra un evento de auditoría.
+
+Ejemplo de argumentos:
+
+```json
+{
+  "title": "Finca agrícola en Boquete",
+  "area": 12000,
+  "allowedUses": ["agricultura"],
+  "location": { "province": "Chiriqui", "district": "Boquete" },
+  "priceRule": { "currency": "USD", "pricePerMonth": 750 }
+}
 ```
 
 `create_payment_session` (`requires: user`): genera un enlace de pago

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -19,7 +19,7 @@ async function connectedClient(actingUser: ActingUser | null = null): Promise<Cl
   return client;
 }
 
-/** Arrendatario de rr_e2e (user_regular). */
+/** Usuario normal (rol `user`, activo) — dueño/arrendatario según la tool. */
 const TENANT_USER: ActingUser = {
   id: "user_regular",
   clerkUserId: "user_regular",
@@ -84,6 +84,65 @@ describe("MCP server E2E (#234)", () => {
     const client = await connectedClient();
     const res = await client.callTool({ name: "search_lands", arguments: { pageSize: 9999 } });
     // El SDK marca isError cuando la validación de entrada falla.
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("la lista de tools incluye create_land (HU-65 #182)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("create_land");
+    await client.close();
+  });
+
+  it("create_land crea un terreno en draft a nombre del usuario que actúa", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({
+      name: "create_land",
+      arguments: {
+        title: "Finca de prueba E2E",
+        area: 5000,
+        allowedUses: ["agricultura"],
+        location: { province: "Cocle", district: "Penonome" },
+        priceRule: { currency: "USD", pricePerMonth: 600 },
+      },
+    });
+    const land = res.structuredContent as { id: string; ownerId: string; status: string };
+    expect(res.isError).toBeFalsy();
+    expect(land.id).toMatch(/^land_/);
+    expect(land.ownerId).toBe("user_regular");
+    expect(land.status).toBe("draft");
+    await client.close();
+  });
+
+  it("create_land sin identidad configurada devuelve error (requires user)", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({
+      name: "create_land",
+      arguments: {
+        title: "No debería crearse",
+        area: 5000,
+        allowedUses: ["agricultura"],
+        location: { province: "Cocle", district: "Penonome" },
+        priceRule: { currency: "USD", pricePerMonth: 600 },
+      },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("create_land valida la entrada (título corto -> error)", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({
+      name: "create_land",
+      arguments: {
+        title: "ab",
+        area: 5000,
+        allowedUses: ["agricultura"],
+        location: { province: "Cocle", district: "Penonome" },
+        priceRule: { currency: "USD", pricePerMonth: 600 },
+      },
+    });
     expect(res.isError).toBe(true);
     await client.close();
   });

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { config } from "./config";
 import type { ToolContext } from "./context";
 import { registerTool } from "./tools/define-tool";
+import { createLandTool } from "./tools/create-land";
 import { createPaymentSessionTool } from "./tools/create-payment-session";
 import { refundPaymentTool } from "./tools/refund-payment";
 import { searchLandsTool } from "./tools/search-lands";
@@ -15,6 +16,7 @@ import { searchLandsTool } from "./tools/search-lands";
  */
 const TOOLS = [
   searchLandsTool,
+  createLandTool,
   createPaymentSessionTool,
   refundPaymentTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
@@ -26,8 +28,9 @@ export function createServer(ctx: ToolContext): McpServer {
     {
       instructions:
         "Servidor MCP de TerraShare: expone el dominio de terrenos/alquileres. " +
-        "Usa search_lands para buscar publicaciones activas y create_payment_session " +
-        "para generar un enlace de pago de una solicitud pagable.",
+        "Usa search_lands para buscar publicaciones activas; hay tools adicionales " +
+        "para publicar terrenos, solicitar alquileres, generar contratos, pagos, " +
+        "reembolsos y moderación (según el rol del usuario).",
     },
   );
 

--- a/apps/mcp-server/src/tools/create-land.test.ts
+++ b/apps/mcp-server/src/tools/create-land.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+
+import { AuditEvent, Land } from "@backend/db/schemas";
+import { createLand } from "./create-land";
+
+const OWNER = "user_regular";
+
+/** Entrada válida mínima; se puede sobreescribir por caso. */
+function validInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: "Finca agrícola en Boquete",
+    area: 12000,
+    allowedUses: ["agricultura"],
+    location: { province: "Chiriqui", district: "Boquete" },
+    priceRule: { currency: "USD", pricePerMonth: 750 },
+    ...overrides,
+  };
+}
+
+describe("create_land tool (HU-65 #182)", () => {
+  it("crea un terreno en draft a nombre del usuario que actúa", async () => {
+    const land = await createLand(validInput(), OWNER);
+
+    expect(land.id).toMatch(/^land_/);
+    expect(land.ownerId).toBe(OWNER);
+    expect(land.status).toBe("draft");
+    expect(land.title).toBe("Finca agrícola en Boquete");
+  });
+
+  it("persiste el terreno en Mongo (recuperable por id)", async () => {
+    const land = await createLand(validInput(), OWNER);
+
+    const stored = await Land.findOne({ id: land.id }).lean();
+    expect(stored).not.toBeNull();
+    expect((stored as { status: string }).status).toBe("draft");
+    expect((stored as { ownerId: string }).ownerId).toBe(OWNER);
+  });
+
+  it("aplica los valores por defecto (operation, photos, features, availability)", async () => {
+    const land = await createLand(validInput(), OWNER);
+
+    expect(land.operation).toBe("alquiler");
+    expect(land.photos).toEqual([]);
+    expect(land.features).toEqual([]);
+    expect(land.availability).toEqual({});
+  });
+
+  it("respeta operation/salePrice/water/access/features cuando se proveen", async () => {
+    const land = await createLand(
+      validInput({
+        operation: "venta",
+        salePrice: 90000,
+        water: "pozo",
+        access: "carretera",
+        features: ["cercado", "luz"],
+      }),
+      OWNER,
+    );
+
+    expect(land.operation).toBe("venta");
+    expect(land.salePrice).toBe(90000);
+    expect(land.water).toBe("pozo");
+    expect(land.access).toBe("carretera");
+    expect(land.features).toEqual(["cercado", "luz"]);
+  });
+
+  it("fija timestamps ISO createdAt === updatedAt en la creación", async () => {
+    const land = await createLand(validInput(), OWNER);
+
+    expect(land.createdAt).toBe(land.updatedAt);
+    expect(() => new Date(land.createdAt).toISOString()).not.toThrow();
+  });
+
+  it("registra un evento de auditoría (entity: land, action: created)", async () => {
+    const land = await createLand(validInput(), OWNER);
+
+    const audit = await AuditEvent.findOne({ entityId: land.id }).lean();
+    expect(audit).not.toBeNull();
+    expect((audit as { entity: string }).entity).toBe("land");
+    expect((audit as { action: string }).action).toBe("created");
+    expect((audit as { actorId: string }).actorId).toBe(OWNER);
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const land = await createLand(validInput(), OWNER);
+
+    expect("_id" in land).toBe(false);
+    expect("__v" in land).toBe(false);
+  });
+
+  it("rechaza título demasiado corto", async () => {
+    await expect(createLand(validInput({ title: "ab" }), OWNER)).rejects.toThrow();
+  });
+
+  it("rechaza área no positiva", async () => {
+    await expect(createLand(validInput({ area: 0 }), OWNER)).rejects.toThrow();
+  });
+
+  it("rechaza cuando no hay usos permitidos", async () => {
+    await expect(createLand(validInput({ allowedUses: [] }), OWNER)).rejects.toThrow();
+  });
+
+  it("rechaza un uso permitido inválido", async () => {
+    await expect(
+      createLand(validInput({ allowedUses: ["mineria"] }), OWNER),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza ubicación sin provincia/distrito", async () => {
+    await expect(
+      createLand(validInput({ location: { province: "", district: "" } }), OWNER),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza precio mensual no positivo", async () => {
+    await expect(
+      createLand(validInput({ priceRule: { currency: "USD", pricePerMonth: 0 } }), OWNER),
+    ).rejects.toThrow();
+  });
+
+  it("no crea nada en Mongo si la validación falla", async () => {
+    const before = await Land.countDocuments({});
+    await expect(createLand(validInput({ title: "x" }), OWNER)).rejects.toThrow();
+    const after = await Land.countDocuments({});
+    expect(after).toBe(before);
+  });
+});

--- a/apps/mcp-server/src/tools/create-land.ts
+++ b/apps/mcp-server/src/tools/create-land.ts
@@ -1,0 +1,102 @@
+import type { ZodRawShape } from "zod";
+import { CreateLandSchema } from "@terrashare/shared";
+
+import { Land } from "@backend/db/schemas";
+import { createAuditEvent } from "@backend/store/audit";
+import type { ActingUser } from "../context";
+import type { ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-65 (#182): Publicar un terreno. Espeja `POST /lands` del backend:
+ * valida con el MISMO schema compartido, crea el terreno en `draft` a nombre del
+ * usuario que actúa y registra el evento de auditoría — sin duplicar reglas.
+ */
+
+// Reusa el shape del schema compartido como `inputSchema` del SDK MCP: una sola
+// fuente de verdad para los campos y sus validaciones (título ≥3, área >0, ≥1
+// uso, location, priceRule, y opcionales operation/salePrice/water/access/…).
+//
+// `@terrashare/shared` resuelve su propia copia de Zod v4 (distinta minor a la
+// del mcp-server); son compatibles en runtime, pero sus tipos nominales no
+// coinciden. Adaptamos el shape al `ZodRawShape` del Zod local para el SDK; la
+// validación real la sigue haciendo `CreateLandSchema.parse` en `createLand`.
+export const createLandInput = CreateLandSchema.shape as unknown as ZodRawShape;
+
+/** Terreno tal como se persiste (sin los campos internos de Mongo). */
+export interface CreatedLand {
+  id: string;
+  ownerId: string;
+  title: string;
+  description?: string;
+  area: number;
+  allowedUses: string[];
+  photos: string[];
+  location: Record<string, unknown>;
+  availability: Record<string, unknown>;
+  priceRule: { currency: string; pricePerMonth: number };
+  status: "draft";
+  operation: string;
+  salePrice?: number;
+  water?: string;
+  access?: string;
+  features: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Lógica pura (testeable de forma aislada): valida la entrada, construye el
+ * terreno igual que el endpoint REST y lo persiste. `ownerId` es el usuario que
+ * actúa (garantizado por `requires: "user"` en la tool).
+ */
+export async function createLand(rawInput: unknown, ownerId: string): Promise<CreatedLand> {
+  const data = CreateLandSchema.parse(rawInput ?? {});
+
+  const now = new Date().toISOString();
+  const land: CreatedLand = {
+    id: `land_${crypto.randomUUID()}`,
+    ownerId,
+    title: data.title,
+    description: data.description,
+    area: data.area,
+    allowedUses: data.allowedUses,
+    photos: [],
+    location: data.location,
+    availability: data.availability ?? {},
+    priceRule: data.priceRule,
+    status: "draft",
+    operation: data.operation ?? "alquiler",
+    salePrice: data.salePrice,
+    water: data.water,
+    access: data.access,
+    features: data.features ?? [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await Land.create(land);
+
+  // Misma auditoría que la API REST (entity: land, action: created).
+  await createAuditEvent({
+    actor: { id: ownerId, role: "user" },
+    entity: "land",
+    action: "created",
+    entityId: land.id,
+  });
+
+  return land;
+}
+
+/**
+ * Definición de la tool. `requires: "user"` → necesita identidad configurada
+ * (MCP_ACTING_USER_ID); el terreno queda a nombre de ese usuario.
+ */
+export const createLandTool: ToolDefinition<typeof createLandInput> = {
+  name: "create_land",
+  title: "Publicar un terreno",
+  description:
+    "Crea un terreno en borrador (draft) a nombre del dueño autenticado. Valida los campos requeridos (título, área, usos, ubicación y precio) antes de crear. Devuelve el terreno creado.",
+  inputSchema: createLandInput,
+  requires: "user",
+  handler: (args, ctx) => createLand(args, (ctx.actingUser as ActingUser).id),
+};


### PR DESCRIPTION
## Qué

Implementa la tool MCP **`create_land`** (HU-65), que permite a un dueño —vía agente— publicar un terreno de punta a punta.

## Comportamiento

- **`requires: user`**: exige identidad configurada (`MCP_ACTING_USER_ID`); el terreno queda a nombre de ese usuario. El andamiaje `registerTool` aplica la puerta automáticamente.
- Espeja `POST /lands` del backend: crea el terreno en **`draft`**, genera `land_<uuid>`, fija `ownerId` = usuario que actúa, aplica defaults (`operation: alquiler`, `photos/features: []`, `availability: {}`) y registra un **evento de auditoría** (`entity: land, action: created`).
- Devuelve el terreno creado, sin campos internos de Mongo.

## Reutilización (sin duplicar lógica)

- **Validación:** el mismo `CreateLandSchema` de `@terrashare/shared` que usa la API REST es la única fuente de verdad (parseo en la función pura `createLand`).
- **Modelo** `Land` y **auditoría** `createAuditEvent` del backend.
- Nota técnica: `@terrashare/shared` resuelve una minor de Zod v4 distinta a la del mcp-server; son compatibles en runtime pero sus tipos nominales no, así que el shape del `inputSchema` se adapta al Zod local (comentado en el código).

## Tests

- **14 unitarios** (`create-land.test.ts`): creación en draft, persistencia, defaults, campos opcionales, timestamps, auditoría, sin `_id/__v`, y validaciones (título corto, área 0, sin usos, uso inválido, ubicación vacía, precio 0, no-persistencia si falla).
- **4 e2e** (`server.e2e.test.ts`) vía cliente MCP real: listado incluye `create_land`, creación end-to-end, puerta de permisos sin identidad, y validación de entrada.

`bun test` → 42 pass / 0 fail · `bun run typecheck` limpio.

Closes #182