### PR TITLE
feat(mcp): tool create_payment_session para enlaces de pago (HU-77 #194)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -105,6 +105,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | Tool | HU | Issue | Estado |
 |------|-----|-------|--------|
 | `search_lands` | HU-63 | #180 | ✅ implementada |
+| `create_payment_session` | HU-77 | #194 | ✅ implementada |
 
 `search_lands`: busca terrenos publicados (activos) con filtros por texto,
 ubicación, uso, operación y precio; devuelve resultados paginados.
@@ -113,6 +114,27 @@ Ejemplo de argumentos:
 
 ```json
 { "province": "Chiriqui", "use": "agricultura", "priceMax": 1000, "pageSize": 10 }
+```
+
+`create_payment_session` (`requires: user`): genera un enlace de pago
+(`checkoutUrl`) para una solicitud **pagable** (`approved`/`pending_payment`), a
+nombre del arrendatario (o admin). Crea una sesión real de Stripe si
+`STRIPE_SECRET_KEY` está configurada; si no, usa el fallback de desarrollo (igual
+que el backend). **No expone secretos de Stripe**. Reusa `CreateCheckoutSessionSchema`,
+`canInitiatePayment` y `computePaymentBreakdown`.
+
+Variables de entorno adicionales (opcionales): `STRIPE_SECRET_KEY`,
+`STRIPE_PLATFORM_FEE_BPS` (default 500 = 5%).
+
+Ejemplo de argumentos:
+
+```json
+{
+  "rentalRequestId": "rr_123",
+  "currency": "USD",
+  "successUrl": "https://app.terrashare.co/pago/ok",
+  "cancelUrl": "https://app.terrashare.co/pago/cancel"
+}
 ```
 
 ## Tests

--- a/apps/mcp-server/bun.lock
+++ b/apps/mcp-server/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "mongoose": "^8.9.5",
+        "stripe": "^22.0.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -274,6 +275,8 @@
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
+    "stripe": ["stripe@22.3.1", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6XSLN0KK0IdfXqDHqMg6CDoO3eO62ye9dhzw0fZp55AUOzHR1YRJOqYHTsuCi4QJ4Ni/usEmXtq69c9ghKDmYw=="],
 
     "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
 

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "mongoose": "^8.9.5",
+    "stripe": "^22.0.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/mcp-server/src/lib/stripe.ts
+++ b/apps/mcp-server/src/lib/stripe.ts
@@ -1,0 +1,42 @@
+import Stripe from "stripe";
+
+/**
+ * Helper Stripe autocontenido para el mcp-server (#194/#197).
+ *
+ * Lee la configuración directamente de `process.env` — NO importa
+ * `@backend/config/env`, que valida Clerk al cargarse y rompería el arranque del
+ * servidor MCP (que corre sin Clerk). Espeja la semántica del backend:
+ * `getStripeClient()` devuelve `null` si no hay clave real (o es el placeholder),
+ * y en ese caso las tools usan el fallback de desarrollo.
+ */
+
+let stripeClient: Stripe | null = null;
+
+/** Cliente Stripe si hay una clave real configurada; `null` en dev/sin clave. */
+export function getStripeClient(): Stripe | null {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key || key === "sk_test_placeholder") return null;
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(key, { apiVersion: "2026-06-24.dahlia" });
+  }
+  return stripeClient;
+}
+
+/** Comisión de plataforma en basis points (default 5% = 500 bps), como el backend. */
+export function platformFeeBps(): number {
+  const raw = Number(process.env.STRIPE_PLATFORM_FEE_BPS);
+  if (!Number.isFinite(raw) || raw < 0 || raw > 10000) return 500;
+  return Math.trunc(raw);
+}
+
+/** Extrae el id del PaymentIntent de la sesión (string u objeto). */
+export function extractPaymentIntentId(
+  paymentIntent: string | { id?: string } | null | undefined,
+): string | undefined {
+  if (typeof paymentIntent === "string") return paymentIntent;
+  if (paymentIntent && typeof paymentIntent === "object" && typeof paymentIntent.id === "string") {
+    return paymentIntent.id;
+  }
+  return undefined;
+}

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -1,20 +1,47 @@
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
+import mongoose from "@backend/db/mongoose";
+import { Payment, RentalRequest } from "@backend/db/schemas";
+import type { ActingUser } from "./context";
 import { createServer } from "./server";
 
 /**
  * E2E de la fundación (#234): un cliente MCP real se conecta al servidor,
  * lista las tools y llama a search_lands contra MongoDB (sembrada en el preload).
  */
