### PR TITLE
feat(mcp): implement list_notifications + mark_notification_read tools (HU-90/HU-91 #202)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -459,3 +459,27 @@ export const IdempotencyKey = mongoose.model<IIdempotencyKey>("IdempotencyKey", 
 export const Favorite = mongoose.model<IFavorite>("Favorite", FavoriteSchema);
 export const Report = mongoose.model<IReport>("Report", ReportSchema);
 export const BackupRecord = mongoose.model<IBackupRecord>("BackupRecord", BackupRecordSchema);
+
+export interface INotification extends Document {
+  id: string;
+  userId: string;
+  type: string;
+  title: string;
+  body?: string;
+  read: boolean;
+  readAt?: string;
+  createdAt: Date;
+}
+
+const NotificationSchema = new Schema<INotification>({
+  id: { type: String, required: true, unique: true },
+  userId: { type: String, required: true, index: true },
+  type: { type: String, required: true },
+  title: { type: String, required: true },
+  body: { type: String },
+  read: { type: Boolean, default: false },
+  readAt: { type: String },
+  createdAt: { type: Date, default: Date.now },
+}, { timestamps: false });
+
+export const Notification = mongoose.models.Notification || mongoose.model<INotification>("Notification", NotificationSchema);

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -125,6 +125,8 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `capture_lead` | HU-88 | #203 | ✅ implementada |
 | `list_leads` | HU-89 | #204 | ✅ implementada |
 | `list_audit_events` | HU-92 | #209 | ✅ implementada |
+| `list_notifications` | HU-90 | #202 | ✅ implementada |
+| `mark_notification_read` | HU-91 | #202 | ✅ implementada |
 
 ## Tests
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -31,6 +31,8 @@ import { getChatMessagesTool } from "./tools/get-chat-messages";
 import { captureLeadTool } from "./tools/capture-lead";
 import { listLeadsTool } from "./tools/list-leads";
 import { listAuditEventsTool } from "./tools/list-audit-events";
+import { listNotificationsTool } from "./tools/list-notifications";
+import { markNotificationReadTool } from "./tools/mark-notification-read";
 import { searchLandsTool } from "./tools/search-lands";
 import { updateLandTool } from "./tools/update-land";
 
@@ -70,6 +72,8 @@ const TOOLS: ToolDefinition<ZodRawShape>[] = [
   captureLeadTool,
   listLeadsTool,
   listAuditEventsTool,
+  listNotificationsTool,
+  markNotificationReadTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/test-preload.ts
+++ b/apps/mcp-server/src/test-preload.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 import { connectMongoose, disconnectMongoose } from "@backend/db/mongoose";
-import { AuditEvent, Chat, ChatMessage, Contract, Land, Lead, Payment, RentalRequest, User } from "@backend/db/schemas";
+import { AuditEvent, Chat, ChatMessage, Contract, Land, Lead, Notification, Payment, RentalRequest, User } from "@backend/db/schemas";
 
 const now = new Date().toISOString();
 
@@ -194,6 +194,37 @@ export const SEED_AUDIT_EVENTS = [
   },
 ];
 
+export const SEED_NOTIFICATIONS = [
+  {
+    id: "notif_seed_01",
+    userId: "user_seed",
+    type: "rental_request",
+    title: "Nueva solicitud de alquiler",
+    body: "Hay una solicitud pendiente para tu terreno",
+    read: false,
+    createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "notif_seed_02",
+    userId: "user_seed",
+    type: "payment",
+    title: "Pago recibido",
+    body: "Pago de $300 confirmado",
+    read: true,
+    readAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "notif_seed_03",
+    userId: "user_regular",
+    type: "system",
+    title: "Bienvenido a TerraShare",
+    body: "Tu cuenta ha sido creada exitosamente",
+    read: false,
+    createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
 const mongod = await MongoMemoryServer.create();
 process.env.MONGODB_URI = `${mongod.getUri()}terrashare_mcp`;
 
@@ -218,6 +249,8 @@ async function seed(): Promise<void> {
   await Lead.insertMany(SEED_LEADS.map((l) => ({ ...l })));
   await AuditEvent.deleteMany({});
   await AuditEvent.insertMany(SEED_AUDIT_EVENTS.map((e) => ({ ...e })));
+  await Notification.deleteMany({});
+  await Notification.insertMany(SEED_NOTIFICATIONS.map((n) => ({ ...n })));
 }
 
 await seed();

--- a/apps/mcp-server/src/tools/list-notifications.test.ts
+++ b/apps/mcp-server/src/tools/list-notifications.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+
+import { listNotifications } from "./list-notifications";
+
+describe("list_notifications tool (HU-90 #202)", () => {
+  it("devuelve notificaciones del usuario autenticado", async () => {
+    const result = await listNotifications({
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const notifs = (result as { items: unknown[] }).items;
+    expect(Array.isArray(notifs)).toBe(true);
+    expect(notifs.length).toBe(2);
+    expect(notifs.every((n: unknown) => (n as { userId: string }).userId === "user_seed")).toBe(true);
+  });
+
+  it("permite a un administrador ver todas las notificaciones", async () => {
+    const result = await listNotifications({
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    const notifs = (result as { items: unknown[] }).items;
+    expect(Array.isArray(notifs)).toBe(true);
+    expect(notifs.length).toBeGreaterThan(0);
+  });
+
+  it("filtra por unreadOnly", async () => {
+    const result = await listNotifications({
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+      unreadOnly: true,
+    });
+    const notifs = (result as { items: { read: boolean }[] }).items;
+    expect(notifs.every((n) => n.read === false)).toBe(true);
+  });
+
+  it("devuelve array vacío si el usuario no tiene notificaciones", async () => {
+    const result = await listNotifications({
+      actingUserId: "user_no_notifs",
+      actingUserRole: "user",
+    });
+    const notifs = (result as { items: unknown[] }).items;
+    expect(notifs.length).toBe(0);
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const result = await listNotifications({
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const notifs = (result as { items: Record<string, unknown>[] }).items;
+    expect(notifs.every((n) => !("_id" in n) && !("__v" in n))).toBe(true);
+  });
+
+  it("lanza error cuando no hay usuario autenticado", async () => {
+    await expect(
+      listNotifications({
+        actingUserId: null,
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+
+  it("incluye campos relevantes en cada notificación", async () => {
+    const result = await listNotifications({
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const notifs = (result as { items: Record<string, unknown>[] }).items;
+    expect(notifs.length).toBeGreaterThan(0);
+    const notif = notifs[0];
+    expect(notif).toHaveProperty("id");
+    expect(notif).toHaveProperty("userId");
+    expect(notif).toHaveProperty("type");
+    expect(notif).toHaveProperty("title");
+    expect(notif).toHaveProperty("read");
+    expect(notif).toHaveProperty("createdAt");
+  });
+});

--- a/apps/mcp-server/src/tools/list-notifications.ts
+++ b/apps/mcp-server/src/tools/list-notifications.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+import { Notification } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-90 (#202): Listar notificaciones. Devuelve las notificaciones
+ * del usuario autenticado, con opción de filtrar solo no leídas.
+ *
+ * NOTA: Esta tool consulta MongoDB directamente. El endpoint REST equivalente
+ * (GET /notifications) usa un store in-memory. Hasta que REST migre a Mongo,
+ * las notificaciones creadas vía REST no aparecerán aquí y viceversa.
+ */
+
+export const listNotificationsInput = {
+  unreadOnly: z.boolean().optional().describe("Mostrar solo notificaciones no leídas"),
+};
+
+export type ListNotificationsInput = z.infer<z.ZodObject<typeof listNotificationsInput>>;
+
+export interface ListNotificationsResult {
+  items: Record<string, unknown>[];
+  total: number;
+}
+
+/**
+ * Función pura de búsqueda (testeable de forma aislada). Devuelve las
+ * notificaciones del usuario, con filtro opcional de no leídas.
+ */
+export async function listNotifications(rawInput: {
+  actingUserId: string | null;
+  actingUserRole?: string;
+  unreadOnly?: boolean;
+}): Promise<ListNotificationsResult> {
+  if (!rawInput.actingUserId) {
+    throw new ToolError("Se requiere un usuario autenticado");
+  }
+
+  // Admin sees all notifications; regular users see only their own
+  const isAdmin = rawInput.actingUserRole === "admin";
+  const query: Record<string, unknown> = {};
+
+  if (!isAdmin) {
+    query.userId = rawInput.actingUserId;
+  }
+
+  if (rawInput.unreadOnly) {
+    query.read = false;
+  }
+
+  const docs = await Notification.find(query).sort({ createdAt: -1 }).lean();
+
+  const items = (docs as unknown as Record<string, unknown>[]).map((d) => {
+    const { _id, __v, ...rest } = d;
+    return rest;
+  });
+
+  return { items, total: items.length };
+}
+
+/**
+ * Definición de la tool. Requiere usuario autenticado (scope user).
+ */
+export const listNotificationsTool: ToolDefinition<typeof listNotificationsInput> = {
+  name: "list_notifications",
+  title: "Listar notificaciones",
+  description:
+    "Devuelve las notificaciones del usuario. Los administradores ven todas. Permite filtrar por no leídas.",
+  inputSchema: listNotificationsInput,
+  requires: "user",
+  handler: (args, ctx) =>
+    listNotifications({
+      actingUserId: ctx.actingUser?.id ?? null,
+      actingUserRole: ctx.actingUser?.role,
+      unreadOnly: args.unreadOnly as boolean | undefined,
+    }),
+};

--- a/apps/mcp-server/src/tools/mark-notification-read.test.ts
+++ b/apps/mcp-server/src/tools/mark-notification-read.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+
+import { markNotificationRead } from "./mark-notification-read";
+
+describe("mark_notification_read tool (HU-91 #202)", () => {
+  it("marca una notificación como leída", async () => {
+    const result = await markNotificationRead({
+      notificationId: "notif_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    expect(result).toBeDefined();
+    expect((result as { read: boolean }).read).toBe(true);
+    expect((result as { readAt: string }).readAt).toBeDefined();
+  });
+
+  it("lanza error cuando la notificación no existe", async () => {
+    await expect(
+      markNotificationRead({
+        notificationId: "nonexistent",
+        actingUserId: "user_seed",
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Notificación no encontrada");
+  });
+
+  it("lanza error cuando el usuario no es el propietario", async () => {
+    await expect(
+      markNotificationRead({
+        notificationId: "notif_seed_03",
+        actingUserId: "user_other",
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("No autorizado");
+  });
+
+  it("permite a un administrador marcar cualquier notificación", async () => {
+    const result = await markNotificationRead({
+      notificationId: "notif_seed_03",
+      actingUserId: "user_admin",
+      actingUserRole: "admin",
+    });
+    expect(result).toBeDefined();
+    expect((result as { read: boolean }).read).toBe(true);
+  });
+
+  it("lanza error cuando no hay usuario autenticado", async () => {
+    await expect(
+      markNotificationRead({
+        notificationId: "notif_seed_01",
+        actingUserId: null,
+        actingUserRole: "user",
+      })
+    ).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const result = await markNotificationRead({
+      notificationId: "notif_seed_01",
+      actingUserId: "user_seed",
+      actingUserRole: "user",
+    });
+    const notif = result as Record<string, unknown>;
+    expect(notif).not.toHaveProperty("_id");
+    expect(notif).not.toHaveProperty("__v");
+  });
+});

--- a/apps/mcp-server/src/tools/mark-notification-read.ts
+++ b/apps/mcp-server/src/tools/mark-notification-read.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+import { Notification } from "@backend/db/schemas";
+import { canReadNotification } from "@backend/lib/auth-helpers";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-91 (#202): Marcar notificación como leída. Cambia el estado
+ * de una notificación a leída y registra la fecha de lectura.
+ *
+ * NOTA: Esta tool consulta MongoDB directamente. El endpoint REST equivalente
+ * (PATCH /notifications/:id/read) usa un store in-memory. Hasta que REST migre
+ * a Mongo, las notificaciones creadas vía REST no estarán disponibles aquí.
+ */
+
+export const markNotificationReadInput = {
+  notificationId: z.string().min(1).describe("ID de la notificación a marcar como leída"),
+};
+
+export type MarkNotificationReadInput = z.infer<z.ZodObject<typeof markNotificationReadInput>>;
+
+/**
+ * Función pura de actualización (testeable de forma aislada). Marca una
+ * notificación como leída y registra la fecha de lectura.
+ */
+export async function markNotificationRead(rawInput: {
+  notificationId: string;
+  actingUserId: string | null;
+  actingUserRole?: string;
+}): Promise<Record<string, unknown>> {
+  if (!rawInput.actingUserId) {
+    throw new ToolError("Se requiere un usuario autenticado");
+  }
+
+  const notification = await Notification.findOne({ id: rawInput.notificationId }).lean();
+  if (!notification) throw new ToolError("Notificación no encontrada");
+
+  // Check permission: only owner or admin can mark as read
+  if (!canReadNotification(
+    { id: rawInput.actingUserId, role: rawInput.actingUserRole ?? "user" } as any,
+    notification as any
+  )) {
+    throw new ToolError("No autorizado para modificar esta notificación");
+  }
+
+  const updated = await Notification.findOneAndUpdate(
+    { id: rawInput.notificationId },
+    { read: true, readAt: new Date().toISOString() },
+    { returnDocument: "after" }
+  ).lean();
+
+  if (!updated) throw new ToolError("Error al actualizar la notificación");
+
+  const { _id, __v, ...rest } = updated as unknown as Record<string, unknown>;
+  return rest;
+}
+
+/**
+ * Definición de la tool. Requiere usuario autenticado (scope user).
+ */
+export const markNotificationReadTool: ToolDefinition<typeof markNotificationReadInput> = {
+  name: "mark_notification_read",
+  title: "Marcar notificación como leída",
+  description:
+    "Marca una notificación como leída. Solo el propietario o un administrador pueden hacerlo.",
+  inputSchema: markNotificationReadInput,
+  requires: "user",
+  handler: (args, ctx) =>
+    markNotificationRead({
+      notificationId: args.notificationId as string,
+      actingUserId: ctx.actingUser?.id ?? null,
+      actingUserRole: ctx.actingUser?.role,
+    }),
+};


### PR DESCRIPTION
What was implemented:

- Tool list_notifications: Lists notifications for the authenticated user with optional unreadOnly filter
- Tool mark_notification_read: Marks a notification as read (owner or admin)
- Mongoose Notification schema added to schemas.ts (new INotification interface + model)
- Unit tests: 13 tests covering both tools
- Registration: Both tools registered in server.ts TOOLS array
- Test data: Added SEED_NOTIFICATIONS to test-preload.ts

Technical details:

list_notifications:
- Input: unreadOnly (boolean, optional)
- Access: user (requires MCP_ACTING_USER_ID)
- Admin sees all; regular users see only their own

mark_notification_read:
- Input: notificationId (string, required)
- Access: user (requires MCP_ACTING_USER_ID)
- Uses canReadNotification permission helper (owner or admin)
- Sets read=true and readAt=ISO timestamp

Both tools pass actingUserRole from ctx.

Verification:

- All 43 MCP server tests pass

Closes #202