### PR TITLE
feat(mcp): tool create_contract para generar contratos (HU-73 #190)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -107,6 +107,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `search_lands` | HU-63 | #180 | ✅ implementada |
 | `create_land` | HU-65 | #182 | ✅ implementada |
 | `create_rental_request` | HU-70 | #187 | ✅ implementada |
+| `create_contract` | HU-73 | #190 | ✅ implementada |
 | `create_payment_session` | HU-77 | #194 | ✅ implementada |
 | `refund_payment` | HU-80 | #197 | ✅ implementada |
 
@@ -148,6 +149,23 @@ Ejemplo de argumentos (alquiler):
   "landId": "land_a",
   "period": { "startDate": "2026-08-01", "endDate": "2026-12-01" },
   "intendedUse": "agricultura"
+}
+```
+
+`create_contract` (`requires: user`): genera un contrato en `draft` vinculado a
+una solicitud, con términos, fechas y partes. Solo el dueño del terreno (o un
+admin) puede crearlo; reusa `CreateContractSchema` y `canCreateContract`.
+
+Ejemplo de argumentos:
+
+```json
+{
+  "rentalRequestId": "rr_123",
+  "terms": {
+    "summary": "Arrendamiento por 12 meses del terreno.",
+    "startsAt": "2026-08-01",
+    "endsAt": "2027-08-01"
+  }
 }
 ```
 

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -3,7 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 import mongoose from "@backend/db/mongoose";
-import { Payment, RentalRequest } from "@backend/db/schemas";
+import { Contract, Payment, RentalRequest } from "@backend/db/schemas";
 import type { ActingUser } from "./context";
 import { createServer } from "./server";
 
@@ -29,6 +29,16 @@ const TENANT_USER: ActingUser = {
   profile: { fullName: "Usuario Regular" },
 };
 
+/** Dueño de land_a (user_seed), para las tools que requieren ser el dueño. */
+const OWNER_USER: ActingUser = {
+  id: "user_seed",
+  clerkUserId: "user_seed",
+  email: "owner@test.com",
+  role: "user",
+  status: "active",
+  profile: { fullName: "Dueño Seed" },
+};
+
 /** Administrador de prueba (rol admin). */
 const ADMIN_USER: ActingUser = {
   id: "user_admin",
@@ -39,11 +49,12 @@ const ADMIN_USER: ActingUser = {
   profile: { fullName: "Admin de Prueba" },
 };
 
-// El preload no toca RentalRequest/Payment → sembramos en el hook (no en el
-// cuerpo del test) una solicitud pagable y un pago pagado para las tools.
+// El preload no toca RentalRequest/Payment/Contract → sembramos en el hook (no en
+// el cuerpo del test) una solicitud pagable y un pago pagado para las tools.
 beforeEach(async () => {
   await RentalRequest.deleteMany({});
   await Payment.deleteMany({});
+  await Contract.deleteMany({});
   await mongoose.connection.db!.collection("rentalrequests").insertOne({
     id: "rr_e2e",
     landId: "land_a",
@@ -180,6 +191,51 @@ describe("MCP server E2E (#234)", () => {
         landId: "land_a",
         period: { startDate: "2026-08-01", endDate: "2026-12-01" },
         intendedUse: "agricultura",
+      },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("la lista de tools incluye create_contract (HU-73 #190)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("create_contract");
+    await client.close();
+  });
+
+  it("create_contract crea un contrato draft para el dueño", async () => {
+    const client = await connectedClient(OWNER_USER);
+    const res = await client.callTool({
+      name: "create_contract",
+      arguments: {
+        rentalRequestId: "rr_e2e",
+        terms: {
+          summary: "Arrendamiento por 12 meses del terreno.",
+          startsAt: "2026-08-01",
+          endsAt: "2027-08-01",
+        },
+      },
+    });
+    const contract = res.structuredContent as { id: string; status: string; ownerId: string };
+    expect(res.isError).toBeFalsy();
+    expect(contract.id).toMatch(/^contract_/);
+    expect(contract.status).toBe("draft");
+    expect(contract.ownerId).toBe("user_seed");
+    await client.close();
+  });
+
+  it("create_contract sin identidad configurada devuelve error (requires user)", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({
+      name: "create_contract",
+      arguments: {
+        rentalRequestId: "rr_e2e",
+        terms: {
+          summary: "Arrendamiento por 12 meses del terreno.",
+          startsAt: "2026-08-01",
+          endsAt: "2027-08-01",
+        },
       },
     });
     expect(res.isError).toBe(true);

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -5,6 +5,7 @@ import type { ToolContext } from "./context";
 import { registerTool } from "./tools/define-tool";
 import { createLandTool } from "./tools/create-land";
 import { createRentalRequestTool } from "./tools/create-rental-request";
+import { createContractTool } from "./tools/create-contract";
 import { createPaymentSessionTool } from "./tools/create-payment-session";
 import { refundPaymentTool } from "./tools/refund-payment";
 import { searchLandsTool } from "./tools/search-lands";
@@ -19,6 +20,7 @@ const TOOLS = [
   searchLandsTool,
   createLandTool,
   createRentalRequestTool,
+  createContractTool,
   createPaymentSessionTool,
   refundPaymentTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.

--- a/apps/mcp-server/src/tools/create-contract.test.ts
+++ b/apps/mcp-server/src/tools/create-contract.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import mongoose from "@backend/db/mongoose";
+import { AuditEvent, Contract, RentalRequest } from "@backend/db/schemas";
+import { createContract } from "./create-contract";
+
+// land_a lo posee "user_seed" (ver test-preload). Partes del contrato.
+const OWNER = { id: "user_seed", role: "user" as const };
+const ADMIN = { id: "user_admin", role: "admin" as const };
+const OTHER = { id: "user_regular", role: "user" as const };
+
+/** Términos válidos por defecto. */
+function contractInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    rentalRequestId: "rr_seed",
+    terms: {
+      summary: "Arrendamiento por 12 meses del terreno.",
+      startsAt: "2026-08-01",
+      endsAt: "2027-08-01",
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Siembra solicitudes con el driver nativo (en beforeEach, NO en el cuerpo del
+ * test): un write desde el cuerpo del test se traba con bun:test + memory-server
+ * y cuelga la siguiente lectura de la tool.
+ */
+beforeEach(async () => {
+  await RentalRequest.deleteMany({});
+  await Contract.deleteMany({});
+  await AuditEvent.deleteMany({});
+  const rentalreqs = mongoose.connection.db!.collection("rentalrequests");
+  await rentalreqs.insertMany([
+    // Solicitud válida sobre land_a (dueño user_seed), arrendatario user_regular.
+    { id: "rr_seed", landId: "land_a", tenantId: "user_regular", operation: "alquiler", status: "approved" },
+    // Solicitud que apunta a un terreno inexistente.
+    { id: "rr_noland", landId: "land_ghost", tenantId: "user_regular", operation: "alquiler", status: "approved" },
+  ]);
+});
+
+describe("create_contract tool (HU-73 #190)", () => {
+  it("el dueño crea un contrato en draft vinculado a la solicitud y con las partes", async () => {
+    const contract = await createContract(contractInput(), OWNER);
+
+    expect(contract.id).toMatch(/^contract_/);
+    expect(contract.status).toBe("draft");
+    expect(contract.rentalRequestId).toBe("rr_seed");
+    expect(contract.ownerId).toBe("user_seed");
+    expect(contract.tenantId).toBe("user_regular");
+    expect(contract.terms.summary).toBe("Arrendamiento por 12 meses del terreno.");
+    expect(contract.terms.startsAt).toBe("2026-08-01");
+    expect(contract.terms.endsAt).toBe("2027-08-01");
+  });
+
+  it("persiste el contrato en Mongo (recuperable por id)", async () => {
+    const contract = await createContract(contractInput(), OWNER);
+    const stored = await Contract.findOne({ id: contract.id }).lean();
+    expect(stored).not.toBeNull();
+    expect((stored as { status: string }).status).toBe("draft");
+    expect((stored as { ownerId: string }).ownerId).toBe("user_seed");
+  });
+
+  it("un admin también puede generar el contrato", async () => {
+    const contract = await createContract(contractInput(), ADMIN);
+    expect(contract.status).toBe("draft");
+    expect(contract.ownerId).toBe("user_seed");
+  });
+
+  it("bloquea a quien no es dueño ni admin", async () => {
+    await expect(createContract(contractInput(), OTHER)).rejects.toThrow(/dueño|admin/i);
+  });
+
+  it("falla si la solicitud no existe", async () => {
+    await expect(
+      createContract(contractInput({ rentalRequestId: "rr_inexistente" }), OWNER),
+    ).rejects.toThrow(/solicitud no encontrada/i);
+  });
+
+  it("falla si el terreno de la solicitud no existe", async () => {
+    await expect(
+      createContract(contractInput({ rentalRequestId: "rr_noland" }), OWNER),
+    ).rejects.toThrow(/terreno.*no encontrado/i);
+  });
+
+  it("registra un evento de auditoría (entity: contract, action: created)", async () => {
+    const contract = await createContract(contractInput(), OWNER);
+    const audit = await AuditEvent.findOne({ entityId: contract.id }).lean();
+    expect(audit).not.toBeNull();
+    expect((audit as { entity: string }).entity).toBe("contract");
+    expect((audit as { action: string }).action).toBe("created");
+    expect((audit as { actorId: string }).actorId).toBe("user_seed");
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const contract = await createContract(contractInput(), OWNER);
+    expect("_id" in contract).toBe(false);
+    expect("__v" in contract).toBe(false);
+  });
+
+  it("rechaza un resumen demasiado corto (< 10 caracteres)", async () => {
+    await expect(
+      createContract(contractInput({ terms: { summary: "corto", startsAt: "2026-08-01", endsAt: "2027-08-01" } }), OWNER),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza fin anterior o igual al inicio", async () => {
+    await expect(
+      createContract(
+        contractInput({ terms: { summary: "Arrendamiento por 12 meses.", startsAt: "2027-08-01", endsAt: "2026-08-01" } }),
+        OWNER,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza cuando falta rentalRequestId", async () => {
+    await expect(
+      createContract({ terms: { summary: "Arrendamiento por 12 meses.", startsAt: "2026-08-01", endsAt: "2027-08-01" } }, OWNER),
+    ).rejects.toThrow();
+  });
+
+  it("no crea nada en Mongo si la validación falla", async () => {
+    const before = await Contract.countDocuments({});
+    await expect(createContract(contractInput({ rentalRequestId: "" }), OWNER)).rejects.toThrow();
+    expect(await Contract.countDocuments({})).toBe(before);
+  });
+});

--- a/apps/mcp-server/src/tools/create-contract.ts
+++ b/apps/mcp-server/src/tools/create-contract.ts
@@ -1,0 +1,107 @@
+import { z, type ZodRawShape } from "zod";
+import { CreateContractSchema } from "@terrashare/shared";
+
+import { Contract, Land, RentalRequest } from "@backend/db/schemas";
+import { createAuditEvent } from "@backend/store/audit";
+import type { ActingUser } from "../context";
+import { canCreateContract } from "../permissions";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-73 (#190): Generar un contrato. Espeja `POST /contracts` del backend:
+ * valida forma con el MISMO `CreateContractSchema` compartido, resuelve la
+ * solicitud y su terreno, verifica que el que actúa sea el dueño (o admin) y
+ * crea el contrato en `draft` vinculado a la solicitud, con términos y partes.
+ */
+
+// El schema compartido tiene `terms` con `.refine` (ZodEffects), así que el
+// `inputSchema` que anuncia el SDK se declara con el Zod local (con `.describe()`);
+// la validación REAL la hace `CreateContractSchema.parse` en la función pura.
+// Tipado como `ZodRawShape` para que `TOOLS` unifique en server.ts.
+export const createContractInput: ZodRawShape = {
+  rentalRequestId: z.string().min(1).describe("ID de la solicitud a formalizar"),
+  terms: z
+    .object({
+      summary: z.string().min(10).describe("Resumen de los términos (mín. 10 caracteres)"),
+      signedAt: z.string().optional().describe("Fecha de firma (ISO), opcional"),
+      startsAt: z.string().describe("Fecha de inicio del contrato (ISO)"),
+      endsAt: z.string().describe("Fecha de fin del contrato (ISO)"),
+    })
+    .describe("Términos del contrato (fin posterior al inicio)"),
+};
+
+/** Contrato creado (sin campos internos de Mongo). */
+export interface CreatedContract {
+  id: string;
+  rentalRequestId: string;
+  ownerId: string;
+  tenantId: string;
+  terms: { summary: string; signedAt?: string; startsAt: string; endsAt: string };
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Lógica pura (testeable): valida, resuelve solicitud/terreno, verifica permiso y
+ * persiste. `actingUser` es el usuario que actúa (garantizado por `requires`).
+ */
+export async function createContract(
+  rawInput: unknown,
+  actingUser: Pick<ActingUser, "id" | "role">,
+): Promise<CreatedContract> {
+  const data = CreateContractSchema.parse(rawInput ?? {});
+
+  const request = await RentalRequest.findOne({ id: data.rentalRequestId }).lean();
+  if (!request) throw new ToolError("Solicitud no encontrada");
+
+  const land = await Land.findOne({ id: request.landId }).lean();
+  if (!land) throw new ToolError("Terreno de la solicitud no encontrado");
+
+  // Misma regla que la API REST: solo el dueño del terreno (o un admin).
+  if (!canCreateContract(actingUser as ActingUser, land)) {
+    throw new ToolError("Solo el dueño o un admin pueden generar el contrato");
+  }
+
+  const record = await Contract.create({
+    id: `contract_${crypto.randomUUID()}`,
+    rentalRequestId: request.id,
+    ownerId: land.ownerId,
+    tenantId: request.tenantId,
+    terms: {
+      summary: data.terms.summary,
+      signedAt: data.terms.signedAt,
+      startsAt: data.terms.startsAt,
+      endsAt: data.terms.endsAt,
+    },
+    status: "draft",
+  });
+
+  await createAuditEvent({
+    actor: { id: actingUser.id, role: actingUser.role },
+    entity: "contract",
+    action: "created",
+    entityId: record.id,
+    metadata: { rentalRequestId: record.rentalRequestId },
+  });
+
+  const { _id, __v, ...rest } = record.toObject();
+  return rest as unknown as CreatedContract;
+}
+
+/**
+ * Definición de la tool. `requires: "user"` → necesita identidad; el permiso por
+ * recurso (dueño/admin) lo aplica `canCreateContract`.
+ */
+export const createContractTool: ToolDefinition<typeof createContractInput> = {
+  name: "create_contract",
+  title: "Generar contrato",
+  description:
+    "Genera un contrato en borrador (draft) vinculado a una solicitud, con términos, fechas y partes. Solo el dueño del terreno (o un admin) puede crearlo. Devuelve el contrato creado.",
+  inputSchema: createContractInput,
+  requires: "user",
+  handler: (args, ctx) => {
+    const actingUser = ctx.actingUser as ActingUser;
+    return createContract(args, { id: actingUser.id, role: actingUser.role });
+  },
+};


### PR DESCRIPTION
## Qué

Implementa la tool MCP **`create_contract`** (HU-73): un dueño, vía agente, genera un contrato en `draft` para formalizar un alquiler.

## Comportamiento (espeja `POST /contracts`)

- **`requires: user`** + permiso por recurso: solo el **dueño del terreno** (o un **admin**) puede crearlo (`canCreateContract`).
- Valida forma con el mismo `CreateContractSchema` compartido: `terms.summary` (≥10), `startsAt`/`endsAt` (fechas válidas, fin posterior al inicio).
- Resuelve la **solicitud** (`rentalRequestId`) y su **terreno**; crea el contrato en `draft` con `ownerId`/`tenantId` (partes) y `terms`, vinculado a la solicitud. Registra auditoría (`contract/created`) y devuelve el contrato, sin campos internos de Mongo.

## Reutilización

- Validación: `CreateContractSchema` de `@terrashare/shared` (fuente de verdad; `terms` es `ZodEffects`, por eso el `inputSchema` del SDK se declara con Zod local y la validación real la hace `parse`).
- Modelos `RentalRequest`/`Land`/`Contract`, helper `canCreateContract` y `createAuditEvent`.

## Tests

- **12 unitarios** (`create-contract.test.ts`): dueño crea draft con partes, persistencia, admin permitido, no-dueño bloqueado, solicitud/terreno inexistentes, auditoría, sin `_id/__v`, validaciones (resumen corto, fin ≤ inicio, sin `rentalRequestId`) y no-persistencia en fallo.
- **e2e** (`server.e2e.test.ts`) vía cliente MCP real: listado incluye la tool, creación `draft` para el dueño, y puerta de permisos sin identidad. La solicitud pre-existente se siembra en `beforeEach`.

`bun test` → 39 pass / 0 fail · `bun run typecheck` limpio.

Closes #190