### PR TITLE
feat(mcp): implement capture_lead tool (HU-88 #203)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -122,6 +122,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `list_payments` | HU-81 | #196 | ✅ implementada |
 | `list_chats` | HU-83 | #198 | ✅ implementada |
 | `get_chat_messages` | HU-84 | #199 | ✅ implementada |
+| `capture_lead` | HU-88 | #203 | ✅ implementada |
 
 ## Tests
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -28,6 +28,7 @@ import { getPaymentStatusTool } from "./tools/get-payment-status";
 import { listPaymentsTool } from "./tools/list-payments";
 import { listChatsTool } from "./tools/list-chats";
 import { getChatMessagesTool } from "./tools/get-chat-messages";
+import { captureLeadTool } from "./tools/capture-lead";
 import { searchLandsTool } from "./tools/search-lands";
 import { updateLandTool } from "./tools/update-land";
 
@@ -64,6 +65,7 @@ const TOOLS: ToolDefinition<ZodRawShape>[] = [
   listPaymentsTool,
   listChatsTool,
   getChatMessagesTool,
+  captureLeadTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/test-preload.ts
+++ b/apps/mcp-server/src/test-preload.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 import { connectMongoose, disconnectMongoose } from "@backend/db/mongoose";
-import { Chat, ChatMessage, Contract, Land, Payment, RentalRequest, User } from "@backend/db/schemas";
+import { Chat, ChatMessage, Contract, Land, Lead, Payment, RentalRequest, User } from "@backend/db/schemas";
 
 const now = new Date().toISOString();
 
@@ -150,6 +150,27 @@ export const SEED_CHAT_MESSAGES = [
   },
 ];
 
+export const SEED_LEADS = [
+  {
+    id: "lead_01",
+    email: "lead1@test.com",
+    source: "landing",
+    createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "lead_02",
+    email: "lead2@test.com",
+    source: "app-web",
+    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "lead_dup_01",
+    email: "dup@example.com",
+    source: "landing",
+    createdAt: new Date().toISOString(),
+  },
+];
+
 const mongod = await MongoMemoryServer.create();
 process.env.MONGODB_URI = `${mongod.getUri()}terrashare_mcp`;
 
@@ -170,6 +191,8 @@ async function seed(): Promise<void> {
   await Chat.insertMany(SEED_CHATS.map((c) => ({ ...c })));
   await ChatMessage.deleteMany({});
   await ChatMessage.insertMany(SEED_CHAT_MESSAGES.map((m) => ({ ...m })));
+  await Lead.deleteMany({});
+  await Lead.insertMany(SEED_LEADS.map((l) => ({ ...l })));
 }
 
 await seed();

--- a/apps/mcp-server/src/tools/capture-lead.test.ts
+++ b/apps/mcp-server/src/tools/capture-lead.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { captureLead } from "./capture-lead";
+
+describe("capture_lead tool (HU-88 #203)", () => {
+  it("captura un nuevo lead correctamente", async () => {
+    const result = await captureLead({
+      email: "nuevo@example.com",
+      source: "landing",
+    });
+    expect(result).toBeDefined();
+    expect((result as { email: string }).email).toBe("nuevo@example.com");
+    expect((result as { source: string }).source).toBe("landing");
+    expect((result as { id: string }).id).toBeDefined();
+  });
+
+  it("captura lead con source app-web", async () => {
+    const result = await captureLead({
+      email: "app@example.com",
+      source: "app-web",
+    });
+    expect((result as { source: string }).source).toBe("app-web");
+  });
+
+  it("lanza error si el email ya existe", async () => {
+    await expect(
+      captureLead({
+        email: "dup@example.com",
+        source: "app-web",
+      })
+    ).rejects.toThrow("Ya existe un lead con este email");
+  });
+
+  it("lanza error si el email es inválido", async () => {
+    await expect(
+      captureLead({
+        email: "invalid-email",
+        source: "landing",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("no expone campos internos de Mongo", async () => {
+    const result = await captureLead({
+      email: "test2@example.com",
+      source: "landing",
+    });
+    const lead = result as Record<string, unknown>;
+    expect(lead).not.toHaveProperty("_id");
+    expect(lead).not.toHaveProperty("__v");
+  });
+
+  it("asigna createdAt automáticamente", async () => {
+    const before = new Date().toISOString();
+    const result = await captureLead({
+      email: "test3@example.com",
+      source: "landing",
+    });
+    const createdAt = (result as { createdAt: Date }).createdAt;
+    expect(new Date(createdAt).getTime()).toBeGreaterThanOrEqual(new Date(before).getTime());
+  });
+});

--- a/apps/mcp-server/src/tools/capture-lead.ts
+++ b/apps/mcp-server/src/tools/capture-lead.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { Lead } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-88 (#203): Capturar lead. Registra un nuevo lead de interés en la
+ * plataforma. Acceso público: cualquier usuario puede enviar sus datos.
+ */
+
+export const captureLeadInput = {
+  email: z.string().email().describe("Email del lead"),
+  source: z.enum(["landing", "app-web", "admin-dashboard"]).describe("Fuente del lead"),
+};
+
+export async function captureLead(rawInput: {
+  email: string;
+  source: string;
+}): Promise<Record<string, unknown>> {
+  const parsed = z.object(captureLeadInput).safeParse(rawInput);
+  if (!parsed.success) throw new ToolError("Email inválido");
+
+  const email = parsed.data.email.trim().toLowerCase();
+
+  const existing = await Lead.findOne({ email }).lean();
+  if (existing) throw new ToolError("Ya existe un lead con este email");
+
+  const lead = await Lead.create({
+    id: `lead_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    email,
+    source: parsed.data.source,
+    createdAt: new Date(),
+  });
+
+  const { _id, __v, ...rest } = lead.toObject() as unknown as Record<string, unknown>;
+  return rest;
+}
+
+/**
+ * Definición de la tool. Pública (no requiere identidad): cualquier
+ * usuario puede enviar un lead desde la landing o la app.
+ */
+export const captureLeadTool: ToolDefinition<typeof captureLeadInput> = {
+  name: "capture_lead",
+  title: "Capturar lead",
+  description: "Registra un nuevo lead de interés en la plataforma. Acceso público.",
+  inputSchema: captureLeadInput,
+  requires: "public",
+  handler: (args) =>
+    captureLead({
+      email: args.email as string,
+      source: args.source as string,
+    }),
+};


### PR DESCRIPTION
What was implemented:

- Tool capture_lead: Creates a new lead (public access, no auth required)
- Unit tests: 6 tests covering successful capture, source variants, duplicate email rejection, invalid email, Mongo fields, auto createdAt
- Registration: Tool registered in server.ts TOOLS array

Technical details:

- Input: email (string, validated), source (enum: landing/app-web/admin-dashboard)
- Access: public (no auth required)
- Returns ToolError for duplicate emails
- Generates unique ID for each lead

Verification:

- All MCP server tests pass

Closes #203