### PR TITLE
feat(mcp): implement get_land tool (HU-64 #181)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -105,14 +105,26 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | Tool | HU | Issue | Estado |
 |------|-----|-------|--------|
 | `search_lands` | HU-63 | #180 | ✅ implementada |
+| `get_land` | HU-64 | #181 | ✅ implementada |
 
-`search_lands`: busca terrenos publicados (activos) con filtros por texto,
-ubicación, uso, operación y precio; devuelve resultados paginados.
+### search_lands
+Busca terrenos publicados (activos) con filtros por texto, ubicación, uso,
+operación y precio; devuelve resultados paginados.
 
 Ejemplo de argumentos:
 
 ```json
 { "province": "Chiriqui", "use": "agricultura", "priceMax": 1000, "pageSize": 10 }
+```
+
+### get_land
+Obtiene la ficha completa de un terreno por su ID, incluyendo ubicación, área,
+usos permitidos, precio y disponibilidad.
+
+Ejemplo de argumentos:
+
+```json
+{ "landId": "land_a" }
 ```
 
 ## Tests

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -41,4 +41,28 @@ describe("MCP server E2E (#234)", () => {
     expect(res.isError).toBe(true);
     await client.close();
   });
+
+  it("un cliente MCP lista las tools e incluye get_land", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("get_land");
+    await client.close();
+  });
+
+  it("llamar get_land devuelve un terreno por ID", async () => {
+    const client = await connectedClient();
+    const res = await client.callTool({ name: "get_land", arguments: { landId: "land_a" } });
+    const structured = res.structuredContent as { id: string; title: string };
+    expect(structured.id).toBe("land_a");
+    expect(structured.title).toBe("Finca agrícola en Chiriquí");
+    await client.close();
+  });
+
+  it("get_land devuelve error para terreno inexistente", async () => {
+    const client = await connectedClient();
+    const res = await client.callTool({ name: "get_land", arguments: { landId: "nonexistent" } });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
 });

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,8 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
 
 import { config } from "./config";
 import type { ToolContext } from "./context";
-import { registerTool } from "./tools/define-tool";
+import { registerTool, type ToolDefinition } from "./tools/define-tool";
+import { getLandTool } from "./tools/get-land";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -11,8 +13,9 @@ import { searchLandsTool } from "./tools/search-lands";
  * Para añadir una tool (HU-64..HU-92): impórtala aquí y añádela al array `TOOLS`.
  * Ver `src/tools/_template.ts` y el README para el patrón.
  */
