### PR TITLE
feat(mcp): tool manage_user_status para moderar cuentas (HU-91 #208)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -111,6 +111,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `create_payment_session` | HU-77 | #194 | ✅ implementada |
 | `refund_payment` | HU-80 | #197 | ✅ implementada |
 | `moderate_land` | HU-90 | #207 | ✅ implementada |
+| `manage_user_status` | HU-91 | #208 | ✅ implementada |
 
 `search_lands`: busca terrenos publicados (activos) con filtros por texto,
 ubicación, uso, operación y precio; devuelve resultados paginados.
@@ -211,6 +212,16 @@ Ejemplo de argumentos:
 
 ```json
 { "landId": "land_123", "status": "inactive", "reason": "Contenido engañoso" }
+```
+
+`manage_user_status` (`requires: admin`): activa o bloquea una cuenta de usuario.
+No permite modificar la propia cuenta. **Acción sensible: exige `confirm: true`.**
+Registra auditoría.
+
+Ejemplo de argumentos:
+
+```json
+{ "userId": "user_abc", "status": "blocked", "reason": "Abuso reportado", "confirm": true }
 ```
 
 ## Tests

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -363,4 +363,44 @@ describe("MCP server E2E (#234)", () => {
     expect(res.isError).toBe(true);
     await client.close();
   });
+
+  it("la lista de tools incluye manage_user_status (HU-91 #208)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("manage_user_status");
+    await client.close();
+  });
+
+  it("manage_user_status bloquea una cuenta para un admin", async () => {
+    const client = await connectedClient(ADMIN_USER);
+    const res = await client.callTool({
+      name: "manage_user_status",
+      arguments: { userId: "user_regular", status: "blocked", confirm: true },
+    });
+    const user = res.structuredContent as { userId: string; status: string };
+    expect(res.isError).toBeFalsy();
+    expect(user.userId).toBe("user_regular");
+    expect(user.status).toBe("blocked");
+    await client.close();
+  });
+
+  it("manage_user_status rechaza a un usuario no admin (requires admin)", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({
+      name: "manage_user_status",
+      arguments: { userId: "user_blocked", status: "active", confirm: true },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("manage_user_status sin identidad configurada devuelve error", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({
+      name: "manage_user_status",
+      arguments: { userId: "user_regular", status: "blocked", confirm: true },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
 });

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -9,6 +9,7 @@ import { createContractTool } from "./tools/create-contract";
 import { createPaymentSessionTool } from "./tools/create-payment-session";
 import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
+import { manageUserStatusTool } from "./tools/manage-user-status";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -25,6 +26,7 @@ const TOOLS = [
   createPaymentSessionTool,
   refundPaymentTool,
   moderateLandTool,
+  manageUserStatusTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/manage-user-status.test.ts
+++ b/apps/mcp-server/src/tools/manage-user-status.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { AuditEvent, User } from "@backend/db/schemas";
+import { manageUserStatus } from "./manage-user-status";
+
+const ADMIN = { id: "user_admin", role: "admin" as const };
+
+// El preload siembra user_admin/user_regular/user_blocked y los reinicia en cada
+// test. Solo limpiamos AuditEvent (que el preload no toca).
+beforeEach(async () => {
+  await AuditEvent.deleteMany({});
+});
+
+describe("manage_user_status tool (HU-91 #208)", () => {
+  it("bloquea una cuenta activa", async () => {
+    const res = await manageUserStatus(
+      { userId: "user_regular", status: "blocked", confirm: true },
+      ADMIN,
+    );
+    expect(res.userId).toBe("user_regular");
+    expect(res.previousStatus).toBe("active");
+    expect(res.status).toBe("blocked");
+  });
+
+  it("persiste el nuevo estado en Mongo", async () => {
+    await manageUserStatus({ userId: "user_regular", status: "blocked", confirm: true }, ADMIN);
+    const user = await User.findOne({ clerkUserId: "user_regular" }).lean();
+    expect((user as { status: string }).status).toBe("blocked");
+  });
+
+  it("reactiva una cuenta bloqueada", async () => {
+    const res = await manageUserStatus(
+      { userId: "user_blocked", status: "active", confirm: true },
+      ADMIN,
+    );
+    expect(res.previousStatus).toBe("blocked");
+    expect(res.status).toBe("active");
+  });
+
+  it("no permite modificar la propia cuenta", async () => {
+    await expect(
+      manageUserStatus({ userId: "user_admin", status: "blocked", confirm: true }, ADMIN),
+    ).rejects.toThrow(/propia cuenta/i);
+  });
+
+  it("exige confirmación explícita (confirm: true)", async () => {
+    await expect(
+      manageUserStatus({ userId: "user_regular", status: "blocked", confirm: false }, ADMIN),
+    ).rejects.toThrow(/confirm/i);
+    await expect(
+      manageUserStatus({ userId: "user_regular", status: "blocked" }, ADMIN),
+    ).rejects.toThrow(/confirm/i);
+  });
+
+  it("falla si el usuario no existe", async () => {
+    await expect(
+      manageUserStatus({ userId: "user_x", status: "blocked", confirm: true }, ADMIN),
+    ).rejects.toThrow(/no encontrado/i);
+  });
+
+  it("registra un evento de auditoría (entity: user, action: status_changed)", async () => {
+    await manageUserStatus(
+      { userId: "user_regular", status: "blocked", reason: "abuso", confirm: true },
+      ADMIN,
+    );
+    const audit = await AuditEvent.findOne({ entityId: "user_regular", action: "status_changed" }).lean();
+    expect(audit).not.toBeNull();
+    expect((audit as { entity: string }).entity).toBe("user");
+    expect((audit as { actorId: string }).actorId).toBe("user_admin");
+    expect((audit as { metadata: { reason: string } }).metadata.reason).toBe("abuso");
+  });
+
+  it("rechaza un estado inválido (validación del schema)", async () => {
+    await expect(
+      manageUserStatus({ userId: "user_regular", status: "suspended", confirm: true }, ADMIN),
+    ).rejects.toThrow();
+  });
+
+  it("rechaza cuando falta userId", async () => {
+    await expect(manageUserStatus({ status: "blocked", confirm: true }, ADMIN)).rejects.toThrow();
+  });
+
+  it("no modifica el usuario si la confirmación falta", async () => {
+    await expect(
+      manageUserStatus({ userId: "user_regular", status: "blocked" }, ADMIN),
+    ).rejects.toThrow();
+    const user = await User.findOne({ clerkUserId: "user_regular" }).lean();
+    expect((user as { status: string }).status).toBe("active");
+  });
+});

--- a/apps/mcp-server/src/tools/manage-user-status.ts
+++ b/apps/mcp-server/src/tools/manage-user-status.ts
@@ -1,0 +1,92 @@
+import { z, type ZodRawShape } from "zod";
+
+import { User } from "@backend/db/schemas";
+import { createAuditEvent } from "@backend/store/audit";
+import type { ActingUser } from "../context";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-91 (#208): Gestionar el estado de un usuario (admin). Espeja
+ * `PATCH /admin/users/:userId/status`: un administrador activa o bloquea una
+ * cuenta. Reglas: solo admin, **no puede modificar su propia cuenta**, y al ser
+ * una acción sensible exige **confirmación explícita** (`confirm: true`).
+ */
+
+const manageUserStatusShape = {
+  userId: z.string().min(1).describe("clerkUserId del usuario a activar/bloquear"),
+  status: z.enum(["active", "blocked"]).describe("Nuevo estado de la cuenta"),
+  reason: z.string().max(500).optional().describe("Motivo (auditoría)"),
+  confirm: z
+    .boolean()
+    .describe("Confirmación explícita obligatoria de esta acción sensible (debe ser true)"),
+};
+const ManageUserStatusSchema = z.object(manageUserStatusShape);
+
+// Tipado como `ZodRawShape` para que `TOOLS` unifique en server.ts.
+export const manageUserStatusInput: ZodRawShape = manageUserStatusShape;
+
+/** Resultado de la gestión de estado. */
+export interface ManageUserStatusResult {
+  userId: string;
+  status: string;
+  previousStatus: string;
+  email?: string;
+}
+
+/**
+ * Lógica pura (testeable): activa/bloquea una cuenta. El acceso admin lo
+ * garantiza `requires: "admin"` en la tool.
+ */
+export async function manageUserStatus(
+  rawInput: unknown,
+  actingUser: Pick<ActingUser, "id" | "role">,
+): Promise<ManageUserStatusResult> {
+  const data = ManageUserStatusSchema.parse(rawInput ?? {});
+
+  // Acción sensible: exige confirmación explícita.
+  if (data.confirm !== true) {
+    throw new ToolError("Esta acción sensible requiere confirmación explícita (confirm: true)");
+  }
+
+  // Regla del backend: un admin no puede modificar su propia cuenta.
+  if (data.userId === actingUser.id) {
+    throw new ToolError("No puedes modificar el estado de tu propia cuenta");
+  }
+
+  const user = await User.findOne({ clerkUserId: data.userId }).lean();
+  if (!user) throw new ToolError("Usuario no encontrado");
+
+  await User.updateOne({ clerkUserId: data.userId }, { status: data.status });
+
+  await createAuditEvent({
+    actor: { id: actingUser.id, role: actingUser.role },
+    entity: "user",
+    action: "status_changed",
+    entityId: data.userId,
+    metadata: { email: user.email, reason: data.reason, from: user.status, to: data.status },
+  });
+
+  return {
+    userId: data.userId,
+    status: data.status,
+    previousStatus: user.status as string,
+    email: user.email,
+  };
+}
+
+/**
+ * Definición de la tool. `requires: "admin"` → solo administradores; el
+ * andamiaje aplica la puerta. Acción sensible: exige `confirm: true`.
+ */
+export const manageUserStatusTool: ToolDefinition<typeof manageUserStatusInput> = {
+  name: "manage_user_status",
+  title: "Gestionar estado de usuario (admin)",
+  description:
+    "Activa o bloquea una cuenta de usuario (solo admin). No permite modificar la propia cuenta. Acción sensible: requiere confirm: true. Registra auditoría y devuelve el estado anterior y el nuevo.",
+  inputSchema: manageUserStatusInput,
+  requires: "admin",
+  handler: (args, ctx) => {
+    const actingUser = ctx.actingUser as ActingUser;
+    return manageUserStatus(args, { id: actingUser.id, role: actingUser.role });
+  },
+};


### PR DESCRIPTION
## Qué

Implementa la tool MCP **`manage_user_status`** (HU-91): un administrador, vía agente, activa o bloquea una cuenta.

## Comportamiento (espeja `PATCH /admin/users/:userId/status`)

- **`requires: admin`** (la puerta del andamiaje rechaza a no-admins).
- **No permite modificar la propia cuenta** (`userId === actingUser.id` → error).
- **Acción sensible:** exige `confirm: true`; si no, error pidiendo confirmación explícita.
- Actualiza `User.status` (`active`/`blocked`) y registra auditoría (`user/status_changed`) con `email`, `reason`, `from`, `to`.
- Devuelve `{ userId, status, previousStatus, email }`.

## Tests

- **10 unitarios** (`manage-user-status.test.ts`): bloquear, persistencia, reactivar, protección de la propia cuenta, confirmación obligatoria, usuario inexistente, auditoría, estado inválido, sin `userId`, y no-mutación sin confirmación.
- **e2e** (`server.e2e.test.ts`) vía cliente MCP real: listado incluye la tool, bloqueo por un admin, **rechazo a no-admin**, y sin identidad.

`bun test` → 38 pass / 0 fail · `bun run typecheck` limpio.

Closes #208