### PR TITLE
feat(mcp): tool get_analytics_overview para métricas admin (HU-88 #205)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -112,6 +112,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `refund_payment` | HU-80 | #197 | ✅ implementada |
 | `moderate_land` | HU-90 | #207 | ✅ implementada |
 | `manage_user_status` | HU-91 | #208 | ✅ implementada |
+| `get_analytics_overview` | HU-88 | #205 | ✅ implementada |
 
 `search_lands`: busca terrenos publicados (activos) con filtros por texto,
 ubicación, uso, operación y precio; devuelve resultados paginados.
@@ -223,6 +224,10 @@ Ejemplo de argumentos:
 ```json
 { "userId": "user_abc", "status": "blocked", "reason": "Abuso reportado", "confirm": true }
 ```
+
+`get_analytics_overview` (`requires: admin`): overview de métricas del negocio —
+terrenos (por categoría), solicitudes (por estado, aprobadas/rechazadas/pendientes,
+recientes), pagos (ingresos y pendientes) y usuarios. Solo lectura. Sin argumentos.
 
 ## Tests
 

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -403,4 +403,35 @@ describe("MCP server E2E (#234)", () => {
     expect(res.isError).toBe(true);
     await client.close();
   });
+
+  it("la lista de tools incluye get_analytics_overview (HU-88 #205)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("get_analytics_overview");
+    await client.close();
+  });
+
+  it("get_analytics_overview devuelve métricas para un admin", async () => {
+    const client = await connectedClient(ADMIN_USER);
+    const res = await client.callTool({ name: "get_analytics_overview", arguments: {} });
+    const overview = res.structuredContent as { lands: { total: number }; users: { total: number } };
+    expect(res.isError).toBeFalsy();
+    expect(overview.lands.total).toBe(3);
+    expect(overview.users.total).toBe(3);
+    await client.close();
+  });
+
+  it("get_analytics_overview rechaza a un usuario no admin (requires admin)", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({ name: "get_analytics_overview", arguments: {} });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("get_analytics_overview sin identidad configurada devuelve error", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({ name: "get_analytics_overview", arguments: {} });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
 });

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -10,6 +10,7 @@ import { createPaymentSessionTool } from "./tools/create-payment-session";
 import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