-async function connectedClient(): Promise<Client> {
-  const server = createServer({ actingUser: null });
+async function connectedClient(actingUser: ActingUser | null = null): Promise<Client> {
+  const server = createServer({ actingUser });
   const client = new Client({ name: "test-client", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
   return client;
 }
+
+/** Arrendatario de rr_e2e (user_regular). */
+const TENANT_USER: ActingUser = {
+  id: "user_regular",
+  clerkUserId: "user_regular",
+  email: "user@test.com",
+  role: "user",
+  status: "active",
+  profile: { fullName: "Usuario Regular" },
+};
+
+// El preload no toca RentalRequest/Payment → sembramos una solicitud pagable en
+// el hook (no en el cuerpo del test) para las tools que la leen.
+beforeEach(async () => {
+  await RentalRequest.deleteMany({});
+  await Payment.deleteMany({});
+  await mongoose.connection.db!.collection("rentalrequests").insertOne({
+    id: "rr_e2e",
+    landId: "land_a",
+    tenantId: "user_regular",
+    operation: "alquiler",
+    status: "approved",
+  });
+});
 
 describe("MCP server E2E (#234)", () => {
   it("un cliente MCP lista las tools e incluye search_lands", async () => {
@@ -38,6 +65,47 @@ describe("MCP server E2E (#234)", () => {
     const client = await connectedClient();
     const res = await client.callTool({ name: "search_lands", arguments: { pageSize: 9999 } });
     // El SDK marca isError cuando la validación de entrada falla.
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("la lista de tools incluye create_payment_session (HU-77 #194)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("create_payment_session");
+    await client.close();
+  });
+
+  it("create_payment_session devuelve un checkoutUrl para el arrendatario", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({
+      name: "create_payment_session",
+      arguments: {
+        rentalRequestId: "rr_e2e",
+        currency: "USD",
+        successUrl: "https://ok.test/return",
+        cancelUrl: "https://cancel.test/return",
+      },
+    });
+    const payment = res.structuredContent as { paymentId: string; checkoutUrl: string; status: string };
+    expect(res.isError).toBeFalsy();
+    expect(payment.paymentId).toMatch(/^pay_/);
+    expect(payment.checkoutUrl).toBe("https://ok.test/return");
+    expect(payment.status).toBe("pending");
+    await client.close();
+  });
+
+  it("create_payment_session sin identidad configurada devuelve error (requires user)", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({
+      name: "create_payment_session",
+      arguments: {
+        rentalRequestId: "rr_e2e",
+        currency: "USD",
+        successUrl: "https://ok.test/return",
+        cancelUrl: "https://cancel.test/return",
+      },
+    });
     expect(res.isError).toBe(true);
     await client.close();
   });

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { config } from "./config";
 import type { ToolContext } from "./context";
 import { registerTool } from "./tools/define-tool";
+import { createPaymentSessionTool } from "./tools/create-payment-session";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -13,6 +14,7 @@ import { searchLandsTool } from "./tools/search-lands";
  */
 const TOOLS = [
   searchLandsTool,
+  createPaymentSessionTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 
@@ -22,7 +24,8 @@ export function createServer(ctx: ToolContext): McpServer {
     {
       instructions:
         "Servidor MCP de TerraShare: expone el dominio de terrenos/alquileres. " +
-        "Usa search_lands para buscar publicaciones activas.",
+        "Usa search_lands para buscar publicaciones activas y create_payment_session " +
+        "para generar un enlace de pago de una solicitud pagable.",
     },
   );
 

--- a/apps/mcp-server/src/tools/create-payment-session.test.ts
+++ b/apps/mcp-server/src/tools/create-payment-session.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import mongoose from "@backend/db/mongoose";
+import { AuditEvent, Payment, RentalRequest } from "@backend/db/schemas";
+import { createPaymentSession } from "./create-payment-session";
+
+// rr_payable: land_a (dueño user_seed), arrendatario user_regular.
+const TENANT = { id: "user_regular", role: "user" as const };
+const ADMIN = { id: "user_admin", role: "admin" as const };
+const OWNER = { id: "user_seed", role: "user" as const }; // dueño, no arrendatario
+
+function paymentInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    rentalRequestId: "rr_payable",
+    currency: "USD",
+    successUrl: "https://ok.test/return",
+    cancelUrl: "https://cancel.test/return",
+    ...overrides,
+  };
+}
+
+// Siembra las solicitudes en beforeEach (no en el cuerpo del test): un write
+// desde el cuerpo del test cuelga la siguiente lectura con bun:test + memory-server.
+beforeEach(async () => {
+  await RentalRequest.deleteMany({});
+  await Payment.deleteMany({});
+  await AuditEvent.deleteMany({});
+  await mongoose.connection.db!.collection("rentalrequests").insertMany([
+    { id: "rr_payable", landId: "land_a", tenantId: "user_regular", operation: "alquiler", status: "approved" },
+    { id: "rr_notpayable", landId: "land_a", tenantId: "user_regular", operation: "alquiler", status: "pending_owner" },
+    // Operación de venta sobre land_b, con oferta acordada.
+    { id: "rr_venta", landId: "land_b", tenantId: "user_regular", operation: "venta", offerAmount: 55000, status: "approved" },
+  ]);
+});
+
+describe("create_payment_session tool (HU-77 #194)", () => {
+  it("el arrendatario obtiene un checkoutUrl para una solicitud pagable", async () => {
+    const res = await createPaymentSession(paymentInput(), TENANT);
+
+    expect(res.paymentId).toMatch(/^pay_/);
+    expect(res.status).toBe("pending");
+    expect(res.currency).toBe("USD");
+    // Sin Stripe real (tests) → fallback dev: checkoutUrl === successUrl.
+    expect(res.checkoutUrl).toBe("https://ok.test/return");
+    expect(res.stripeSessionId).toMatch(/^cs_dev_/);
+    // land_a: pricePerMonth 300 (alquiler → primer mes).
+    expect(res.amount).toBe(300);
+  });
+
+  it("persiste el pago con el desglose (comisión y neto)", async () => {
+    const res = await createPaymentSession(paymentInput(), TENANT);
+    const payment = await Payment.findOne({ id: res.paymentId }).lean();
+    expect(payment).not.toBeNull();
+    expect((payment as { status: string }).status).toBe("pending");
+    expect((payment as { amount: number }).amount).toBe(300);
+    // 5% de 300 = 15; neto 285.
+    expect((payment as { platformFeeAmount: number }).platformFeeAmount).toBe(15);
+    expect((payment as { netAmount: number }).netAmount).toBe(285);
+  });
+
+  it("transiciona la solicitud a pending_payment", async () => {
+    await createPaymentSession(paymentInput(), TENANT);
+    const request = await RentalRequest.findOne({ id: "rr_payable" }).lean();
+    expect((request as { status: string }).status).toBe("pending_payment");
+  });
+
+  it("un admin también puede iniciar el pago", async () => {
+    const res = await createPaymentSession(paymentInput(), ADMIN);
+    expect(res.status).toBe("pending");
+    expect(res.checkoutUrl).toBe("https://ok.test/return");
+  });
+
+  it("bloquea a quien no es el arrendatario ni admin (p. ej. el dueño)", async () => {
+    await expect(createPaymentSession(paymentInput(), OWNER)).rejects.toThrow(/arrendatario|admin/i);
+  });
+
+  it("rechaza una solicitud que no es pagable", async () => {
+    await expect(
+      createPaymentSession(paymentInput({ rentalRequestId: "rr_notpayable" }), TENANT),
+    ).rejects.toThrow(/no es pagable/i);
+  });
+
+  it("falla si la solicitud no existe", async () => {
+    await expect(
+      createPaymentSession(paymentInput({ rentalRequestId: "rr_inexistente" }), TENANT),
+    ).rejects.toThrow(/no encontrada/i);
+  });
+
+  it("registra un evento de auditoría (entity: payment, action: created)", async () => {
+    const res = await createPaymentSession(paymentInput(), TENANT);
+    const audit = await AuditEvent.findOne({ entityId: res.paymentId }).lean();
+    expect(audit).not.toBeNull();
+    expect((audit as { entity: string }).entity).toBe("payment");
+    expect((audit as { action: string }).action).toBe("created");
+    expect((audit as { actorId: string }).actorId).toBe("user_regular");
+  });
+
+  it("no expone secretos de Stripe en el resultado", async () => {
+    const res = await createPaymentSession(paymentInput(), TENANT);
+    const keys = Object.keys(res);
+    expect(keys).toEqual(
+      expect.arrayContaining(["paymentId", "stripeSessionId", "checkoutUrl", "status", "amount", "currency"]),
+    );
+    // Nada que parezca una clave/secreto.
+    const serialized = JSON.stringify(res).toLowerCase();
+    expect(serialized).not.toContain("sk_");
+    expect(serialized).not.toContain("secret");
+  });
+
+  it("cobra la oferta en operaciones de venta", async () => {
+    const res = await createPaymentSession(paymentInput({ rentalRequestId: "rr_venta" }), TENANT);
+    expect(res.amount).toBe(55000);
+  });
+
+  it("rechaza una successUrl inválida (validación del schema)", async () => {
+    await expect(
+      createPaymentSession(paymentInput({ successUrl: "no-es-url" }), TENANT),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza cuando falta la moneda (validación del schema)", async () => {
+    await expect(
+      createPaymentSession({ rentalRequestId: "rr_payable", successUrl: "https://ok.test/x", cancelUrl: "https://c.test/x" }, TENANT),
+    ).rejects.toThrow();
+  });
+
+  it("no crea ningún pago si la validación falla", async () => {
+    const before = await Payment.countDocuments({});
+    await expect(createPaymentSession(paymentInput({ currency: "EUR" }), TENANT)).rejects.toThrow();
+    expect(await Payment.countDocuments({})).toBe(before);
+  });
+});

--- a/apps/mcp-server/src/tools/create-payment-session.ts
+++ b/apps/mcp-server/src/tools/create-payment-session.ts
@@ -1,0 +1,183 @@
+import { z, type ZodRawShape } from "zod";
+import { CreateCheckoutSessionSchema } from "@terrashare/shared";
+
+import { Land, Payment, RentalRequest } from "@backend/db/schemas";
+import { createAuditEvent } from "@backend/store/audit";
+import {
+  computePaymentBreakdown,
+  stripeChargeCurrency,
+  toStripeMinorUnits,
+} from "@backend/lib/payments-money";
+import type { ActingUser } from "../context";
+import { canInitiatePayment } from "../permissions";
+import { extractPaymentIntentId, getStripeClient, platformFeeBps } from "../lib/stripe";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-77 (#194): Crear una sesión de pago. Espeja
+ * `POST /payments/checkout-session`: valida forma con el MISMO
+ * `CreateCheckoutSessionSchema`, verifica que el que actúa sea el arrendatario
+ * (o admin) y que la solicitud sea PAGABLE, crea el pago y una sesión de Stripe
+ * (o un fallback de desarrollo), y devuelve el `checkoutUrl` — **sin exponer
+ * secretos de Stripe** (solo la URL pública de checkout y los ids de sesión).
+ */
+
+// El `inputSchema` que anuncia el SDK se declara con el Zod local (con
+// `.describe()`); la validación real la hace `CreateCheckoutSessionSchema.parse`.
+// Tipado como `ZodRawShape` para que `TOOLS` unifique en server.ts.
+export const createPaymentSessionInput: ZodRawShape = {
+  rentalRequestId: z.string().min(1).describe("ID de la solicitud a pagar"),
+  currency: z.enum(["USD", "PAB"]).describe("Moneda de presentación"),
+  successUrl: z.string().url().describe("URL de retorno tras el pago exitoso"),
+  cancelUrl: z.string().url().describe("URL de retorno si se cancela el pago"),
+};
+
+/** Estados en los que una solicitud es pagable. */
+const PAYABLE_STATUSES = ["approved", "pending_payment"];
+
+/** Resultado de la tool: nunca incluye secretos de Stripe. */
+export interface PaymentSessionResult {
+  paymentId: string;
+  stripeSessionId?: string;
+  checkoutUrl?: string;
+  status: string;
+  amount: number;
+  currency: string;
+}
+
+/** Monto a cobrar (espeja `computePaymentAmount` del backend). */
+async function computeAmount(
+  request: { operation?: string; offerAmount?: number; landId: string },
+  fallback = 1000,
+): Promise<number> {
+  const land = await Land.findOne({ id: request.landId }).lean();
+  if (request.operation === "venta") {
+    return request.offerAmount ?? land?.salePrice ?? fallback;
+  }
+  return land?.priceRule?.pricePerMonth ?? fallback;
+}
+
+/**
+ * Lógica pura (testeable): valida, verifica permiso y pagabilidad, crea el pago +
+ * la sesión (Stripe real o fallback dev) y pasa la solicitud a `pending_payment`.
+ */
+export async function createPaymentSession(
+  rawInput: unknown,
+  actingUser: Pick<ActingUser, "id" | "role">,
+): Promise<PaymentSessionResult> {
+  const data = CreateCheckoutSessionSchema.parse(rawInput ?? {});
+
+  const request = await RentalRequest.findOne({ id: data.rentalRequestId }).lean();
+  if (!request) throw new ToolError("Solicitud no encontrada");
+
+  // Misma regla que la API REST: solo el arrendatario (o un admin).
+  if (!canInitiatePayment(actingUser as ActingUser, request)) {
+    throw new ToolError("Solo el arrendatario o un admin pueden iniciar el pago");
+  }
+
+  if (!PAYABLE_STATUSES.includes(request.status)) {
+    throw new ToolError("La solicitud no es pagable en su estado actual");
+  }
+
+  const amount = await computeAmount(request as { operation?: string; offerAmount?: number; landId: string });
+  const breakdown = computePaymentBreakdown(amount, data.currency, platformFeeBps());
+  const paymentId = `pay_${crypto.randomUUID()}`;
+
+  await Payment.create({
+    id: paymentId,
+    rentalRequestId: request.id,
+    amount: breakdown.grossAmount,
+    currency: data.currency,
+    platformFeeAmount: breakdown.platformFeeAmount,
+    netAmount: breakdown.netAmount,
+    settlementCurrency: breakdown.settlementCurrency,
+    status: "pending",
+  });
+
+  const stripe = getStripeClient();
+  if (stripe) {
+    const feeMetadata = {
+      presentmentCurrency: data.currency,
+      platformFeeAmount: String(breakdown.platformFeeAmount),
+      netAmount: String(breakdown.netAmount),
+    };
+    const session = await stripe.checkout.sessions.create(
+      {
+        mode: "payment",
+        client_reference_id: paymentId,
+        success_url: data.successUrl,
+        cancel_url: data.cancelUrl,
+        line_items: [
+          {
+            quantity: 1,
+            price_data: {
+              currency: stripeChargeCurrency(data.currency),
+              unit_amount: toStripeMinorUnits(breakdown.grossAmount),
+              product_data: { name: `TerraShare rental ${request.id}` },
+            },
+          },
+        ],
+        metadata: { paymentId, rentalRequestId: request.id, ...feeMetadata },
+        payment_intent_data: {
+          metadata: { paymentId, rentalRequestId: request.id, ...feeMetadata },
+        },
+      },
+      { idempotencyKey: paymentId },
+    );
+
+    await Payment.updateOne(
+      { id: paymentId },
+      {
+        stripeSessionId: session.id,
+        stripePaymentIntentId: extractPaymentIntentId(session.payment_intent),
+        checkoutUrl: session.url ?? undefined,
+      },
+    );
+  } else {
+    // Fallback de desarrollo (sin clave real de Stripe): igual que el backend.
+    await Payment.updateOne(
+      { id: paymentId },
+      { stripeSessionId: `cs_dev_${crypto.randomUUID()}`, checkoutUrl: data.successUrl },
+    );
+  }
+
+  await RentalRequest.updateOne(
+    { id: request.id },
+    { status: "pending_payment", updatedAt: new Date() },
+  );
+
+  await createAuditEvent({
+    actor: { id: actingUser.id, role: actingUser.role },
+    entity: "payment",
+    action: "created",
+    entityId: paymentId,
+    metadata: { rentalRequestId: request.id, amount, currency: data.currency },
+  });
+
+  const payment = await Payment.findOne({ id: paymentId }).lean();
+  return {
+    paymentId,
+    stripeSessionId: payment?.stripeSessionId,
+    checkoutUrl: payment?.checkoutUrl,
+    status: payment?.status ?? "pending",
+    amount: breakdown.grossAmount,
+    currency: data.currency,
+  };
+}
+
+/**
+ * Definición de la tool. `requires: "user"` → necesita identidad; el permiso por
+ * recurso (arrendatario/admin) lo aplica `canInitiatePayment`.
+ */
+export const createPaymentSessionTool: ToolDefinition<typeof createPaymentSessionInput> = {
+  name: "create_payment_session",
+  title: "Crear sesión de pago",
+  description:
+    "Genera un enlace de pago (checkoutUrl) para una solicitud pagable, a nombre del arrendatario autenticado. No expone secretos de Stripe. Devuelve el checkoutUrl y el estado del pago.",
+  inputSchema: createPaymentSessionInput,
+  requires: "user",
+  handler: (args, ctx) => {
+    const actingUser = ctx.actingUser as ActingUser;
+    return createPaymentSession(args, { id: actingUser.id, role: actingUser.role });
+  },
+};


### PR DESCRIPTION
## Qué

Implementa la tool MCP **`create_payment_session`** (HU-77): un arrendatario, vía agente, obtiene un enlace de pago (`checkoutUrl`) para su alquiler.

## Comportamiento (espeja `POST /payments/checkout-session`)

- **`requires: user`** + permiso por recurso `canInitiatePayment` (solo el **arrendatario** o un **admin**).
- Solo si la solicitud es **pagable** (`approved`/`pending_payment`); si no → error de negocio.
- Calcula el desglose con `computePaymentBreakdown` (bruto, comisión de plataforma, neto), crea el `Payment` en `pending`, genera la **sesión de Stripe** (o el fallback de desarrollo cuando no hay clave real), pasa la solicitud a `pending_payment` y registra auditoría (`payment/created`).
- **No expone secretos de Stripe**: devuelve `paymentId`, `stripeSessionId`, `checkoutUrl`, `status`, `amount`, `currency`.

## Nueva dependencia + helper

- Añade `stripe` a `apps/mcp-server` (misma familia de versión que el backend) y `src/lib/stripe.ts`, un helper autocontenido que lee `STRIPE_SECRET_KEY` / `STRIPE_PLATFORM_FEE_BPS` de `process.env`. **No** importa `@backend/config/env` (que valida Clerk al cargarse y rompería el arranque del mcp). Semántica igual al backend: sin clave real → `null` → fallback dev.
- Reusa `CreateCheckoutSessionSchema`, `canInitiatePayment` y `computePaymentBreakdown`/`stripeChargeCurrency`/`toStripeMinorUnits`.

## Tests

- **13 unitarios** (`create-payment-session.test.ts`): arrendatario obtiene checkoutUrl, desglose (comisión/neto), transición a `pending_payment`, admin permitido, no-arrendatario bloqueado, no-pagable, no-existe, auditoría, **no expone secretos**, oferta de venta, y validaciones (URL inválida, sin moneda, no-persistencia en fallo).
- **e2e** (`server.e2e.test.ts`) vía cliente MCP real: listado incluye la tool, checkoutUrl para el arrendatario, y puerta de permisos sin identidad. Solicitud pagable sembrada en `beforeEach`.

`bun test` → 40 pass / 0 fail · `bun run typecheck` limpio. `bun.lock` actualizado (nueva dep).

Closes #194