-const TOOLS = [
+const TOOLS: ToolDefinition<ZodRawShape>[] = [
   searchLandsTool,
+  getLandTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/get-land.test.ts
+++ b/apps/mcp-server/src/tools/get-land.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+
+import { getLand } from "./get-land";
+
+describe("get_land tool (HU-64 #181)", () => {
+  it("devuelve un terreno existente por ID", async () => {
+    const result = await getLand({ landId: "land_a" });
+    expect(result).toBeDefined();
+    expect((result as { id: string }).id).toBe("land_a");
+    expect((result as { title: string }).title).toBe("Finca agrícola en Chiriquí");
+    expect((result as { location: { province: string } }).location.province).toBe("Chiriqui");
+  });
+
+  it("devuelve todos los campos esperados", async () => {
+    const result = await getLand({ landId: "land_a" });
+    const land = result as Record<string, unknown>;
+    expect(land).toHaveProperty("id");
+    expect(land).toHaveProperty("ownerId");
+    expect(land).toHaveProperty("title");
+    expect(land).toHaveProperty("area");
+    expect(land).toHaveProperty("allowedUses");
+    expect(land).toHaveProperty("location");
+    expect(land).toHaveProperty("priceRule");
+    expect(land).toHaveProperty("status");
+    expect(land).toHaveProperty("operation");
+  });
+
+  it("lanza error cuando el terreno no existe", async () => {
+    await expect(getLand({ landId: "nonexistent" })).rejects.toThrow("Terreno no encontrado");
+  });
+
+  it("lanza error cuando landId está vacío", async () => {
+    await expect(getLand({ landId: "" })).rejects.toThrow();
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const result = await getLand({ landId: "land_a" });
+    const land = result as Record<string, unknown>;
+    expect(land).not.toHaveProperty("_id");
+    expect(land).not.toHaveProperty("__v");
+  });
+
+  it("devuelve terreno inactivo (sin filtro de status)", async () => {
+    const result = await getLand({ landId: "land_inactive" });
+    expect(result).toBeDefined();
+    expect((result as { id: string }).id).toBe("land_inactive");
+    expect((result as { status: string }).status).toBe("inactive");
+  });
+});

--- a/apps/mcp-server/src/tools/get-land.test.ts
+++ b/apps/mcp-server/src/tools/get-land.test.ts
@@ -40,10 +40,7 @@ describe("get_land tool (HU-64 #181)", () => {
     expect(land).not.toHaveProperty("__v");
   });
 
-  it("devuelve terreno inactivo (sin filtro de status)", async () => {
-    const result = await getLand({ landId: "land_inactive" });
-    expect(result).toBeDefined();
-    expect((result as { id: string }).id).toBe("land_inactive");
-    expect((result as { status: string }).status).toBe("inactive");
+  it("lanza error cuando el terreno está inactivo", async () => {
+    await expect(getLand({ landId: "land_inactive" })).rejects.toThrow("Terreno no encontrado");
   });
 });

--- a/apps/mcp-server/src/tools/get-land.ts
+++ b/apps/mcp-server/src/tools/get-land.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+import { Land } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-64 (#181): Obtener detalle de terreno. Devuelve la ficha completa
+ * de un terreno por su ID, incluyendo ubicación, área, usos, precio y
+ * disponibilidad.
+ */
+
+export const getLandInput = {
+  landId: z.string().min(1).describe("ID del terreno a consultar"),
+};
+
+export type GetLandInput = z.infer<z.ZodObject<typeof getLandInput>>;
+
+/**
+ * Función pura de búsqueda (testeable de forma aislada). Busca un terreno
+ * por ID y devuelve sus datos completos.
+ */
+export async function getLand(rawInput: unknown): Promise<Record<string, unknown>> {
+  const input = z.object(getLandInput).parse(rawInput);
+
+  const land = await Land.findOne({ id: input.landId }).lean();
+  if (!land) throw new ToolError("Terreno no encontrado");
+
+  const { _id, __v, ...rest } = land as unknown as Record<string, unknown>;
+  return rest;
+}
+
+/**
+ * Definición de la tool. Pública (no requiere identidad): cualquier
+ * usuario puede consultar terrenos publicados.
+ */
+export const getLandTool: ToolDefinition<typeof getLandInput> = {
+  name: "get_land",
+  title: "Obtener terreno",
+  description:
+    "Obtiene la ficha completa de un terreno por su ID, incluyendo ubicación, área, usos permitidos, precio y disponibilidad.",
+  inputSchema: getLandInput,
+  requires: "public",
+  handler: (args) => getLand(args),
+};

--- a/apps/mcp-server/src/tools/get-land.ts
+++ b/apps/mcp-server/src/tools/get-land.ts
@@ -23,7 +23,7 @@ export async function getLand(rawInput: unknown): Promise<Record<string, unknown
   const input = z.object(getLandInput).parse(rawInput);
 
   const land = await Land.findOne({ id: input.landId }).lean();
-  if (!land) throw new ToolError("Terreno no encontrado");
+  if (!land || land.status === "inactive") throw new ToolError("Terreno no encontrado");
 
   const { _id, __v, ...rest } = land as unknown as Record<string, unknown>;
   return rest;


### PR DESCRIPTION
## What was implemented

- **Tool get_land**: Retrieves full land details by ID, including location, area, allowed uses, price, and availability
- **Unit tests**: 6 tests covering successful retrieval, field validation, error handling, and Mongo field exclusion
- **E2E tests**: 3 tests verifying tool registration, successful call, and error handling through MCP protocol
- **Registration**: Tool registered in server.ts TOOLS array
- **Documentation**: README.md updated with tool description and example

## Technical details

- Input: landId (string, required)
- Access: public (no authentication required)
- Uses Land.findOne() from @backend/db/schemas
- Strips internal Mongo fields (_id, __v)
- Returns ToolError for non-existent lands

## Verification

- All 33 MCP server tests pass
- TypeScript typecheck passes
- E2E tests verify tool works through MCP protocol

Closes #181