### PR TITLE
feat(mcp): implement delete_land tool (HU-69 #186)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
 import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
+import { deleteLandTool } from "./tools/delete-land";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -29,6 +30,7 @@ const TOOLS = [
   moderateLandTool,
   manageUserStatusTool,
   getAnalyticsOverviewTool,
+  deleteLandTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/delete-land.test.ts
+++ b/apps/mcp-server/src/tools/delete-land.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { Land, User } from "@backend/db/schemas";
+import { deleteLand } from "./delete-land";
+
+const ownerUser = { id: "user_seed", role: "user" };
+const adminUser = { id: "user_admin", role: "admin" };
+const regularUser = { id: "user_regular", role: "user" };
+
+describe("delete_land tool (HU-69 #186)", () => {
+  beforeEach(async () => {
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_seed" },
+      { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Seed Owner" } },
+      { upsert: true },
+    );
+  });
+
+  it("elimina un terreno existente con confirmación", async () => {
+    const res = await deleteLand({ landId: "land_a", confirm: true }, ownerUser);
+    expect(res).toEqual({ deleted: true, landId: "land_a" });
+    const gone = await Land.findOne({ id: "land_a" }).lean();
+    expect(gone).toBeNull();
+  });
+
+  it("admin puede eliminar terrenos de otros", async () => {
+    const res = await deleteLand({ landId: "land_b", confirm: true }, adminUser);
+    expect(res).toEqual({ deleted: true, landId: "land_b" });
+  });
+
+  it("sin confirm lanza error", async () => {
+    try {
+      await deleteLand({ landId: "land_a" } as never, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("confirmar");
+    }
+  });
+
+  it("confirm=false lanza error", async () => {
+    try {
+      await deleteLand({ landId: "land_a", confirm: false }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("confirmar");
+    }
+  });
+
+  it("usuario regular NO puede eliminar terreno de otro", async () => {
+    try {
+      await deleteLand({ landId: "land_a", confirm: true }, regularUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("No autorizado");
+    }
+  });
+
+  it("terreno inexistente lanza error", async () => {
+    try {
+      await deleteLand({ landId: "land_nonexistent", confirm: true }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("no encontrado");
+    }
+  });
+});

--- a/apps/mcp-server/src/tools/delete-land.ts
+++ b/apps/mcp-server/src/tools/delete-land.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+import { Land, AuditEvent } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { canMutateLand } from "../permissions";
+
+const deleteLandInput = {
+  landId: z.string().min(1).describe("ID del terreno a eliminar"),
+  confirm: z.boolean().optional().describe("Debe ser true para confirmar la eliminación"),
+};
+
+export type DeleteLandInput = z.infer<z.ZodObject<typeof deleteLandInput>>;
+
+export async function deleteLand(
+  rawInput: unknown,
+  actingUser: { id: string; role: string },
+): Promise<Record<string, unknown>> {
+  const schema = z.object(deleteLandInput);
+  const input = schema.parse(rawInput ?? {});
+
+  if (input.confirm !== true) {
+    throw new ToolError("Debes confirmar la eliminación con confirm: true");
+  }
+
+  const current = await Land.findOne({ id: input.landId }).lean();
+  if (!current) throw new ToolError("Terreno no encontrado");
+
+  if (!canMutateLand(actingUser as never, { ownerId: current.ownerId } as never)) {
+    throw new ToolError("No autorizado para eliminar este terreno");
+  }
+
+  await Land.deleteOne({ id: input.landId });
+
+  await AuditEvent.create({
+    id: `audit_${crypto.randomUUID()}`,
+    actorId: actingUser.id,
+    actorRole: actingUser.role as "user" | "admin",
+    entity: "land",
+    action: "deleted",
+    entityId: input.landId,
+  });
+
+  return { deleted: true, landId: input.landId };
+}
+
+export const deleteLandTool: ToolDefinition<typeof deleteLandInput> = {
+  name: "delete_land",
+  title: "Eliminar terreno",
+  description:
+    "Elimina un terreno existente de forma permanente. Requiere confirmación explícita. Solo el propietario o un administrador pueden eliminarlo.",
+  inputSchema: deleteLandInput,
+  requires: "user",
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!;
+    return deleteLand(args, actingUser);
+  },
+};


### PR DESCRIPTION
## Resumen

Implementa la tool MCP delete_land (HU-69, issue #186) que permite a un propietario eliminar un terreno de forma permanente vía agente MCP.

## Cambios

- **pps/mcp-server/src/tools/delete-land.ts**: Tool con confirmación explícita, permisos canMutateLand, y audit logging
- **pps/mcp-server/src/tools/delete-land.test.ts**: 6 tests (owner, admin, sin confirm, confirm=false, no-owner, inexistente)
- **pps/mcp-server/src/server.ts**: Registro de deleteLandTool en el array TOOLS

## Funcionalidad

- Hard delete de terreno (igual que la API REST)
- Requiere confirm: true explícito para ejecutar
- Solo propietario o administrador pueden eliminar
- Registra evento de auditoría land/deleted

Closes #186