### PR TITLE
feat(mcp): implement list_audit_events tool (HU-92 #209)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -124,6 +124,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `get_chat_messages` | HU-84 | #199 | ✅ implementada |
 | `capture_lead` | HU-88 | #203 | ✅ implementada |
 | `list_leads` | HU-89 | #204 | ✅ implementada |
+| `list_audit_events` | HU-92 | #209 | ✅ implementada |
 
 ## Tests
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -30,6 +30,7 @@ import { listChatsTool } from "./tools/list-chats";
 import { getChatMessagesTool } from "./tools/get-chat-messages";
 import { captureLeadTool } from "./tools/capture-lead";
 import { listLeadsTool } from "./tools/list-leads";
+import { listAuditEventsTool } from "./tools/list-audit-events";
 import { searchLandsTool } from "./tools/search-lands";
 import { updateLandTool } from "./tools/update-land";
 
@@ -68,6 +69,7 @@ const TOOLS: ToolDefinition<ZodRawShape>[] = [
   getChatMessagesTool,
   captureLeadTool,
   listLeadsTool,
+  listAuditEventsTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/test-preload.ts
+++ b/apps/mcp-server/src/test-preload.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 import { connectMongoose, disconnectMongoose } from "@backend/db/mongoose";
-import { Chat, ChatMessage, Contract, Land, Lead, Payment, RentalRequest, User } from "@backend/db/schemas";
+import { AuditEvent, Chat, ChatMessage, Contract, Land, Lead, Payment, RentalRequest, User } from "@backend/db/schemas";
 
 const now = new Date().toISOString();
 
@@ -171,6 +171,29 @@ export const SEED_LEADS = [
   },
 ];
 
+export const SEED_AUDIT_EVENTS = [
+  {
+    id: "audit_seed_01",
+    actorId: "user_admin",
+    actorRole: "admin",
+    entity: "land",
+    action: "created",
+    entityId: "land_a",
+    metadata: { title: "Finca agrícola en Chiriquí" },
+    createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "audit_seed_02",
+    actorId: "user_admin",
+    actorRole: "admin",
+    entity: "user",
+    action: "updated",
+    entityId: "user_regular",
+    metadata: { field: "status" },
+    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
 const mongod = await MongoMemoryServer.create();
 process.env.MONGODB_URI = `${mongod.getUri()}terrashare_mcp`;
 
@@ -193,6 +216,8 @@ async function seed(): Promise<void> {
   await ChatMessage.insertMany(SEED_CHAT_MESSAGES.map((m) => ({ ...m })));
   await Lead.deleteMany({});
   await Lead.insertMany(SEED_LEADS.map((l) => ({ ...l })));
+  await AuditEvent.deleteMany({});
+  await AuditEvent.insertMany(SEED_AUDIT_EVENTS.map((e) => ({ ...e })));
 }
 
 await seed();

--- a/apps/mcp-server/src/tools/list-audit-events.test.ts
+++ b/apps/mcp-server/src/tools/list-audit-events.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { listAuditEvents } from "./list-audit-events";
+
+describe("list_audit_events tool (HU-92 #209)", () => {
+  it("devuelve todos los eventos para un administrador", async () => {
+    const result = await listAuditEvents({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const events = (result as { items: unknown[] }).items;
+    expect(Array.isArray(events)).toBe(true);
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it("lanza error cuando el usuario no es administrador", async () => {
+    await expect(
+      listAuditEvents({
+        actingUserId: "user_regular",
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("No autorizado");
+  });
+
+  it("filtra por entity", async () => {
+    const result = await listAuditEvents({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+      entity: "land",
+    });
+    const events = (result as { items: { entity: string }[] }).items;
+    expect(events.every((e) => e.entity === "land")).toBe(true);
+  });
+
+  it("filtra por action", async () => {
+    const result = await listAuditEvents({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+      action: "created",
+    });
+    const events = (result as { items: { action: string }[] }).items;
+    expect(events.every((e) => e.action === "created")).toBe(true);
+  });
+
+  it("lanza error cuando no hay usuario autenticado", async () => {
+    await expect(
+      listAuditEvents({
+        actingUserId: null,
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+
+  it("no expone campos internos de Mongo", async () => {
+    const result = await listAuditEvents({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const events = (result as { items: Record<string, unknown>[] }).items;
+    expect(events.every((e) => !("_id" in e) && !("__v" in e))).toBe(true);
+  });
+
+  it("ordena por fecha de creación descendente", async () => {
+    const result = await listAuditEvents({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const events = (result as { items: { createdAt: Date }[] }).items;
+    expect(events.length).toBeGreaterThan(1);
+    expect(new Date(events[0].createdAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(events[1].createdAt).getTime()
+    );
+  });
+
+  it("incluye campos relevantes en cada evento", async () => {
+    const result = await listAuditEvents({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const events = (result as { items: Record<string, unknown>[] }).items;
+    expect(events.length).toBeGreaterThan(0);
+    const event = events[0];
+    expect(event).toHaveProperty("id");
+    expect(event).toHaveProperty("actorId");
+    expect(event).toHaveProperty("entity");
+    expect(event).toHaveProperty("action");
+    expect(event).toHaveProperty("entityId");
+    expect(event).toHaveProperty("createdAt");
+  });
+});

--- a/apps/mcp-server/src/tools/list-audit-events.ts
+++ b/apps/mcp-server/src/tools/list-audit-events.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { AuditEvent } from "@backend/db/schemas";
+import { canAccessAuditEvents } from "@backend/lib/auth-helpers";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+export const listAuditEventsInput = {
+  entity: z.enum(["auth", "user", "land", "rental_request", "contract", "payment", "chat", "report", "webhook", "backup"]).optional().describe("Filtrar por tipo de entidad"),
+  action: z.enum(["created", "updated", "deleted", "approved", "rejected", "cancelled", "paid", "refunded", "signed", "completed", "status_changed", "verified"]).optional().describe("Filtrar por tipo de acción"),
+};
+
+export async function listAuditEvents(rawInput: {
+  actingUserId: string | null;
+  actingUserRole?: string;
+  entity?: string;
+  action?: string;
+}): Promise<{ items: Record<string, unknown>[]; total: number }> {
+  if (!rawInput.actingUserId) {
+    throw new ToolError("Se requiere un usuario autenticado");
+  }
+
+  if (!canAccessAuditEvents({ id: rawInput.actingUserId, role: rawInput.actingUserRole ?? "user" } as any)) {
+    throw new ToolError("No autorizado");
+  }
+
+  const query: Record<string, unknown> = {};
+  if (rawInput.entity) query.entity = rawInput.entity;
+  if (rawInput.action) query.action = rawInput.action;
+
+  const docs = await AuditEvent.find(query).sort({ createdAt: -1 }).lean();
+  const items = (docs as unknown as Record<string, unknown>[]).map((d) => {
+    const { _id, __v, ...rest } = d;
+    return rest;
+  });
+
+  return { items, total: items.length };
+}
+
+export const listAuditEventsTool: ToolDefinition<typeof listAuditEventsInput> = {
+  name: "list_audit_events",
+  title: "Listar eventos de auditoría",
+  description: "Devuelve los eventos de auditoría del sistema. Solo administradores. Permite filtrar por entidad y acción.",
+  inputSchema: listAuditEventsInput,
+  requires: "admin",
+  handler: (args, ctx) =>
+    listAuditEvents({
+      actingUserId: ctx.actingUser?.id ?? null,
+      actingUserRole: ctx.actingUser?.role,
+      entity: args.entity as string | undefined,
+      action: args.action as string | undefined,
+    }),
+};


### PR DESCRIPTION
What was implemented:

- Tool list_audit_events: Lists audit events (admin-only) with optional entity/action filters
- Unit tests: 8 tests covering admin access, non-admin rejection, entity filter, action filter, unauthenticated, Mongo fields, sorting, field validation
- Registration: Tool registered in server.ts TOOLS array
- Test data: Added SEED_AUDIT_EVENTS to test-preload.ts

Technical details:

- Input: entity (optional enum), action (optional enum)
- Access: admin (requires MCP_ACTING_USER_ID with admin role)
- Uses canAccessAuditEvents permission helper (admin check)
- Events sorted by createdAt descending
- Passes actingUserRole from ctx

Verification:

- All MCP server tests pass

Closes #209