### PR TITLE
feat(mcp): implement get_payment_status tool (HU-80 #195)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -118,6 +118,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `list_my_lands` | HU-68 | #185 | ✅ implementada |
 | `list_rental_requests` | HU-71 | #188 | ✅ implementada |
 | `get_contract` | HU-76 | #193 | ✅ implementada |
+| `get_payment_status` | HU-80 | #195 | ✅ implementada |
 
 ## Tests
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -24,6 +24,7 @@ import { getLandTool } from "./tools/get-land";
 import { listMyLandsTool } from "./tools/list-my-lands";
 import { listRentalRequestsTool } from "./tools/list-rental-requests";
 import { setLandStatusTool } from "./tools/set-land-status";
+import { getPaymentStatusTool } from "./tools/get-payment-status";
 import { searchLandsTool } from "./tools/search-lands";
 import { updateLandTool } from "./tools/update-land";
 
@@ -56,6 +57,7 @@ const TOOLS: ToolDefinition<ZodRawShape>[] = [
   listMyLandsTool,
   listRentalRequestsTool,
   setLandStatusTool,
+  getPaymentStatusTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/test-preload.ts
+++ b/apps/mcp-server/src/test-preload.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 import { connectMongoose, disconnectMongoose } from "@backend/db/mongoose";
-import { Contract, Land, RentalRequest, User } from "@backend/db/schemas";
+import { Contract, Land, Payment, RentalRequest, User } from "@backend/db/schemas";
 
 const now = new Date().toISOString();
 
@@ -83,6 +83,21 @@ export const SEED_CONTRACTS = [
   },
 ];
 
+export const SEED_PAYMENTS = [
+  {
+    id: "payment_seed_01",
+    rentalRequestId: "rr_seed_01",
+    amount: 300,
+    currency: "USD",
+    platformFeeAmount: 15,
+    netAmount: 285,
+    settlementCurrency: "USD",
+    status: "paid",
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
 const mongod = await MongoMemoryServer.create();
 process.env.MONGODB_URI = `${mongod.getUri()}terrashare_mcp`;
 
@@ -97,6 +112,8 @@ async function seed(): Promise<void> {
   await RentalRequest.insertMany(SEED_RENTAL_REQUESTS.map((r) => ({ ...r })));
   await Contract.deleteMany({});
   await Contract.insertMany(SEED_CONTRACTS.map((c) => ({ ...c })));
+  await Payment.deleteMany({});
+  await Payment.insertMany(SEED_PAYMENTS.map((p) => ({ ...p })));
 }
 
 await seed();

--- a/apps/mcp-server/src/tools/get-payment-status.test.ts
+++ b/apps/mcp-server/src/tools/get-payment-status.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { getPaymentStatus } from "./get-payment-status";
+
+describe("get_payment_status tool (HU-80 #195)", () => {
+  it("devuelve el estado de un pago existente", async () => {
+    const result = await getPaymentStatus({
+      paymentId: "payment_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    expect(result).toBeDefined();
+    expect((result as { id: string }).id).toBe("payment_seed_01");
+    expect((result as { status: string }).status).toBe("paid");
+    expect((result as { amount: number }).amount).toBe(300);
+  });
+
+  it("permite al arrendatario ver el pago de su solicitud", async () => {
+    const result = await getPaymentStatus({
+      paymentId: "payment_seed_01",
+      actingUserId: "user_tenant_01",
+      actingUserRole: "user",
+    });
+    expect(result).toBeDefined();
+    expect((result as { id: string }).id).toBe("payment_seed_01");
+  });
+
+  it("permite a un administrador ver cualquier pago", async () => {
+    const result = await getPaymentStatus({
+      paymentId: "payment_seed_01",
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    expect(result).toBeDefined();
+    expect((result as { id: string }).id).toBe("payment_seed_01");
+  });
+
+  it("lanza error cuando el pago no existe", async () => {
+    await expect(
+      getPaymentStatus({
+        paymentId: "nonexistent",
+        actingUserId: "user_seed",
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Pago no encontrado");
+  });
+
+  it("lanza error cuando el usuario no tiene permiso", async () => {
+    await expect(
+      getPaymentStatus({
+        paymentId: "payment_seed_01",
+        actingUserId: "user_other",
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("No autorizado");
+  });
+
+  it("lanza error cuando no hay usuario autenticado", async () => {
+    await expect(
+      getPaymentStatus({
+        paymentId: "payment_seed_01",
+        actingUserId: null,
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const result = await getPaymentStatus({
+      paymentId: "payment_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const payment = result as Record<string, unknown>;
+    expect(payment).not.toHaveProperty("_id");
+    expect(payment).not.toHaveProperty("__v");
+  });
+
+  it("incluye campos relevantes del pago", async () => {
+    const result = await getPaymentStatus({
+      paymentId: "payment_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const payment = result as Record<string, unknown>;
+    expect(payment).toHaveProperty("id");
+    expect(payment).toHaveProperty("rentalRequestId");
+    expect(payment).toHaveProperty("amount");
+    expect(payment).toHaveProperty("currency");
+    expect(payment).toHaveProperty("status");
+    expect(payment).toHaveProperty("createdAt");
+  });
+});

--- a/apps/mcp-server/src/tools/get-payment-status.ts
+++ b/apps/mcp-server/src/tools/get-payment-status.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+import { Payment, RentalRequest, Land } from "@backend/db/schemas";
+import { canReadPayment } from "@backend/lib/auth-helpers";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+export const getPaymentStatusInput = {
+  paymentId: z.string().min(1).describe("ID del pago a consultar"),
+};
+
+export type GetPaymentStatusInput = z.infer<z.ZodObject<typeof getPaymentStatusInput>>;
+
+export async function getPaymentStatus(rawInput: {
+  paymentId: string;
+  actingUserId: string | null;
+  actingUserRole?: string;
+}): Promise<Record<string, unknown>> {
+  if (!rawInput.actingUserId) {
+    throw new ToolError("Se requiere un usuario autenticado");
+  }
+
+  const payment = await Payment.findOne({ id: rawInput.paymentId }).lean();
+  if (!payment) throw new ToolError("Pago no encontrado");
+
+  const request = await RentalRequest.findOne({ id: payment.rentalRequestId }).lean();
+  if (!request) throw new ToolError("Solicitud de alquiler no encontrada");
+
+  const land = await Land.findOne({ id: request.landId }).lean();
+  if (!land) throw new ToolError("Terreno no encontrado");
+
+  if (
+    !canReadPayment(
+      { id: rawInput.actingUserId, role: rawInput.actingUserRole ?? "user" } as any,
+      request as any,
+      land as any,
+    )
+  ) {
+    throw new ToolError("No autorizado para ver este pago");
+  }
+
+  const { _id, __v, ...rest } = payment as unknown as Record<string, unknown>;
+  return rest;
+}
+
+export const getPaymentStatusTool: ToolDefinition<typeof getPaymentStatusInput> = {
+  name: "get_payment_status",
+  title: "Consultar estado de pago",
+  description:
+    "Obtiene el estado de un pago por su ID, incluyendo monto, moneda y estado. Solo las partes o un administrador pueden verlo.",
+  inputSchema: getPaymentStatusInput,
+  requires: "user",
+  handler: (args, ctx) =>
+    getPaymentStatus({
+      paymentId: args.paymentId as string,
+      actingUserId: ctx.actingUser?.id ?? null,
+      actingUserRole: ctx.actingUser?.role,
+    }),
+};


### PR DESCRIPTION
What was implemented:

- Tool get_payment_status: Returns payment details by ID with permission checks
- Unit tests: 8 tests covering successful retrieval, tenant/owner/admin access, error handling, and field validation
- Registration: Tool registered in server.ts TOOLS array
- Documentation: README.md updated with tool description

Technical details:

- Input: paymentId (string, required)
- Access: user (requires MCP_ACTING_USER_ID)
- Uses canReadPayment permission helper from backend
- Returns ToolError for unauthorized access or non-existent payments
- Passes actingUserRole from ctx to permission helper (admin access works correctly)

Verification:

- All MCP server tests pass
- TypeScript typecheck passes

Closes #195