+import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -27,6 +28,7 @@ const TOOLS = [
   refundPaymentTool,
   moderateLandTool,
   manageUserStatusTool,
+  getAnalyticsOverviewTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/get-analytics-overview.test.ts
+++ b/apps/mcp-server/src/tools/get-analytics-overview.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import mongoose from "@backend/db/mongoose";
+import { Payment, RentalRequest } from "@backend/db/schemas";
+import { getAnalyticsOverview } from "./get-analytics-overview";
+
+const now = new Date().toISOString();
+
+// El preload siembra los terrenos (land_a/b/c activos, land_inactive inactivo).
+// Sembramos solicitudes y pagos en beforeEach (no en el cuerpo del test).
+beforeEach(async () => {
+  await RentalRequest.deleteMany({});
+  await Payment.deleteMany({});
+  await mongoose.connection.db!.collection("rentalrequests").insertMany([
+    { id: "rr_ap", landId: "land_a", tenantId: "u1", operation: "alquiler", status: "approved", createdAt: now, updatedAt: now },
+    { id: "rr_re", landId: "land_a", tenantId: "u2", operation: "alquiler", status: "rejected", createdAt: now, updatedAt: now },
+    { id: "rr_pe", landId: "land_b", tenantId: "u3", operation: "alquiler", status: "pending_owner", createdAt: now, updatedAt: now },
+  ]);
+  await mongoose.connection.db!.collection("payments").insertMany([
+    { id: "pay_ok", rentalRequestId: "rr_ap", amount: 300, currency: "USD", status: "paid" },
+    { id: "pay_wait", rentalRequestId: "rr_ap", amount: 500, currency: "USD", status: "pending" },
+  ]);
+});
+
+describe("get_analytics_overview tool (HU-88 #205)", () => {
+  it("agrega los terrenos activos por categoría (excluye inactivos)", async () => {
+    const res = await getAnalyticsOverview();
+    // land_a (agricultura), land_b (ganaderia), land_c (forestal); land_inactive excluido.
+    expect(res.lands.total).toBe(3);
+    expect(res.lands.byCategory.agricultura).toBe(1);
+    expect(res.lands.byCategory.ganaderia).toBe(1);
+    expect(res.lands.byCategory.forestal).toBe(1);
+  });
+
+  it("agrega las solicitudes por estado y buckets", async () => {
+    const res = await getAnalyticsOverview();
+    expect(res.requests.total).toBe(3);
+    expect(res.requests.approved).toBe(1);
+    expect(res.requests.rejected).toBe(1);
+    expect(res.requests.pending).toBe(1);
+    expect(res.requests.byStatus.approved).toBe(1);
+    expect(res.requests.byStatus.rejected).toBe(1);
+    expect(res.requests.byStatus.pending_owner).toBe(1);
+    expect(res.requests.last7Days).toBe(3);
+    expect(res.requests.last30Days).toBe(3);
+  });
+
+  it("agrega los pagos: ingresos pagados y pendientes", async () => {
+    const res = await getAnalyticsOverview();
+    expect(res.payments.total).toBe(2);
+    expect(res.payments.totalRevenue).toBe(300);
+    expect(res.payments.pendingRevenue).toBe(500);
+    expect(res.payments.byStatus.paid).toBe(1);
+    expect(res.payments.byStatus.pending).toBe(1);
+  });
+
+  it("incluye el total y activos de usuarios", async () => {
+    const res = await getAnalyticsOverview();
+    // Preload: user_admin, user_regular (activos), user_blocked (bloqueado).
+    expect(res.users.total).toBe(3);
+    expect(res.users.active).toBe(2);
+  });
+
+  describe("sin solicitudes ni pagos", () => {
+    // Se limpia en el hook (no en el cuerpo del test) tras la siembra del outer.
+    beforeEach(async () => {
+      await RentalRequest.deleteMany({});
+      await Payment.deleteMany({});
+    });
+
+    it("devuelve ceros pero conserva los terrenos del preload", async () => {
+      const res = await getAnalyticsOverview();
+      expect(res.requests.total).toBe(0);
+      expect(res.requests.approved).toBe(0);
+      expect(res.payments.total).toBe(0);
+      expect(res.payments.totalRevenue).toBe(0);
+      expect(res.lands.total).toBe(3);
+    });
+  });
+});

--- a/apps/mcp-server/src/tools/get-analytics-overview.ts
+++ b/apps/mcp-server/src/tools/get-analytics-overview.ts
@@ -1,0 +1,119 @@
+import type { ZodRawShape } from "zod";
+
+import { Land, Payment, RentalRequest, User } from "@backend/db/schemas";
+import type { ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-88 (#205): Analítica general (admin). Espeja el núcleo de
+ * `GET /analytics/overview`: métricas agregadas de terrenos, solicitudes y pagos
+ * (más usuarios) para que el agente genere reportes ejecutivos. Solo lectura.
+ */
+
+// Sin argumentos. Tipado como `ZodRawShape` para unificar en el array `TOOLS`.
+export const getAnalyticsOverviewInput: ZodRawShape = {};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Estados de solicitud que cuentan como "aprobadas" (avanzadas). */
+const APPROVED_STATUSES = ["approved", "pending_payment", "paid"];
+
+export interface AnalyticsOverview {
+  lands: { total: number; byCategory: Record<string, number> };
+  requests: {
+    total: number;
+    approved: number;
+    rejected: number;
+    pending: number;
+    last7Days: number;
+    last30Days: number;
+    byStatus: Record<string, number>;
+  };
+  payments: {
+    total: number;
+    totalRevenue: number;
+    pendingRevenue: number;
+    byStatus: Record<string, number>;
+  };
+  users: { total: number; active: number };
+}
+
+/** Cuenta ocurrencias por una clave string en una colección. */
+function countBy<T>(items: T[], key: (item: T) => string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const item of items) out[key(item)] = (out[key(item)] || 0) + 1;
+  return out;
+}
+
+/**
+ * Lógica pura (testeable): agrega las métricas desde Mongo. Solo lectura; el
+ * acceso admin lo garantiza `requires: "admin"` en la tool.
+ */
+export async function getAnalyticsOverview(): Promise<AnalyticsOverview> {
+  const now = Date.now();
+  const d7 = now - 7 * DAY_MS;
+  const d30 = now - 30 * DAY_MS;
+
+  const [activeLands, requests, payments, users] = await Promise.all([
+    Land.find({ status: "active" }).lean(),
+    RentalRequest.find().lean(),
+    Payment.find().lean(),
+    User.find().lean(),
+  ]);
+
+  // Terrenos (activos) por categoría de uso.
+  const landsByCategory: Record<string, number> = {};
+  for (const land of activeLands as unknown as { allowedUses?: string[] }[]) {
+    for (const use of land.allowedUses ?? []) {
+      landsByCategory[use] = (landsByCategory[use] || 0) + 1;
+    }
+  }
+
+  const reqs = requests as unknown as { status: string; createdAt: Date | string }[];
+  const approved = reqs.filter((r) => APPROVED_STATUSES.includes(r.status)).length;
+  const rejected = reqs.filter((r) => r.status === "rejected").length;
+  const inWindow = (d: Date | string, from: number) => new Date(d).getTime() >= from;
+
+  const pays = payments as unknown as { status: string; amount: number }[];
+  const totalRevenue = pays
+    .filter((p) => p.status === "paid")
+    .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+  const pendingRevenue = pays
+    .filter((p) => p.status === "pending" || p.status === "processing")
+    .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+
+  const usrs = users as unknown as { status: string }[];
+
+  return {
+    lands: { total: activeLands.length, byCategory: landsByCategory },
+    requests: {
+      total: reqs.length,
+      approved,
+      rejected,
+      pending: reqs.length - approved - rejected,
+      last7Days: reqs.filter((r) => inWindow(r.createdAt, d7)).length,
+      last30Days: reqs.filter((r) => inWindow(r.createdAt, d30)).length,
+      byStatus: countBy(reqs, (r) => r.status),
+    },
+    payments: {
+      total: pays.length,
+      totalRevenue: Math.round(totalRevenue * 100) / 100,
+      pendingRevenue: Math.round(pendingRevenue * 100) / 100,
+      byStatus: countBy(pays, (p) => p.status),
+    },
+    users: { total: usrs.length, active: usrs.filter((u) => u.status === "active").length },
+  };
+}
+
+/**
+ * Definición de la tool. `requires: "admin"` → solo administradores; el
+ * andamiaje aplica la puerta. Sin argumentos.
+ */
+export const getAnalyticsOverviewTool: ToolDefinition<typeof getAnalyticsOverviewInput> = {
+  name: "get_analytics_overview",
+  title: "Analítica general (admin)",
+  description:
+    "Devuelve un overview de métricas del negocio: terrenos (por categoría), solicitudes (por estado, aprobadas/rechazadas/pendientes, recientes), pagos (ingresos y pendientes) y usuarios. Solo admin; solo lectura.",
+  inputSchema: getAnalyticsOverviewInput,
+  requires: "admin",
+  handler: () => getAnalyticsOverview(),
+};


### PR DESCRIPTION
## Qué

Implementa la tool MCP **`get_analytics_overview`** (HU-88): un administrador, vía agente, obtiene métricas generales del negocio para reportes ejecutivos.

## Comportamiento (espeja el núcleo de `GET /analytics/overview`)

- **`requires: admin`** (la puerta del andamiaje rechaza a no-admins). Solo lectura, sin argumentos.
- Devuelve:
  - **Terrenos:** total activos y desglose por categoría de uso.
  - **Solicitudes:** total, aprobadas / rechazadas / pendientes, últimas 7 y 30 días, y desglose por estado.
  - **Pagos:** total, ingresos pagados (`totalRevenue`), ingresos pendientes (`pendingRevenue`) y desglose por estado.
  - **Usuarios:** total y activos.

## Tests

- **5 unitarios** (`get-analytics-overview.test.ts`): agregación de terrenos por categoría (excluye inactivos), solicitudes por estado + buckets, pagos (ingresos pagados/pendientes), usuarios, y caso sin datos. Solicitudes/pagos sembrados en `beforeEach`.
- **e2e** (`server.e2e.test.ts`) vía cliente MCP real: listado incluye la tool, métricas para un admin, **rechazo a no-admin**, y sin identidad.

`bun test` → 33 pass / 0 fail · `bun run typecheck` limpio.

Closes #205