### PR TITLE
feat(mcp): tool create_rental_request para solicitar terrenos (HU-70 #187)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -106,6 +106,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 |------|-----|-------|--------|
 | `search_lands` | HU-63 | #180 | ✅ implementada |
 | `create_land` | HU-65 | #182 | ✅ implementada |
+| `create_rental_request` | HU-70 | #187 | ✅ implementada |
 | `create_payment_session` | HU-77 | #194 | ✅ implementada |
 | `refund_payment` | HU-80 | #197 | ✅ implementada |
 
@@ -131,6 +132,22 @@ Ejemplo de argumentos:
   "allowedUses": ["agricultura"],
   "location": { "province": "Chiriqui", "district": "Boquete" },
   "priceRule": { "currency": "USD", "pricePerMonth": 750 }
+}
+```
+
+`create_rental_request` (`requires: user`): crea una solicitud de alquiler (o de
+compra) sobre un terreno, a nombre del arrendatario autenticado. Reusa el
+`CreateRentalRequestSchema` compartido, aplica las reglas de negocio (dueño no
+puede solicitar su propio terreno, operación/uso permitidos, solapamiento de
+período) y crea en estado `pending_owner`.
+
+Ejemplo de argumentos (alquiler):
+
+```json
+{
+  "landId": "land_a",
+  "period": { "startDate": "2026-08-01", "endDate": "2026-12-01" },
+  "intendedUse": "agricultura"
 }
 ```
 

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -147,6 +147,45 @@ describe("MCP server E2E (#234)", () => {
     await client.close();
   });
 
+  it("la lista de tools incluye create_rental_request (HU-70 #187)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("create_rental_request");
+    await client.close();
+  });
+
+  it("create_rental_request crea una solicitud en pending_owner", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({
+      name: "create_rental_request",
+      arguments: {
+        landId: "land_a",
+        period: { startDate: "2026-08-01", endDate: "2026-12-01" },
+        intendedUse: "agricultura",
+      },
+    });
+    const rr = res.structuredContent as { id: string; tenantId: string; status: string };
+    expect(res.isError).toBeFalsy();
+    expect(rr.id).toMatch(/^rr_/);
+    expect(rr.tenantId).toBe("user_regular");
+    expect(rr.status).toBe("pending_owner");
+    await client.close();
+  });
+
+  it("create_rental_request sin identidad configurada devuelve error (requires user)", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({
+      name: "create_rental_request",
+      arguments: {
+        landId: "land_a",
+        period: { startDate: "2026-08-01", endDate: "2026-12-01" },
+        intendedUse: "agricultura",
+      },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
   it("la lista de tools incluye create_payment_session (HU-77 #194)", async () => {
     const client = await connectedClient();
     const { tools } = await client.listTools();

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -4,6 +4,7 @@ import { config } from "./config";
 import type { ToolContext } from "./context";
 import { registerTool } from "./tools/define-tool";
 import { createLandTool } from "./tools/create-land";
+import { createRentalRequestTool } from "./tools/create-rental-request";
 import { createPaymentSessionTool } from "./tools/create-payment-session";
 import { refundPaymentTool } from "./tools/refund-payment";
 import { searchLandsTool } from "./tools/search-lands";
@@ -17,6 +18,7 @@ import { searchLandsTool } from "./tools/search-lands";
 const TOOLS = [
   searchLandsTool,
   createLandTool,
+  createRentalRequestTool,
   createPaymentSessionTool,
   refundPaymentTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.

--- a/apps/mcp-server/src/tools/create-rental-request.test.ts
+++ b/apps/mcp-server/src/tools/create-rental-request.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import mongoose from "@backend/db/mongoose";
+import { AuditEvent, RentalRequest } from "@backend/db/schemas";
+import { createRentalRequest } from "./create-rental-request";
+
+const TENANT = "user_regular";
+
+/**
+ * Siembra una solicitud pre-existente con el driver nativo (como el preload del
+ * backend). Un `Model.create` de Mongoose desde el cuerpo del test se traba con
+ * bun:test + mongodb-memory-server y cuelga la siguiente lectura.
+ */
+async function seedRental(doc: Record<string, unknown>): Promise<void> {
+  await mongoose.connection.db!.collection("rentalrequests").insertOne({
+    landId: "land_a",
+    tenantId: "user_other",
+    operation: "alquiler",
+    status: "approved",
+    ...doc,
+  });
+}
+
+/** Entrada de alquiler válida por defecto (land_a admite 'agricultura'). */
+function rentalInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    landId: "land_a",
+    period: { startDate: "2026-08-01", endDate: "2026-12-01" },
+    intendedUse: "agricultura",
+    ...overrides,
+  };
+}
+
+// El preload no limpia RentalRequest/AuditEvent entre tests → aislamos aquí.
+beforeEach(async () => {
+  await RentalRequest.deleteMany({});
+  await AuditEvent.deleteMany({});
+});
+
+describe("create_rental_request tool (HU-70 #187)", () => {
+  it("crea una solicitud de alquiler en pending_owner a nombre del arrendatario", async () => {
+    const rr = await createRentalRequest(rentalInput(), TENANT);
+
+    expect(rr.id).toMatch(/^rr_/);
+    expect(rr.tenantId).toBe(TENANT);
+    expect(rr.operation).toBe("alquiler");
+    expect(rr.status).toBe("pending_owner");
+    expect(rr.period).toEqual({ startDate: "2026-08-01", endDate: "2026-12-01" });
+    expect(rr.intendedUse).toBe("agricultura");
+  });
+
+  it("persiste la solicitud en Mongo (recuperable por id)", async () => {
+    const rr = await createRentalRequest(rentalInput(), TENANT);
+    const stored = await RentalRequest.findOne({ id: rr.id }).lean();
+    expect(stored).not.toBeNull();
+    expect((stored as { status: string }).status).toBe("pending_owner");
+  });
+
+  it("crea una solicitud de compra (venta) con offerAmount", async () => {
+    const rr = await createRentalRequest(
+      { landId: "land_b", operation: "venta", offerAmount: 90000 },
+      TENANT,
+    );
+    expect(rr.operation).toBe("venta");
+    expect(rr.offerAmount).toBe(90000);
+    expect(rr.status).toBe("pending_owner");
+    expect(rr.period).toBeUndefined();
+  });
+
+  it("registra un evento de auditoría (entity: rental_request, action: created)", async () => {
+    const rr = await createRentalRequest(rentalInput(), TENANT);
+    const audit = await AuditEvent.findOne({ entityId: rr.id }).lean();
+    expect(audit).not.toBeNull();
+    expect((audit as { entity: string }).entity).toBe("rental_request");
+    expect((audit as { action: string }).action).toBe("created");
+    expect((audit as { actorId: string }).actorId).toBe(TENANT);
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const rr = await createRentalRequest(rentalInput(), TENANT);
+    expect("_id" in rr).toBe(false);
+    expect("__v" in rr).toBe(false);
+  });
+
+  it("bloquea si el solicitante es el dueño del terreno", async () => {
+    // land_a lo posee "user_seed"; si ese mismo usuario solicita, se bloquea.
+    await expect(
+      createRentalRequest(rentalInput({ landId: "land_a" }), "user_seed"),
+    ).rejects.toThrow(/dueño/i);
+  });
+
+  it("falla si el terreno no existe", async () => {
+    await expect(
+      createRentalRequest(rentalInput({ landId: "land_inexistente" }), TENANT),
+    ).rejects.toThrow(/no encontrado/i);
+  });
+
+  it("rechaza una operación no admitida por el terreno (venta sobre terreno de alquiler)", async () => {
+    await expect(
+      createRentalRequest({ landId: "land_a", operation: "venta", offerAmount: 1000 }, TENANT),
+    ).rejects.toThrow(/no admite la operación/i);
+  });
+
+  it("rechaza un uso no permitido por el terreno", async () => {
+    await expect(
+      createRentalRequest(rentalInput({ intendedUse: "ganaderia" }), TENANT),
+    ).rejects.toThrow(/no está permitido/i);
+  });
+
+  // Nota: el terreno con una solicitud aprobada pre-existente se siembra en un
+  // beforeEach (no en el cuerpo del test). Un write desde el cuerpo del test,
+  // seguido de la lectura de la tool, se traba con bun:test + mongodb-memory-server;
+  // sembrar en el hook (como hace el preload del backend) lo evita.
+  describe("con una solicitud aprobada pre-existente en land_a (2026-09-01..10-01)", () => {
+    beforeEach(async () => {
+      await seedRental({
+        id: "rr_existing",
+        period: { startDate: "2026-09-01", endDate: "2026-10-01" },
+      });
+    });
+
+    it("bloquea un período que solapa", async () => {
+      await expect(
+        createRentalRequest(rentalInput({ period: { startDate: "2026-08-01", endDate: "2026-12-01" } }), TENANT),
+      ).rejects.toThrow(/solapa/i);
+    });
+
+    it("permite un período que no solapa (posterior)", async () => {
+      const rr = await createRentalRequest(
+        rentalInput({ period: { startDate: "2026-11-01", endDate: "2026-12-01" } }),
+        TENANT,
+      );
+      expect(rr.status).toBe("pending_owner");
+    });
+  });
+
+  it("rechaza alquiler sin período (validación del schema)", async () => {
+    await expect(
+      createRentalRequest({ landId: "land_a", intendedUse: "agricultura" }, TENANT),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza alquiler sin intendedUse (validación del schema)", async () => {
+    await expect(
+      createRentalRequest(
+        { landId: "land_a", period: { startDate: "2026-08-01", endDate: "2026-12-01" } },
+        TENANT,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza un período con fin anterior o igual al inicio", async () => {
+    await expect(
+      createRentalRequest(
+        rentalInput({ period: { startDate: "2026-12-01", endDate: "2026-08-01" } }),
+        TENANT,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza venta sin offerAmount (validación del schema)", async () => {
+    await expect(
+      createRentalRequest({ landId: "land_b", operation: "venta" }, TENANT),
+    ).rejects.toThrow();
+  });
+
+  it("no crea nada en Mongo si la validación falla", async () => {
+    const before = await RentalRequest.countDocuments({});
+    await expect(
+      createRentalRequest({ landId: "land_a" }, TENANT),
+    ).rejects.toThrow();
+    expect(await RentalRequest.countDocuments({})).toBe(before);
+  });
+});

--- a/apps/mcp-server/src/tools/create-rental-request.ts
+++ b/apps/mcp-server/src/tools/create-rental-request.ts
@@ -1,0 +1,179 @@
+import { z, type ZodRawShape } from "zod";
+import { CreateRentalRequestSchema } from "@terrashare/shared";
+
+import { Land, RentalRequest } from "@backend/db/schemas";
+import { createAuditEvent } from "@backend/store/audit";
+import type { ActingUser } from "../context";
+import { canCreateRentalRequest } from "../permissions";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-70 (#187): Crear una solicitud de alquiler (o de compra). Espeja
+ * `POST /rental-requests` del backend: valida forma con el MISMO
+ * `CreateRentalRequestSchema` compartido, aplica las reglas de negocio con la BD
+ * (dueño no puede solicitar su propio terreno, operación/uso permitidos,
+ * solapamiento) y crea la solicitud en `pending_owner` a nombre del arrendatario.
+ */
+
+// El schema compartido es un `ZodEffects` (usa `superRefine`), así que no expone
+// `.shape`. Declaramos aquí el shape que anuncia el SDK MCP (con `.describe()`);
+// la validación REAL —incluidas las reglas condicionales venta/alquiler— la hace
+// `CreateRentalRequestSchema.parse` dentro de la función pura (fuente de verdad).
+// Tipado como `ZodRawShape` (el supertipo común): así `TOOLS` en server.ts
+// colapsa a `ToolDefinition<ZodRawShape>` y `registerTool` infiere el genérico
+// sin ambigüedad frente a otras tools con shapes concretos distintos.
+export const createRentalRequestInput: ZodRawShape = {
+  landId: z.string().min(1).describe("ID del terreno a solicitar"),
+  operation: z
+    .enum(["alquiler", "venta"])
+    .optional()
+    .describe("Tipo de operación (por defecto: alquiler)"),
+  period: z
+    .object({
+      startDate: z.string().describe("Fecha de inicio (ISO)"),
+      endDate: z.string().describe("Fecha de fin (ISO)"),
+    })
+    .optional()
+    .describe("Período del alquiler (requerido para operación 'alquiler')"),
+  intendedUse: z
+    .string()
+    .optional()
+    .describe("Uso propuesto del terreno (requerido para 'alquiler'; debe estar permitido)"),
+  offerAmount: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Monto ofertado (requerido para operación 'venta')"),
+  notes: z.string().optional().describe("Notas opcionales para el dueño"),
+};
+
+/** Solicitud creada (sin campos internos de Mongo). */
+export interface CreatedRentalRequest {
+  id: string;
+  landId: string;
+  tenantId: string;
+  operation: "alquiler" | "venta";
+  period?: { startDate: string; endDate: string };
+  intendedUse?: string;
+  offerAmount?: number;
+  notes?: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Lógica pura (testeable): valida, aplica reglas de negocio y persiste. `tenantId`
+ * es el usuario que actúa (garantizado por `requires: "user"`).
+ */
+export async function createRentalRequest(
+  rawInput: unknown,
+  tenantId: string,
+): Promise<CreatedRentalRequest> {
+  const data = CreateRentalRequestSchema.parse(rawInput ?? {});
+  const operation = data.operation ?? "alquiler";
+
+  const land = await Land.findOne({ id: data.landId }).lean();
+  if (!land) throw new ToolError("Terreno no encontrado");
+
+  // Misma regla que la API REST: el dueño no puede solicitar su propio terreno.
+  if (!canCreateRentalRequest({ id: tenantId } as unknown as ActingUser, land)) {
+    throw new ToolError("El dueño no puede crear una solicitud sobre su propio terreno");
+  }
+
+  // La operación solicitada debe estar admitida por el terreno ("ambas" acepta las dos).
+  const landOperation = (land.operation ?? "alquiler") as string;
+  if (landOperation !== "ambas" && landOperation !== operation) {
+    throw new ToolError(`Este terreno no admite la operación '${operation}'`);
+  }
+
+  const initialStatus = "pending_owner";
+
+  if (operation === "venta") {
+    // El schema garantiza offerAmount presente y > 0 para venta.
+    const record = await RentalRequest.create({
+      id: `rr_${crypto.randomUUID()}`,
+      landId: data.landId,
+      tenantId,
+      operation: "venta",
+      offerAmount: data.offerAmount,
+      notes: data.notes,
+      status: initialStatus,
+    });
+
+    await createAuditEvent({
+      actor: { id: tenantId, role: "user" },
+      entity: "rental_request",
+      action: "created",
+      entityId: record.id,
+      metadata: { landId: data.landId, operation: "venta", offerAmount: data.offerAmount },
+    });
+
+    return clean(record);
+  }
+
+  // ── Alquiler ── (schema garantiza period válido con endDate > startDate e intendedUse)
+  const allowedUses = (land.allowedUses ?? []) as string[];
+  if (allowedUses.length > 0 && data.intendedUse && !allowedUses.includes(data.intendedUse)) {
+    throw new ToolError(`El uso '${data.intendedUse}' no está permitido en este terreno`);
+  }
+
+  const periodStart = Date.parse(data.period!.startDate);
+  const periodEnd = Date.parse(data.period!.endDate);
+
+  // Bloquea si ya existe una solicitud aprobada/pendiente/pagada que solape.
+  const overlapping = await RentalRequest.findOne({
+    landId: data.landId,
+    operation: { $ne: "venta" },
+    status: { $in: ["approved", "pending_payment", "paid"] },
+  }).lean();
+
+  if (overlapping?.period) {
+    const existingStart = Date.parse(overlapping.period.startDate);
+    const existingEnd = Date.parse(overlapping.period.endDate);
+    if (periodStart < existingEnd && periodEnd > existingStart) {
+      throw new ToolError("El terreno ya tiene una solicitud aprobada/pendiente que solapa el período");
+    }
+  }
+
+  const record = await RentalRequest.create({
+    id: `rr_${crypto.randomUUID()}`,
+    landId: data.landId,
+    tenantId,
+    operation: "alquiler",
+    period: { startDate: data.period!.startDate, endDate: data.period!.endDate },
+    intendedUse: data.intendedUse,
+    notes: data.notes,
+    status: initialStatus,
+  });
+
+  await createAuditEvent({
+    actor: { id: tenantId, role: "user" },
+    entity: "rental_request",
+    action: "created",
+    entityId: record.id,
+    metadata: { landId: data.landId, period: record.period },
+  });
+
+  return clean(record);
+}
+
+/** Convierte el doc Mongoose a objeto plano sin `_id`/`__v`. */
+function clean(doc: { toObject: () => Record<string, unknown> }): CreatedRentalRequest {
+  const { _id, __v, ...rest } = doc.toObject();
+  return rest as unknown as CreatedRentalRequest;
+}
+
+/**
+ * Definición de la tool. `requires: "user"` → necesita identidad configurada
+ * (MCP_ACTING_USER_ID); la solicitud queda a nombre de ese usuario (arrendatario).
+ */
+export const createRentalRequestTool: ToolDefinition<typeof createRentalRequestInput> = {
+  name: "create_rental_request",
+  title: "Crear solicitud de alquiler",
+  description:
+    "Crea una solicitud de alquiler (o de compra) sobre un terreno, a nombre del arrendatario autenticado. Valida período y uso, bloquea si el solicitante es el dueño, y devuelve la solicitud creada con estado inicial 'pending_owner'.",
+  inputSchema: createRentalRequestInput,
+  requires: "user",
+  handler: (args, ctx) => createRentalRequest(args, (ctx.actingUser as ActingUser).id),
+};


### PR DESCRIPTION
## Qué

Implementa la tool MCP **`create_rental_request`** (HU-70): un arrendatario, vía agente, crea una solicitud de alquiler (o de compra) sobre un terreno.

## Comportamiento (espeja `POST /rental-requests`)

- **`requires: user`**: la solicitud queda a nombre del arrendatario autenticado (`MCP_ACTING_USER_ID`).
- **Validación de forma** con el mismo `CreateRentalRequestSchema` compartido: `venta` → requiere `offerAmount` (>0); `alquiler` (por defecto) → requiere `period` (fin > inicio) e `intendedUse`.
- **Reglas de negocio con la BD** (reusa `canCreateRentalRequest`):
  - el dueño no puede solicitar su propio terreno;
  - la operación debe estar admitida por el terreno (`ambas` acepta las dos);
  - el `intendedUse` debe estar en `allowedUses`;
  - bloquea si el período **solapa** una solicitud `approved`/`pending_payment`/`paid` existente.
- Crea en estado inicial **`pending_owner`** y registra evento de auditoría (`rental_request/created`). Devuelve la solicitud creada, sin campos internos de Mongo.

## Reutilización (sin duplicar lógica)

- Validación: `CreateRentalRequestSchema` de `@terrashare/shared` (fuente de verdad; `parse` en la función pura).
- Modelos `Land`/`RentalRequest`, helper `canCreateRentalRequest` y `createAuditEvent` del backend.
- Notas técnicas (comentadas en el código): el schema compartido es un `ZodEffects` (sin `.shape`), por lo que el `inputSchema` que anuncia el SDK se declara con el Zod local y la validación real la hace `CreateRentalRequestSchema.parse`; el shape se tipa como `ZodRawShape` para que `TOOLS` unifique en `server.ts`.

## Tests

- **16 unitarios** (`create-rental-request.test.ts`): creación alquiler/venta, persistencia, defaults, auditoría, sin `_id/__v`, dueño bloqueado, terreno inexistente, operación/uso no admitidos, solapamiento (bloquea/permite), y validaciones de schema.
- **e2e** (`server.e2e.test.ts`) vía cliente MCP real: listado incluye la tool, creación `pending_owner`, y puerta de permisos sin identidad.

**Nota de harness (reutilizable):** los datos pre-existentes se siembran en `beforeEach`, no en el cuerpo del test — un write desde el cuerpo del test se traba con `bun:test` + `mongodb-memory-server` y cuelga la siguiente lectura (el mismo patrón que usa el preload del backend).

`bun test` → 43 pass / 0 fail · `bun run typecheck` limpio.

Closes #187