### PR TITLE
feat(mcp): tool moderate_land para moderación admin (HU-90 #207)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -110,6 +110,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `create_contract` | HU-73 | #190 | ✅ implementada |
 | `create_payment_session` | HU-77 | #194 | ✅ implementada |
 | `refund_payment` | HU-80 | #197 | ✅ implementada |
+| `moderate_land` | HU-90 | #207 | ✅ implementada |
 
 `search_lands`: busca terrenos publicados (activos) con filtros por texto,
 ubicación, uso, operación y precio; devuelve resultados paginados.
@@ -200,6 +201,16 @@ Ejemplo de argumentos (reembolso parcial):
 
 ```json
 { "paymentId": "pay_123", "amount": 100, "reason": "Cancelación parcial", "confirm": true }
+```
+
+`moderate_land` (`requires: admin`): cambia el estado de un terreno —`inactive`
+para despublicar contenido que viole políticas, `active` para reactivarlo— y
+registra la acción en auditoría.
+
+Ejemplo de argumentos:
+
+```json
+{ "landId": "land_123", "status": "inactive", "reason": "Contenido engañoso" }
 ```
 
 ## Tests

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -323,4 +323,44 @@ describe("MCP server E2E (#234)", () => {
     expect(res.isError).toBe(true);
     await client.close();
   });
+
+  it("la lista de tools incluye moderate_land (HU-90 #207)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("moderate_land");
+    await client.close();
+  });
+
+  it("moderate_land despublica un terreno para un admin", async () => {
+    const client = await connectedClient(ADMIN_USER);
+    const res = await client.callTool({
+      name: "moderate_land",
+      arguments: { landId: "land_a", status: "inactive", reason: "e2e" },
+    });
+    const land = res.structuredContent as { landId: string; status: string };
+    expect(res.isError).toBeFalsy();
+    expect(land.landId).toBe("land_a");
+    expect(land.status).toBe("inactive");
+    await client.close();
+  });
+
+  it("moderate_land rechaza a un usuario no admin (requires admin)", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({
+      name: "moderate_land",
+      arguments: { landId: "land_a", status: "inactive" },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("moderate_land sin identidad configurada devuelve error", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({
+      name: "moderate_land",
+      arguments: { landId: "land_a", status: "inactive" },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
 });

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { createRentalRequestTool } from "./tools/create-rental-request";
 import { createContractTool } from "./tools/create-contract";
 import { createPaymentSessionTool } from "./tools/create-payment-session";
 import { refundPaymentTool } from "./tools/refund-payment";
+import { moderateLandTool } from "./tools/moderate-land";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -23,6 +24,7 @@ const TOOLS = [
   createContractTool,
   createPaymentSessionTool,
   refundPaymentTool,
+  moderateLandTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/moderate-land.test.ts
+++ b/apps/mcp-server/src/tools/moderate-land.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { AuditEvent, Land } from "@backend/db/schemas";
+import { moderateLand } from "./moderate-land";
+
+const ADMIN = { id: "user_admin", role: "admin" as const };
+
+// El preload siembra land_a (active) y lo reinicia en cada test. Solo limpiamos
+// AuditEvent (que el preload no toca).
+beforeEach(async () => {
+  await AuditEvent.deleteMany({});
+});
+
+describe("moderate_land tool (HU-90 #207)", () => {
+  it("despublica un terreno (active -> inactive)", async () => {
+    const res = await moderateLand({ landId: "land_a", status: "inactive", reason: "Spam" }, ADMIN);
+
+    expect(res.landId).toBe("land_a");
+    expect(res.previousStatus).toBe("active");
+    expect(res.status).toBe("inactive");
+  });
+
+  it("persiste el nuevo estado en Mongo", async () => {
+    await moderateLand({ landId: "land_a", status: "inactive" }, ADMIN);
+    const land = await Land.findOne({ id: "land_a" }).lean();
+    expect((land as { status: string }).status).toBe("inactive");
+  });
+
+  it("reactiva un terreno inactivo (inactive -> active)", async () => {
+    const res = await moderateLand({ landId: "land_inactive", status: "active" }, ADMIN);
+    expect(res.previousStatus).toBe("inactive");
+    expect(res.status).toBe("active");
+  });
+
+  it("registra auditoría 'rejected' al despublicar", async () => {
+    await moderateLand({ landId: "land_a", status: "inactive", reason: "Spam" }, ADMIN);
+    const audit = await AuditEvent.findOne({ entityId: "land_a", action: "rejected" }).lean();
+    expect(audit).not.toBeNull();
+    expect((audit as { entity: string }).entity).toBe("land");
+    expect((audit as { actorId: string }).actorId).toBe("user_admin");
+    expect((audit as { metadata: { reason: string } }).metadata.reason).toBe("Spam");
+  });
+
+  it("registra auditoría 'approved' al reactivar", async () => {
+    await moderateLand({ landId: "land_inactive", status: "active" }, ADMIN);
+    const audit = await AuditEvent.findOne({ entityId: "land_inactive", action: "approved" }).lean();
+    expect(audit).not.toBeNull();
+  });
+
+  it("falla si el terreno no existe", async () => {
+    await expect(
+      moderateLand({ landId: "land_x", status: "inactive" }, ADMIN),
+    ).rejects.toThrow(/no encontrado/i);
+  });
+
+  it("rechaza un estado inválido (validación del schema)", async () => {
+    await expect(
+      moderateLand({ landId: "land_a", status: "draft" }, ADMIN),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza cuando falta landId", async () => {
+    await expect(moderateLand({ status: "inactive" }, ADMIN)).rejects.toThrow();
+  });
+});

--- a/apps/mcp-server/src/tools/moderate-land.ts
+++ b/apps/mcp-server/src/tools/moderate-land.ts
@@ -1,0 +1,85 @@
+import { z, type ZodRawShape } from "zod";
+
+import { Land } from "@backend/db/schemas";
+import { createAuditEvent } from "@backend/store/audit";
+import type { ActingUser } from "../context";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-90 (#207): Moderar un terreno (admin). Espeja
+ * `PATCH /admin/lands/:landId/status`: un administrador cambia el estado de un
+ * terreno (típicamente `inactive` para despublicar contenido que viole
+ * políticas, o `active` para reactivarlo) y registra la acción en auditoría.
+ */
+
+const moderateLandShape = {
+  landId: z.string().min(1).describe("ID del terreno a moderar"),
+  status: z
+    .enum(["active", "inactive"])
+    .describe("Nuevo estado: 'inactive' despublica; 'active' reactiva"),
+  reason: z.string().max(500).optional().describe("Motivo de la moderación (auditoría)"),
+};
+const ModerateLandSchema = z.object(moderateLandShape);
+
+// Tipado como `ZodRawShape` para que `TOOLS` unifique en server.ts.
+export const moderateLandInput: ZodRawShape = moderateLandShape;
+
+/** Resultado de la moderación. */
+export interface ModerateLandResult {
+  landId: string;
+  status: string;
+  previousStatus: string;
+  title: string;
+}
+
+/**
+ * Lógica pura (testeable): cambia el estado del terreno y audita. El acceso
+ * admin lo garantiza `requires: "admin"` en la tool.
+ */
+export async function moderateLand(
+  rawInput: unknown,
+  actingUser: Pick<ActingUser, "id" | "role">,
+): Promise<ModerateLandResult> {
+  const data = ModerateLandSchema.parse(rawInput ?? {});
+
+  const land = await Land.findOne({ id: data.landId }).lean();
+  if (!land) throw new ToolError("Terreno no encontrado");
+
+  await Land.updateOne(
+    { id: data.landId },
+    { status: data.status, updatedAt: new Date().toISOString() },
+  );
+
+  // Misma semántica de auditoría que la API REST: active→approved, inactive→rejected.
+  await createAuditEvent({
+    actor: { id: actingUser.id, role: actingUser.role },
+    entity: "land",
+    action: data.status === "active" ? "approved" : "rejected",
+    entityId: data.landId,
+    metadata: { title: land.title, reason: data.reason, from: land.status, to: data.status },
+  });
+
+  return {
+    landId: data.landId,
+    status: data.status,
+    previousStatus: land.status as string,
+    title: land.title as string,
+  };
+}
+
+/**
+ * Definición de la tool. `requires: "admin"` → solo administradores; el
+ * andamiaje aplica la puerta.
+ */
+export const moderateLandTool: ToolDefinition<typeof moderateLandInput> = {
+  name: "moderate_land",
+  title: "Moderar terreno (admin)",
+  description:
+    "Cambia el estado de un terreno (solo admin): 'inactive' lo despublica, 'active' lo reactiva. Registra la acción en auditoría. Devuelve el estado anterior y el nuevo.",
+  inputSchema: moderateLandInput,
+  requires: "admin",
+  handler: (args, ctx) => {
+    const actingUser = ctx.actingUser as ActingUser;
+    return moderateLand(args, { id: actingUser.id, role: actingUser.role });
+  },
+};


### PR DESCRIPTION
## Qué

Implementa la tool MCP **`moderate_land`** (HU-90): un administrador, vía agente, modera un terreno.

## Comportamiento (espeja `PATCH /admin/lands/:landId/status`)

- **`requires: admin`** (la puerta del andamiaje rechaza a no-admins).
- Cambia el estado del terreno: `inactive` **despublica** contenido que viole políticas, `active` lo **reactiva**.
- Registra auditoría (`land/approved` al reactivar, `land/rejected` al despublicar) con `title`, `reason`, `from` y `to`.
- Devuelve `{ landId, status, previousStatus, title }`.

## Tests

- **8 unitarios** (`moderate-land.test.ts`): despublicar, persistencia, reactivar, auditoría `rejected`/`approved`, terreno inexistente, estado inválido, sin `landId`.
- **e2e** (`server.e2e.test.ts`) vía cliente MCP real: listado incluye la tool, moderación por un admin, **rechazo a no-admin**, y sin identidad.

`bun test` → 36 pass / 0 fail · `bun run typecheck` limpio.

Closes #207