### PR TITLE
feat(mcp): implement list_chats tool (HU-83 #198)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -120,6 +120,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `get_contract` | HU-76 | #193 | ✅ implementada |
 | `get_payment_status` | HU-80 | #195 | ✅ implementada |
 | `list_payments` | HU-81 | #196 | ✅ implementada |
+| `list_chats` | HU-83 | #198 | ✅ implementada |
 
 ## Tests
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -26,6 +26,7 @@ import { listRentalRequestsTool } from "./tools/list-rental-requests";
 import { setLandStatusTool } from "./tools/set-land-status";
 import { getPaymentStatusTool } from "./tools/get-payment-status";
 import { listPaymentsTool } from "./tools/list-payments";
+import { listChatsTool } from "./tools/list-chats";
 import { searchLandsTool } from "./tools/search-lands";
 import { updateLandTool } from "./tools/update-land";
 
@@ -60,6 +61,7 @@ const TOOLS: ToolDefinition<ZodRawShape>[] = [
   setLandStatusTool,
   getPaymentStatusTool,
   listPaymentsTool,
+  listChatsTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/test-preload.ts
+++ b/apps/mcp-server/src/test-preload.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 import { connectMongoose, disconnectMongoose } from "@backend/db/mongoose";
-import { Contract, Land, Payment, RentalRequest, User } from "@backend/db/schemas";
+import { Chat, ChatMessage, Contract, Land, Payment, RentalRequest, User } from "@backend/db/schemas";
 
 const now = new Date().toISOString();
 
@@ -38,6 +38,9 @@ export const SEED_USERS = [
   { clerkUserId: "user_admin", email: "admin@test.com", role: "admin", status: "active", profile: { fullName: "Admin de Prueba" } },
   { clerkUserId: "user_regular", email: "user@test.com", role: "user", status: "active", profile: { fullName: "Usuario Regular" } },
   { clerkUserId: "user_blocked", email: "blocked@test.com", role: "user", status: "blocked", profile: { fullName: "Usuario Bloqueado" } },
+  { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Usuario Seed" } },
+  { clerkUserId: "user_tenant_01", email: "tenant1@test.com", role: "user", status: "active", profile: { fullName: "Arrendatario Uno" } },
+  { clerkUserId: "user_other", email: "other@test.com", role: "user", status: "active", profile: { fullName: "Otro Usuario" } },
 ];
 
 export const SEED_RENTAL_REQUESTS = [
@@ -98,6 +101,55 @@ export const SEED_PAYMENTS = [
   },
 ];
 
+export const SEED_CHATS = [
+  {
+    id: "chat_seed_01",
+    landId: "land_a",
+    participants: [
+      { userId: "user_seed", role: "owner" },
+      { userId: "user_tenant_01", role: "tenant" },
+    ],
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "chat_seed_02",
+    landId: "land_b",
+    participants: [
+      { userId: "user_admin", role: "admin" },
+      { userId: "user_regular", role: "tenant" },
+    ],
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+export const SEED_CHAT_MESSAGES = [
+  {
+    id: "msg_seed_01",
+    chatId: "chat_seed_01",
+    senderId: "user_seed",
+    text: "Hola, estoy interesado en el terreno.",
+    createdAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "msg_seed_02",
+    chatId: "chat_seed_01",
+    senderId: "user_tenant_01",
+    text: "¡Hola! Sí, el terreno está disponible.",
+    createdAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "msg_seed_03",
+    chatId: "chat_seed_01",
+    senderId: "user_seed",
+    text: "¿Cuál es el precio mensual?",
+    createdAt: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+  },
+];
+
 const mongod = await MongoMemoryServer.create();
 process.env.MONGODB_URI = `${mongod.getUri()}terrashare_mcp`;
 
@@ -114,6 +166,10 @@ async function seed(): Promise<void> {
   await Contract.insertMany(SEED_CONTRACTS.map((c) => ({ ...c })));
   await Payment.deleteMany({});
   await Payment.insertMany(SEED_PAYMENTS.map((p) => ({ ...p })));
+  await Chat.deleteMany({});
+  await Chat.insertMany(SEED_CHATS.map((c) => ({ ...c })));
+  await ChatMessage.deleteMany({});
+  await ChatMessage.insertMany(SEED_CHAT_MESSAGES.map((m) => ({ ...m })));
 }
 
 await seed();

--- a/apps/mcp-server/src/tools/get-analytics-overview.test.ts
+++ b/apps/mcp-server/src/tools/get-analytics-overview.test.ts
@@ -56,9 +56,10 @@ describe("get_analytics_overview tool (HU-88 #205)", () => {
 
   it("incluye el total y activos de usuarios", async () => {
     const res = await getAnalyticsOverview();
-    // Preload: user_admin, user_regular (activos), user_blocked (bloqueado).
-    expect(res.users.total).toBe(3);
-    expect(res.users.active).toBe(2);
+    // Preload: user_admin, user_regular, user_seed, user_tenant_01, user_other
+    // (activos) y user_blocked (bloqueado).
+    expect(res.users.total).toBe(6);
+    expect(res.users.active).toBe(5);
   });
 
   describe("sin solicitudes ni pagos", () => {

--- a/apps/mcp-server/src/tools/list-chats.test.ts
+++ b/apps/mcp-server/src/tools/list-chats.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+
+import { listChats } from "./list-chats";
+
+describe("list_chats tool (HU-83 #198)", () => {
+  it("devuelve chats donde el usuario es participante", async () => {
+    const result = await listChats({
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const chats = (result as { items: unknown[] }).items;
+    expect(Array.isArray(chats)).toBe(true);
+    expect(chats.length).toBeGreaterThan(0);
+  });
+
+  it("devuelve todos los chats para un administrador", async () => {
+    const result = await listChats({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const chats = (result as { items: unknown[] }).items;
+    expect(Array.isArray(chats)).toBe(true);
+    expect(chats.length).toBeGreaterThan(0);
+  });
+
+  it("devuelve array vacío si el usuario no tiene chats", async () => {
+    const result = await listChats({
+      actingUserId: "user_no_chats",
+      actingUserRole: "user",
+    });
+    const chats = (result as { items: unknown[] }).items;
+    expect(chats.length).toBe(0);
+  });
+
+  it("no expone campos internos de Mongo", async () => {
+    const result = await listChats({
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const chats = (result as { items: Record<string, unknown>[] }).items;
+    expect(chats.every((c) => !("_id" in c) && !("__v" in c))).toBe(true);
+  });
+
+  it("lanza error cuando no hay usuario autenticado", async () => {
+    await expect(
+      listChats({ actingUserId: null, actingUserRole: "user" })
+    ).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+
+  it("incluye campos relevantes en cada chat", async () => {
+    const result = await listChats({
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const chats = (result as { items: Record<string, unknown>[] }).items;
+    expect(chats.length).toBeGreaterThan(0);
+    const chat = chats[0];
+    expect(chat).toHaveProperty("id");
+    expect(chat).toHaveProperty("participants");
+    expect(chat).toHaveProperty("status");
+    expect(chat).toHaveProperty("createdAt");
+  });
+});

--- a/apps/mcp-server/src/tools/list-chats.ts
+++ b/apps/mcp-server/src/tools/list-chats.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+import { Chat } from "@backend/db/schemas";
+import { isAdmin } from "@backend/lib/auth-helpers";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-83 (#198): Listar chats. Devuelve los chats donde el usuario
+ * es participante. Los administradores ven todos los chats.
+ */
+
+export const listChatsInput = {};
+
+export async function listChats(rawInput: {
+  actingUserId: string | null;
+  actingUserRole?: string;
+}): Promise<{ items: Record<string, unknown>[]; total: number }> {
+  if (!rawInput.actingUserId) {
+    throw new ToolError("Se requiere un usuario autenticado");
+  }
+
+  const query: Record<string, unknown> = {};
+  if (
+    !isAdmin({
+      id: rawInput.actingUserId,
+      role: rawInput.actingUserRole ?? "user",
+    } as any)
+  ) {
+    query["participants.userId"] = rawInput.actingUserId;
+  }
+
+  const docs = await Chat.find(query).sort({ createdAt: -1 }).lean();
+  const items = (docs as unknown as Record<string, unknown>[]).map((d) => {
+    const { _id, __v, ...rest } = d;
+    return rest;
+  });
+
+  return { items, total: items.length };
+}
+
+/**
+ * Definición de la tool. Requiere usuario autenticado.
+ */
+export const listChatsTool: ToolDefinition<typeof listChatsInput> = {
+  name: "list_chats",
+  title: "Listar chats",
+  description:
+    "Devuelve los chats donde el usuario es participante. Los administradores ven todos los chats.",
+  inputSchema: listChatsInput,
+  requires: "user",
+  handler: (_args, ctx) =>
+    listChats({
+      actingUserId: ctx.actingUser?.id ?? null,
+      actingUserRole: ctx.actingUser?.role,
+    }),
+};


### PR DESCRIPTION
What was implemented:

- Tool list_chats: Lists chats where the user is a participant
- Unit tests: 6 tests covering participant filter, admin sees all, empty results, Mongo fields, auth, field validation
- Registration: Tool registered in server.ts TOOLS array

Technical details:

- Input: none (uses ctx.actingUser)
- Access: user (requires MCP_ACTING_USER_ID)
- Filters chats by participants[].userId for regular users
- Admins see all chats
- Passes actingUserRole from ctx

Verification:

- All MCP server tests pass

Closes #198