### PR TITLE
feat(mcp): implement update_land tool (HU-66 #183)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
 
 import { config } from "./config";
 import type { ToolContext } from "./context";
-import { registerTool } from "./tools/define-tool";
+import { registerTool, type ToolDefinition } from "./tools/define-tool";
 import { createLandTool } from "./tools/create-land";
 import { createRentalRequestTool } from "./tools/create-rental-request";
 import { createContractTool } from "./tools/create-contract";
@@ -12,6 +13,7 @@ import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
 import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
 import { searchLandsTool } from "./tools/search-lands";
+import { updateLandTool } from "./tools/update-land";
 
 /**
  * Crea el servidor MCP de TerraShare y registra las tools disponibles (#234).
@@ -19,7 +21,7 @@ import { searchLandsTool } from "./tools/search-lands";
  * Para añadir una tool (HU-64..HU-92): impórtala aquí y añádela al array `TOOLS`.
  * Ver `src/tools/_template.ts` y el README para el patrón.
  */
-const TOOLS = [
+const TOOLS: ToolDefinition<ZodRawShape>[] = [
   searchLandsTool,
   createLandTool,
   createRentalRequestTool,
@@ -29,6 +31,7 @@ const TOOLS = [
   moderateLandTool,
   manageUserStatusTool,
   getAnalyticsOverviewTool,
+  updateLandTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/update-land.test.ts
+++ b/apps/mcp-server/src/tools/update-land.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { Land, User } from "@backend/db/schemas";
+import { updateLand } from "./update-land";
+
+const ownerUser = { id: "user_seed", role: "user" };
+const adminUser = { id: "user_admin", role: "admin" };
+const regularUser = { id: "user_regular", role: "user" };
+
+describe("update_land tool (HU-66 #183)", () => {
+  beforeEach(async () => {
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_seed" },
+      { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Seed Owner" } },
+      { upsert: true },
+    );
+  });
+
+  it("actualiza título de un terreno existente (owner)", async () => {
+    const res = await updateLand({ landId: "land_a", title: "Finca Actualizada" }, ownerUser);
+    expect((res as { title: string }).title).toBe("Finca Actualizada");
+    expect((res as { id: string }).id).toBe("land_a");
+  });
+
+  it("actualiza precio mensual", async () => {
+    const res = await updateLand({ landId: "land_a", priceRule: { currency: "USD", pricePerMonth: 999 } }, ownerUser);
+    expect((res as { priceRule: { pricePerMonth: number } }).priceRule.pricePerMonth).toBe(999);
+  });
+
+  it("preserva id y ownerId (no se alteran)", async () => {
+    const res = await updateLand({ landId: "land_a", title: "Nuevo" }, ownerUser);
+    expect((res as { id: string }).id).toBe("land_a");
+    expect((res as { ownerId: string }).ownerId).toBe("user_seed");
+  });
+
+  it("admin puede modificar terrenos de otros", async () => {
+    const res = await updateLand({ landId: "land_a", title: "Admin Edit" }, adminUser);
+    expect((res as { title: string }).title).toBe("Admin Edit");
+  });
+
+  it("usuario regular NO puede modificar terreno de otro", async () => {
+    try {
+      await updateLand({ landId: "land_a", title: "Hack" }, regularUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("No autorizado");
+    }
+  });
+
+  it("terreno inexistente lanza error", async () => {
+    try {
+      await updateLand({ landId: "land_nonexistent", title: "Titulo valido" }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("no encontrado");
+    }
+  });
+
+  it("actualización parcial solo cambia campos provistos", async () => {
+    const before = await Land.findOne({ id: "land_b" }).lean();
+    const res = await updateLand({ landId: "land_b", title: "Solo título" }, ownerUser);
+    expect((res as { title: string }).title).toBe("Solo título");
+    expect((res as { area: number }).area).toBe(before!.area);
+  });
+
+  it("no expone _id ni __v", async () => {
+    const res = await updateLand({ landId: "land_a", title: "Test" }, ownerUser);
+    expect("_id" in res).toBe(false);
+    expect("__v" in res).toBe(false);
+  });
+});

--- a/apps/mcp-server/src/tools/update-land.ts
+++ b/apps/mcp-server/src/tools/update-land.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+import { Land, AuditEvent } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { canMutateLand } from "../permissions";
+
+const updateLandInput = {
+  landId: z.string().min(1).describe("ID del terreno a actualizar"),
+  title: z.string().min(3).optional().describe("Nuevo título (mín. 3 caracteres)"),
+  description: z.string().optional().describe("Nueva descripción"),
+  area: z.number().positive().optional().describe("Nueva área (mayor a 0)"),
+  allowedUses: z
+    .array(z.enum(["agricultura", "ganaderia", "forestal", "acuicultura", "mixto", "otro"]))
+    .min(1)
+    .optional()
+    .describe("Usos permitidos del terreno"),
+  location: z
+    .object({
+      province: z.string().min(1).optional(),
+      district: z.string().min(1).optional(),
+      corregimiento: z.string().optional(),
+      addressLine: z.string().optional(),
+      lat: z.number().optional(),
+      lng: z.number().optional(),
+    })
+    .optional()
+    .describe("Ubicación del terreno"),
+  availability: z
+    .object({
+      availableFrom: z.string().optional(),
+      availableTo: z.string().optional(),
+    })
+    .optional()
+    .describe("Disponibilidad temporal"),
+  priceRule: z
+    .object({
+      currency: z.enum(["USD", "PAB"]),
+      pricePerMonth: z.number().positive(),
+    })
+    .optional()
+    .describe("Regla de precio mensual"),
+  operation: z
+    .enum(["alquiler", "venta", "ambas"])
+    .optional()
+    .describe("Tipo de operación"),
+  salePrice: z.number().positive().optional().describe("Precio de venta"),
+  water: z.string().optional().describe("Disponibilidad de agua"),
+  access: z.string().optional().describe("Acceso al terreno"),
+  features: z.array(z.string()).optional().describe("Características adicionales"),
+};
+
+export type UpdateLandInput = z.infer<z.ZodObject<typeof updateLandInput>>;
+
+export async function updateLand(
+  rawInput: unknown,
+  actingUser: { id: string; role: string },
+): Promise<Record<string, unknown>> {
+  const schema = z.object(updateLandInput);
+  const input = schema.parse(rawInput ?? {});
+
+  const current = await Land.findOne({ id: input.landId }).lean();
+  if (!current) throw new ToolError("Terreno no encontrado");
+
+  if (!canMutateLand(actingUser as never, { ownerId: current.ownerId } as never)) {
+    throw new ToolError("No autorizado para modificar este terreno");
+  }
+
+  const { landId, ...updates } = input;
+  const merged = {
+    ...current,
+    ...updates,
+    id: current.id,
+    ownerId: current.ownerId,
+    updatedAt: new Date(),
+  };
+
+  const doc = await Land.findOneAndUpdate({ id: landId }, { $set: merged }, { returnDocument: "after" });
+  if (!doc) throw new ToolError("Error al actualizar el terreno");
+  const { _id, __v, ...updated } = doc.toObject();
+
+  await AuditEvent.create({
+    id: `audit_${crypto.randomUUID()}`,
+    actorId: actingUser.id,
+    actorRole: actingUser.role as "user" | "admin",
+    entity: "land",
+    action: "updated",
+    entityId: landId,
+    metadata: { fields: Object.keys(updates) },
+  });
+
+  return updated;
+}
+
+export const updateLandTool: ToolDefinition<typeof updateLandInput> = {
+  name: "update_land",
+  title: "Actualizar terreno",
+  description:
+    "Actualiza los datos de un terreno existente. Solo el propietario o un administrador pueden modificarlo. Los campos id y ownerId no se alteran.",
+  inputSchema: updateLandInput,
+  requires: "user",
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!;
+    return updateLand(args, actingUser);
+  },
+};


### PR DESCRIPTION
## Resumen

Implementa la tool MCP update_land (HU-66, issue #183) que permite a un propietario actualizar los datos de su terreno vía agente MCP.

## Cambios

- **pps/mcp-server/src/tools/update-land.ts**: Tool con inputSchema Zod, handler con permisos canMutateLand, y audit logging
- **pps/mcp-server/src/tools/update-land.test.ts**: 8 tests (owner, admin, no-owner, inexistente, parcial, preservación de id/ownerId)
- **pps/mcp-server/src/server.ts**: Registro de updateLandTool en el array TOOLS

## Funcionalidad

- Actualiza campos opcionales: title, description, area, allowedUses, location, availability, priceRule, operation, salePrice, water, access, features
- Preserva id y ownerId (no alterables)
- Registra evento de auditoría con los campos modificados
- Reutiliza canMutateLand del backend (mismas reglas que la API REST)

## Verificación

- 32/32 tests pasan (un test)
- Typecheck limpio (un run typecheck)

Closes #183