### PR TITLE
feat(mcp): implement list_payments tool (HU-81 #196)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -119,6 +119,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `list_rental_requests` | HU-71 | #188 | ✅ implementada |
 | `get_contract` | HU-76 | #193 | ✅ implementada |
 | `get_payment_status` | HU-80 | #195 | ✅ implementada |
+| `list_payments` | HU-81 | #196 | ✅ implementada |
 
 ## Tests
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -25,6 +25,7 @@ import { listMyLandsTool } from "./tools/list-my-lands";
 import { listRentalRequestsTool } from "./tools/list-rental-requests";
 import { setLandStatusTool } from "./tools/set-land-status";
 import { getPaymentStatusTool } from "./tools/get-payment-status";
+import { listPaymentsTool } from "./tools/list-payments";
 import { searchLandsTool } from "./tools/search-lands";
 import { updateLandTool } from "./tools/update-land";
 
@@ -58,6 +59,7 @@ const TOOLS: ToolDefinition<ZodRawShape>[] = [
   listRentalRequestsTool,
   setLandStatusTool,
   getPaymentStatusTool,
+  listPaymentsTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/list-payments.test.ts
+++ b/apps/mcp-server/src/tools/list-payments.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { listPayments } from "./list-payments";
+
+describe("list_payments tool (HU-81 #196)", () => {
+  it("devuelve pagos del arrendatario", async () => {
+    const result = await listPayments({
+      actingUserId: "user_tenant_01",
+      actingUserRole: "user",
+    });
+    const payments = (result as { items: unknown[] }).items;
+    expect(Array.isArray(payments)).toBe(true);
+    expect(payments.length).toBeGreaterThan(0);
+  });
+
+  it("devuelve todos los pagos para un administrador", async () => {
+    const result = await listPayments({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const payments = (result as { items: unknown[] }).items;
+    expect(Array.isArray(payments)).toBe(true);
+    expect(payments.length).toBeGreaterThan(0);
+  });
+
+  it("filtra por estado", async () => {
+    const result = await listPayments({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+      status: "paid",
+    });
+    const payments = (result as { items: { status: string }[] }).items;
+    expect(payments.every((p) => p.status === "paid")).toBe(true);
+  });
+
+  it("devuelve array vacío si el usuario no tiene pagos", async () => {
+    const result = await listPayments({
+      actingUserId: "user_no_payments",
+      actingUserRole: "user",
+    });
+    const payments = (result as { items: unknown[] }).items;
+    expect(payments.length).toBe(0);
+  });
+
+  it("no expone campos internos de Mongo", async () => {
+    const result = await listPayments({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const payments = (result as { items: Record<string, unknown>[] }).items;
+    expect(payments.every((p) => !("_id" in p) && !("__v" in p))).toBe(true);
+  });
+
+  it("lanza error cuando no hay usuario autenticado", async () => {
+    await expect(
+      listPayments({ actingUserId: null, actingUserRole: "user" })
+    ).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+
+  it("incluye campos relevantes en cada pago", async () => {
+    const result = await listPayments({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const payments = (result as { items: Record<string, unknown>[] }).items;
+    expect(payments.length).toBeGreaterThan(0);
+    const payment = payments[0];
+    expect(payment).toHaveProperty("id");
+    expect(payment).toHaveProperty("rentalRequestId");
+    expect(payment).toHaveProperty("amount");
+    expect(payment).toHaveProperty("status");
+    expect(payment).toHaveProperty("createdAt");
+  });
+});

--- a/apps/mcp-server/src/tools/list-payments.ts
+++ b/apps/mcp-server/src/tools/list-payments.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { Land, Payment, RentalRequest } from "@backend/db/schemas";
+import { canListPayments } from "@backend/lib/auth-helpers";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+export const listPaymentsInput = {
+  status: z.enum(["pending", "processing", "paid", "failed", "cancelled", "refunded", "partially_refunded"]).optional().describe("Filtrar por estado del pago"),
+};
+
+export async function listPayments(rawInput: {
+  actingUserId: string | null;
+  actingUserRole?: string;
+  status?: string;
+}): Promise<{ items: Record<string, unknown>[]; total: number }> {
+  if (!rawInput.actingUserId) {
+    throw new ToolError("Se requiere un usuario autenticado");
+  }
+
+  const ownerLands = await Land.find({ ownerId: rawInput.actingUserId }).lean();
+  const ownerLandIds = ownerLands.map((l) => l.id);
+
+  const userRequests = await RentalRequest.find({
+    $or: [{ tenantId: rawInput.actingUserId }, { landId: { $in: ownerLandIds } }],
+  }).lean();
+  const requestIds = userRequests.map((r) => r.id);
+
+  const permissionQuery = canListPayments(
+    { id: rawInput.actingUserId, role: rawInput.actingUserRole ?? "user" } as any,
+    requestIds
+  );
+
+  const query: Record<string, unknown> = { ...permissionQuery };
+  if (rawInput.status) {
+    query.status = rawInput.status;
+  }
+
+  const docs = await Payment.find(query).sort({ createdAt: -1 }).lean();
+  const items = (docs as unknown as Record<string, unknown>[]).map((d) => {
+    const { _id, __v, ...rest } = d;
+    return rest;
+  });
+
+  return { items, total: items.length };
+}
+
+export const listPaymentsTool: ToolDefinition<typeof listPaymentsInput> = {
+  name: "list_payments",
+  title: "Listar pagos",
+  description: "Devuelve los pagos del usuario autenticado. Los administradores ven todos los pagos. Permite filtrar por estado.",
+  inputSchema: listPaymentsInput,
+  requires: "user",
+  handler: (args, ctx) =>
+    listPayments({
+      actingUserId: ctx.actingUser?.id ?? null,
+      actingUserRole: ctx.actingUser?.role,
+      status: args.status as string | undefined,
+    }),
+};


### PR DESCRIPTION
What was implemented:

- Tool list_payments: Lists payments for the authenticated user with optional status filter
- Unit tests: 7 tests covering tenant payments, admin sees all, status filter, empty results, Mongo fields, auth, field validation
- Registration: Tool registered in server.ts TOOLS array

Technical details:

- Input: status (optional enum filter)
- Access: user (requires MCP_ACTING_USER_ID)
- Uses canListPayments permission helper from backend (returns query filter)
- Admins see all payments; regular users see only their own
- Passes actingUserRole from ctx to permission helper

Verification:

- All MCP server tests pass

Closes #196