### PR TITLE
feat(mcp): implement get_chat_messages tool (HU-84 #199)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -121,6 +121,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `get_payment_status` | HU-80 | #195 | ✅ implementada |
 | `list_payments` | HU-81 | #196 | ✅ implementada |
 | `list_chats` | HU-83 | #198 | ✅ implementada |
+| `get_chat_messages` | HU-84 | #199 | ✅ implementada |
 
 ## Tests
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -27,6 +27,7 @@ import { setLandStatusTool } from "./tools/set-land-status";
 import { getPaymentStatusTool } from "./tools/get-payment-status";
 import { listPaymentsTool } from "./tools/list-payments";
 import { listChatsTool } from "./tools/list-chats";
+import { getChatMessagesTool } from "./tools/get-chat-messages";
 import { searchLandsTool } from "./tools/search-lands";
 import { updateLandTool } from "./tools/update-land";
 
@@ -62,6 +63,7 @@ const TOOLS: ToolDefinition<ZodRawShape>[] = [
   getPaymentStatusTool,
   listPaymentsTool,
   listChatsTool,
+  getChatMessagesTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/get-chat-messages.test.ts
+++ b/apps/mcp-server/src/tools/get-chat-messages.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { getChatMessages } from "./get-chat-messages";
+
+describe("get_chat_messages tool (HU-84 #199)", () => {
+  it("devuelve mensajes de un chat existente", async () => {
+    const result = await getChatMessages({
+      chatId: "chat_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const messages = (result as { items: unknown[] }).items;
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it("permite a un administrador ver mensajes de cualquier chat", async () => {
+    const result = await getChatMessages({
+      chatId: "chat_seed_01",
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const messages = (result as { items: unknown[] }).items;
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it("lanza error cuando el chat no existe", async () => {
+    await expect(
+      getChatMessages({
+        chatId: "nonexistent",
+        actingUserId: "user_seed",
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Chat no encontrado");
+  });
+
+  it("lanza error cuando el usuario no es participante", async () => {
+    await expect(
+      getChatMessages({
+        chatId: "chat_seed_01",
+        actingUserId: "user_other",
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("No autorizado");
+  });
+
+  it("lanza error cuando no hay usuario autenticado", async () => {
+    await expect(
+      getChatMessages({
+        chatId: "chat_seed_01",
+        actingUserId: null,
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+
+  it("no expone campos internos de Mongo", async () => {
+    const result = await getChatMessages({
+      chatId: "chat_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const messages = (result as { items: Record<string, unknown>[] }).items;
+    expect(messages.every((m) => !("_id" in m) && !("__v" in m))).toBe(true);
+  });
+
+  it("ordena mensajes por fecha de creación ascendente", async () => {
+    const result = await getChatMessages({
+      chatId: "chat_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const messages = (result as { items: { createdAt: string }[] }).items;
+    expect(messages.length).toBeGreaterThan(1);
+    expect(new Date(messages[0].createdAt).getTime()).toBeLessThanOrEqual(
+      new Date(messages[1].createdAt).getTime()
+    );
+  });
+
+  it("incluye campos relevantes en cada mensaje", async () => {
+    const result = await getChatMessages({
+      chatId: "chat_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const messages = (result as { items: Record<string, unknown>[] }).items;
+    expect(messages.length).toBeGreaterThan(0);
+    const msg = messages[0];
+    expect(msg).toHaveProperty("id");
+    expect(msg).toHaveProperty("chatId");
+    expect(msg).toHaveProperty("senderId");
+    expect(msg).toHaveProperty("text");
+    expect(msg).toHaveProperty("createdAt");
+  });
+});

--- a/apps/mcp-server/src/tools/get-chat-messages.ts
+++ b/apps/mcp-server/src/tools/get-chat-messages.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+import { Chat, ChatMessage } from "@backend/db/schemas";
+import { canReadChat } from "@backend/lib/auth-helpers";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+export const getChatMessagesInput = {
+  chatId: z.string().min(1).describe("ID del chat"),
+};
+
+export async function getChatMessages(rawInput: {
+  chatId: string;
+  actingUserId: string | null;
+  actingUserRole?: string;
+}): Promise<{ items: Record<string, unknown>[]; total: number }> {
+  if (!rawInput.actingUserId) {
+    throw new ToolError("Se requiere un usuario autenticado");
+  }
+
+  const chat = await Chat.findOne({ id: rawInput.chatId }).lean();
+  if (!chat) throw new ToolError("Chat no encontrado");
+
+  if (
+    !canReadChat(
+      { id: rawInput.actingUserId, role: rawInput.actingUserRole ?? "user" } as any,
+      chat as any
+    )
+  ) {
+    throw new ToolError("No autorizado para ver este chat");
+  }
+
+  const docs = await ChatMessage.find({ chatId: rawInput.chatId })
+    .sort({ createdAt: 1 })
+    .lean();
+  const items = (docs as unknown as Record<string, unknown>[]).map((d) => {
+    const { _id, __v, ...rest } = d;
+    return rest;
+  });
+
+  return { items, total: items.length };
+}
+
+export const getChatMessagesTool: ToolDefinition<typeof getChatMessagesInput> = {
+  name: "get_chat_messages",
+  title: "Obtener mensajes de chat",
+  description:
+    "Devuelve los mensajes de un chat ordenados por fecha. Solo los participantes o un administrador pueden verlos.",
+  inputSchema: getChatMessagesInput,
+  requires: "user",
+  handler: (args, ctx) =>
+    getChatMessages({
+      chatId: args.chatId as string,
+      actingUserId: ctx.actingUser?.id ?? null,
+      actingUserRole: ctx.actingUser?.role,
+    }),
+};


### PR DESCRIPTION
What was implemented:

- Tool get_chat_messages: Returns messages for a chat sorted by creation date
- Unit tests: 8 tests covering message retrieval, admin access, chat not found, unauthorized, auth, Mongo fields, sorting, field validation
- Registration: Tool registered in server.ts TOOLS array

Technical details:

- Input: chatId (string, required)
- Access: user (requires MCP_ACTING_USER_ID)
- Uses canReadChat permission helper (participant or admin)
- Messages sorted by createdAt ascending
- Passes actingUserRole from ctx

Verification:

- All MCP server tests pass

Closes #199