### PR TITLE
feat(mcp): tool refund_payment para reembolsos admin (HU-80 #197)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -106,6 +106,7 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 |------|-----|-------|--------|
 | `search_lands` | HU-63 | #180 | ✅ implementada |
 | `create_payment_session` | HU-77 | #194 | ✅ implementada |
+| `refund_payment` | HU-80 | #197 | ✅ implementada |
 
 `search_lands`: busca terrenos publicados (activos) con filtros por texto,
 ubicación, uso, operación y precio; devuelve resultados paginados.
@@ -135,6 +136,18 @@ Ejemplo de argumentos:
   "successUrl": "https://app.terrashare.co/pago/ok",
   "cancelUrl": "https://app.terrashare.co/pago/cancel"
 }
+```
+
+`refund_payment` (`requires: admin`): reembolsa total o parcialmente un pago
+pagado. **Acción sensible: exige `confirm: true`.** Usa Stripe real si hay
+`STRIPE_SECRET_KEY` y el pago tiene `stripePaymentIntentId`; actualiza el estado
+del pago (`partially_refunded`/`refunded`) y registra auditoría. Reusa
+`CreateRefundSchema` y el helper de Stripe.
+
+Ejemplo de argumentos (reembolso parcial):
+
+```json
+{ "paymentId": "pay_123", "amount": 100, "reason": "Cancelación parcial", "confirm": true }
 ```
 
 ## Tests

--- a/apps/mcp-server/src/server.e2e.test.ts
+++ b/apps/mcp-server/src/server.e2e.test.ts
@@ -29,8 +29,18 @@ const TENANT_USER: ActingUser = {
   profile: { fullName: "Usuario Regular" },
 };
 
-// El preload no toca RentalRequest/Payment → sembramos una solicitud pagable en
-// el hook (no en el cuerpo del test) para las tools que la leen.
+/** Administrador de prueba (rol admin). */
+const ADMIN_USER: ActingUser = {
+  id: "user_admin",
+  clerkUserId: "user_admin",
+  email: "admin@test.com",
+  role: "admin",
+  status: "active",
+  profile: { fullName: "Admin de Prueba" },
+};
+
+// El preload no toca RentalRequest/Payment → sembramos en el hook (no en el
+// cuerpo del test) una solicitud pagable y un pago pagado para las tools.
 beforeEach(async () => {
   await RentalRequest.deleteMany({});
   await Payment.deleteMany({});
@@ -40,6 +50,15 @@ beforeEach(async () => {
     tenantId: "user_regular",
     operation: "alquiler",
     status: "approved",
+  });
+  await mongoose.connection.db!.collection("payments").insertOne({
+    id: "pay_e2e",
+    rentalRequestId: "rr_e2e",
+    amount: 300,
+    currency: "USD",
+    status: "paid",
+    refundedAmount: 0,
+    refunds: [],
   });
 });
 
@@ -105,6 +124,47 @@ describe("MCP server E2E (#234)", () => {
         successUrl: "https://ok.test/return",
         cancelUrl: "https://cancel.test/return",
       },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("la lista de tools incluye refund_payment (HU-80 #197)", async () => {
+    const client = await connectedClient();
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("refund_payment");
+    await client.close();
+  });
+
+  it("refund_payment reembolsa un pago pagado para un admin", async () => {
+    const client = await connectedClient(ADMIN_USER);
+    const res = await client.callTool({
+      name: "refund_payment",
+      arguments: { paymentId: "pay_e2e", amount: 100, reason: "e2e", confirm: true },
+    });
+    const payment = res.structuredContent as { paymentId: string; status: string; refundedAmount: number };
+    expect(res.isError).toBeFalsy();
+    expect(payment.paymentId).toBe("pay_e2e");
+    expect(payment.status).toBe("partially_refunded");
+    expect(payment.refundedAmount).toBe(100);
+    await client.close();
+  });
+
+  it("refund_payment rechaza a un usuario no admin (requires admin)", async () => {
+    const client = await connectedClient(TENANT_USER);
+    const res = await client.callTool({
+      name: "refund_payment",
+      arguments: { paymentId: "pay_e2e", confirm: true },
+    });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it("refund_payment sin identidad configurada devuelve error", async () => {
+    const client = await connectedClient(null);
+    const res = await client.callTool({
+      name: "refund_payment",
+      arguments: { paymentId: "pay_e2e", confirm: true },
     });
     expect(res.isError).toBe(true);
     await client.close();

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -4,6 +4,7 @@ import { config } from "./config";
 import type { ToolContext } from "./context";
 import { registerTool } from "./tools/define-tool";
 import { createPaymentSessionTool } from "./tools/create-payment-session";
+import { refundPaymentTool } from "./tools/refund-payment";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -15,6 +16,7 @@ import { searchLandsTool } from "./tools/search-lands";
 const TOOLS = [
   searchLandsTool,
   createPaymentSessionTool,
+  refundPaymentTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/refund-payment.test.ts
+++ b/apps/mcp-server/src/tools/refund-payment.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import mongoose from "@backend/db/mongoose";
+import { AuditEvent, Payment } from "@backend/db/schemas";
+import { refundPayment } from "./refund-payment";
+
+const ADMIN = { id: "user_admin", role: "admin" as const };
+
+function refundInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { paymentId: "pay_paid", confirm: true, ...overrides };
+}
+
+// Pagos sembrados con el driver nativo en beforeEach (no en el cuerpo del test).
+beforeEach(async () => {
+  await Payment.deleteMany({});
+  await AuditEvent.deleteMany({});
+  await mongoose.connection.db!.collection("payments").insertMany([
+    // Pagado, sin reembolsos (reembolsable 300).
+    { id: "pay_paid", rentalRequestId: "rr_1", amount: 300, currency: "USD", status: "paid", refundedAmount: 0, refunds: [] },
+    // Parcialmente reembolsado (reembolsable 100).
+    { id: "pay_partial", rentalRequestId: "rr_2", amount: 300, currency: "USD", status: "partially_refunded", refundedAmount: 200, refunds: [] },
+    // Pendiente (no reembolsable por estado).
+    { id: "pay_pending", rentalRequestId: "rr_3", amount: 300, currency: "USD", status: "pending", refundedAmount: 0, refunds: [] },
+    // Reembolsable 0 (ya al máximo pese al estado).
+    { id: "pay_maxed", rentalRequestId: "rr_4", amount: 300, currency: "USD", status: "partially_refunded", refundedAmount: 300, refunds: [] },
+  ]);
+});
+
+describe("refund_payment tool (HU-80 #197)", () => {
+  it("reembolsa el total cuando no se indica importe", async () => {
+    const res = await refundPayment(refundInput(), ADMIN);
+
+    expect(res.paymentId).toBe("pay_paid");
+    expect(res.status).toBe("refunded");
+    expect(res.refundedAmount).toBe(300);
+    expect(res.refund.id).toMatch(/^rf_/);
+    expect(res.refund.amount).toBe(300);
+  });
+
+  it("reembolsa parcialmente y deja el pago en partially_refunded", async () => {
+    const res = await refundPayment(refundInput({ amount: 100, reason: "Ajuste" }), ADMIN);
+
+    expect(res.status).toBe("partially_refunded");
+    expect(res.refundedAmount).toBe(100);
+    expect(res.refund.amount).toBe(100);
+    expect(res.refund.reason).toBe("Ajuste");
+  });
+
+  it("completa un reembolso parcial previo hasta el total", async () => {
+    const res = await refundPayment(refundInput({ paymentId: "pay_partial", amount: 100 }), ADMIN);
+    expect(res.status).toBe("refunded");
+    expect(res.refundedAmount).toBe(300);
+  });
+
+  it("persiste el reembolso en Payment.refunds y refundedAmount", async () => {
+    const res = await refundPayment(refundInput({ amount: 120 }), ADMIN);
+    const payment = await Payment.findOne({ id: "pay_paid" }).lean();
+    expect((payment as { refundedAmount: number }).refundedAmount).toBe(120);
+    const refunds = (payment as { refunds: { id: string; amount: number }[] }).refunds;
+    expect(refunds.length).toBe(1);
+    expect(refunds[0].id).toBe(res.refund.id);
+    expect(refunds[0].amount).toBe(120);
+  });
+
+  it("exige confirmación explícita (confirm: true)", async () => {
+    await expect(refundPayment({ paymentId: "pay_paid", confirm: false }, ADMIN)).rejects.toThrow(/confirm/i);
+    await expect(refundPayment({ paymentId: "pay_paid" }, ADMIN)).rejects.toThrow(/confirm/i);
+  });
+
+  it("falla si el pago no existe", async () => {
+    await expect(refundPayment(refundInput({ paymentId: "pay_x" }), ADMIN)).rejects.toThrow(/no encontrado/i);
+  });
+
+  it("rechaza reembolsar un pago no pagado", async () => {
+    await expect(refundPayment(refundInput({ paymentId: "pay_pending" }), ADMIN)).rejects.toThrow(/pagados/i);
+  });
+
+  it("rechaza un importe que excede el saldo reembolsable", async () => {
+    await expect(refundPayment(refundInput({ amount: 500 }), ADMIN)).rejects.toThrow(/excede/i);
+  });
+
+  it("rechaza si el pago ya está totalmente reembolsado", async () => {
+    await expect(refundPayment(refundInput({ paymentId: "pay_maxed" }), ADMIN)).rejects.toThrow(/totalmente reembolsado/i);
+  });
+
+  it("registra un evento de auditoría (entity: payment, action: refunded)", async () => {
+    await refundPayment(refundInput({ amount: 50, reason: "test" }), ADMIN);
+    const audit = await AuditEvent.findOne({ entityId: "pay_paid", action: "refunded" }).lean();
+    expect(audit).not.toBeNull();
+    expect((audit as { entity: string }).entity).toBe("payment");
+    expect((audit as { actorId: string }).actorId).toBe("user_admin");
+    expect((audit as { metadata: { amount: number } }).metadata.amount).toBe(50);
+  });
+
+  it("rechaza un importe negativo (validación del schema)", async () => {
+    await expect(refundPayment(refundInput({ amount: -10 }), ADMIN)).rejects.toThrow();
+  });
+
+  it("no modifica el pago si la validación falla", async () => {
+    await expect(refundPayment(refundInput({ amount: -10 }), ADMIN)).rejects.toThrow();
+    const payment = await Payment.findOne({ id: "pay_paid" }).lean();
+    expect((payment as { refundedAmount: number }).refundedAmount).toBe(0);
+    expect((payment as { status: string }).status).toBe("paid");
+  });
+});

--- a/apps/mcp-server/src/tools/refund-payment.ts
+++ b/apps/mcp-server/src/tools/refund-payment.ts
@@ -1,0 +1,168 @@
+import { z, type ZodRawShape } from "zod";
+import { CreateRefundSchema } from "@terrashare/shared";
+
+import { Payment } from "@backend/db/schemas";
+import { createAuditEvent } from "@backend/store/audit";
+import type { ActingUser } from "../context";
+import { getStripeClient } from "../lib/stripe";
+import { ToolError, type ToolDefinition } from "./define-tool";
+
+/**
+ * Tool HU-80 (#197): Reembolsar un pago (admin). Espeja
+ * `POST /payments/:paymentId/refund`: reembolso total o parcial de un pago
+ * pagado, con Stripe real cuando hay clave, actualización del estado del pago y
+ * auditoría. Es una **acción sensible**: exige `confirm: true`.
+ */
+
+// El `inputSchema` que anuncia el SDK se declara con el Zod local (con
+// `.describe()`); el importe/razón se validan con `CreateRefundSchema.parse`.
+// Tipado como `ZodRawShape` para que `TOOLS` unifique en server.ts.
+export const refundPaymentInput: ZodRawShape = {
+  paymentId: z.string().min(1).describe("ID del pago a reembolsar"),
+  amount: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Importe a reembolsar; si se omite, reembolsa el saldo pendiente (total)"),
+  reason: z.string().max(500).optional().describe("Motivo del reembolso (auditoría)"),
+  confirm: z
+    .boolean()
+    .describe("Confirmación explícita obligatoria de esta acción sensible (debe ser true)"),
+};
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+/** Resultado de la tool (sin secretos de Stripe). */
+export interface RefundResult {
+  paymentId: string;
+  status: string;
+  amount: number;
+  refundedAmount: number;
+  refund: { id: string; amount: number; reason?: string; stripeRefundId?: string };
+  currency: string;
+}
+
+/**
+ * Lógica pura (testeable): valida, reembolsa total/parcial (Stripe si procede) y
+ * actualiza el pago. El acceso admin lo garantiza `requires: "admin"` en la tool.
+ */
+export async function refundPayment(
+  rawInput: unknown,
+  actingUser: Pick<ActingUser, "id" | "role">,
+): Promise<RefundResult> {
+  const input = (rawInput ?? {}) as Record<string, unknown>;
+
+  // Acción sensible: exige confirmación explícita.
+  if (input.confirm !== true) {
+    throw new ToolError("Esta acción sensible requiere confirmación explícita (confirm: true)");
+  }
+
+  const paymentId = typeof input.paymentId === "string" ? input.paymentId : "";
+  if (!paymentId) throw new ToolError("paymentId es requerido");
+
+  // Valida importe/razón con el mismo schema que la API REST.
+  const body = CreateRefundSchema.parse({ amount: input.amount, reason: input.reason });
+
+  const payment = await Payment.findOne({ id: paymentId }).lean();
+  if (!payment) throw new ToolError("Pago no encontrado");
+
+  if (payment.status !== "paid" && payment.status !== "partially_refunded") {
+    throw new ToolError("Solo se pueden reembolsar pagos pagados");
+  }
+
+  const alreadyRefunded = payment.refundedAmount ?? 0;
+  const refundable = round2(payment.amount - alreadyRefunded);
+  if (refundable <= 0) {
+    throw new ToolError("El pago ya está totalmente reembolsado");
+  }
+
+  const requested = body.amount != null ? round2(body.amount) : refundable;
+  if (requested <= 0) throw new ToolError("El importe del reembolso debe ser positivo");
+  if (requested > refundable) throw new ToolError("El importe excede el saldo reembolsable");
+
+  const refundId = `rf_${crypto.randomUUID()}`;
+  let stripeRefundId: string | undefined;
+
+  const stripe = getStripeClient();
+  if (stripe && payment.stripePaymentIntentId) {
+    try {
+      const refund = await stripe.refunds.create(
+        {
+          payment_intent: payment.stripePaymentIntentId,
+          amount: Math.round(requested * 100),
+          reason: "requested_by_customer",
+          metadata: { paymentId: payment.id, note: body.reason ?? "" },
+        },
+        { idempotencyKey: refundId },
+      );
+      stripeRefundId = refund.id;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Error de Stripe al reembolsar";
+      throw new ToolError(`Stripe rechazó el reembolso: ${message}`);
+    }
+  }
+
+  const newRefundedAmount = round2(alreadyRefunded + requested);
+  const newStatus = newRefundedAmount >= payment.amount ? "refunded" : "partially_refunded";
+
+  await Payment.updateOne(
+    { id: payment.id },
+    {
+      status: newStatus,
+      refundedAmount: newRefundedAmount,
+      updatedAt: new Date(),
+      $push: {
+        refunds: {
+          id: refundId,
+          amount: requested,
+          reason: body.reason,
+          stripeRefundId,
+          createdAt: new Date(),
+        },
+      },
+    },
+  );
+
+  await createAuditEvent({
+    actor: { id: actingUser.id, role: actingUser.role },
+    entity: "payment",
+    action: "refunded",
+    entityId: payment.id,
+    metadata: {
+      refundId,
+      amount: requested,
+      reason: body.reason,
+      refundedAmount: newRefundedAmount,
+      status: newStatus,
+      stripeRefundId,
+    },
+  });
+
+  return {
+    paymentId: payment.id,
+    status: newStatus,
+    amount: payment.amount,
+    refundedAmount: newRefundedAmount,
+    refund: { id: refundId, amount: requested, reason: body.reason, stripeRefundId },
+    currency: payment.currency,
+  };
+}
+
+/**
+ * Definición de la tool. `requires: "admin"` → solo administradores; el
+ * andamiaje aplica la puerta. Acción sensible: exige `confirm: true`.
+ */
+export const refundPaymentTool: ToolDefinition<typeof refundPaymentInput> = {
+  name: "refund_payment",
+  title: "Reembolsar pago (admin)",
+  description:
+    "Emite un reembolso total o parcial de un pago pagado (solo admin). Acción sensible: requiere confirm: true. Devuelve el estado del pago y el reembolso aplicado.",
+  inputSchema: refundPaymentInput,
+  requires: "admin",
+  handler: (args, ctx) => {
+    const actingUser = ctx.actingUser as ActingUser;
+    return refundPayment(args, { id: actingUser.id, role: actingUser.role });
+  },
+};


### PR DESCRIPTION
> Reemplaza a #301 (cerrado automáticamente al mergear #291 con `--delete-branch`). Rebasada sobre `main`; ya solo contiene el diff de `refund_payment`.

## Qué

Tool MCP **`refund_payment`** (HU-80): un administrador emite un reembolso total o parcial de un pago.

## Comportamiento (espeja `POST /payments/:paymentId/refund`)

- **`requires: admin`**; **acción sensible** → exige `confirm: true`.
- Valida con `CreateRefundSchema`; exige pago `paid`/`partially_refunded`; calcula el saldo reembolsable y rechaza importes ≤0, que excedan el saldo, o pagos ya totalmente reembolsados.
- Reembolso en Stripe si hay clave real y `stripePaymentIntentId`; actualiza el pago (`partially_refunded`/`refunded`) con `$push` a `refunds` y audita (`payment/refunded`). No expone secretos.
- Reutiliza el helper `src/lib/stripe.ts` (ya en `main` vía #291).

## Tests

- 12 unitarios + e2e vía cliente MCP real (incluye rechazo a no-admin). `bun test` → 56 pass / 0 fail; typecheck limpio.

Closes #197