### PR TITLE
feat(mcp): implement sign_contract tool (HU-74 #191)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
 import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
+import { signContractTool } from "./tools/sign-contract";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -29,6 +30,7 @@ const TOOLS = [
   moderateLandTool,
   manageUserStatusTool,
   getAnalyticsOverviewTool,
+  signContractTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/sign-contract.test.ts
+++ b/apps/mcp-server/src/tools/sign-contract.test.ts
@@ -42,19 +42,19 @@ describe("sign_contract tool (HU-74 #191)", () => {
   });
 
   it("owner firma contrato draft → active", async () => {
-    const res = await signContract({ contractId: "contract_draft" }, ownerUser);
+    const res = await signContract({ contractId: "contract_draft", confirm: true }, ownerUser);
     expect((res as { status: string }).status).toBe("active");
     expect((res as { terms: { signedAt: string } }).terms.signedAt).toBeDefined();
   });
 
   it("tenant firma su propio contrato draft", async () => {
-    const res = await signContract({ contractId: "contract_draft" }, tenantUser);
+    const res = await signContract({ contractId: "contract_draft", confirm: true }, tenantUser);
     expect((res as { status: string }).status).toBe("active");
   });
 
   it("contrato active → firmar lanza error", async () => {
     try {
-      await signContract({ contractId: "contract_active" }, ownerUser);
+      await signContract({ contractId: "contract_active", confirm: true }, ownerUser);
       expect(true).toBe(false);
     } catch (err) {
       expect((err as Error).message).toContain("draft");
@@ -63,7 +63,7 @@ describe("sign_contract tool (HU-74 #191)", () => {
 
   it("usuario que NO es parte no puede firmar", async () => {
     try {
-      await signContract({ contractId: "contract_draft" }, outsiderUser);
+      await signContract({ contractId: "contract_draft", confirm: true }, outsiderUser);
       expect(true).toBe(false);
     } catch (err) {
       expect((err as Error).message).toContain("No autorizado");
@@ -72,7 +72,7 @@ describe("sign_contract tool (HU-74 #191)", () => {
 
   it("contrato inexistente lanza error", async () => {
     try {
-      await signContract({ contractId: "contract_nonexistent" }, ownerUser);
+      await signContract({ contractId: "contract_nonexistent", confirm: true }, ownerUser);
       expect(true).toBe(false);
     } catch (err) {
       expect((err as Error).message).toContain("no encontrado");
@@ -80,7 +80,25 @@ describe("sign_contract tool (HU-74 #191)", () => {
   });
 
   it("admin puede firmar contratos de otros", async () => {
-    const res = await signContract({ contractId: "contract_draft" }, adminUser);
+    const res = await signContract({ contractId: "contract_draft", confirm: true }, adminUser);
     expect((res as { status: string }).status).toBe("active");
+  });
+
+  it("sin confirmacion lanza error", async () => {
+    try {
+      await signContract({ contractId: "contract_draft" } as never, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("confirmar");
+    }
+  });
+
+  it("confirm=false lanza error", async () => {
+    try {
+      await signContract({ contractId: "contract_draft", confirm: false }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("confirmar");
+    }
   });
 });

--- a/apps/mcp-server/src/tools/sign-contract.test.ts
+++ b/apps/mcp-server/src/tools/sign-contract.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { Contract, User } from "@backend/db/schemas";
+import { signContract } from "./sign-contract";
+
+const ownerUser = { id: "user_seed", role: "user" };
+const tenantUser = { id: "user_regular", role: "user" };
+const adminUser = { id: "user_admin", role: "admin" };
+const outsiderUser = { id: "user_outsider", role: "user" };
+
+describe("sign_contract tool (HU-74 #191)", () => {
+  beforeEach(async () => {
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_seed" },
+      { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Seed Owner" } },
+      { upsert: true },
+    );
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_outsider" },
+      { clerkUserId: "user_outsider", email: "outsider@test.com", role: "user", status: "active", profile: { fullName: "Outsider" } },
+      { upsert: true },
+    );
+    await Contract.deleteMany({});
+    await Contract.insertMany([
+      {
+        id: "contract_draft",
+        rentalRequestId: "req_1",
+        ownerId: "user_seed",
+        tenantId: "user_regular",
+        terms: { summary: "Alquiler de finca", startsAt: "2026-08-01", endsAt: "2026-12-31" },
+        status: "draft",
+      },
+      {
+        id: "contract_active",
+        rentalRequestId: "req_2",
+        ownerId: "user_seed",
+        tenantId: "user_regular",
+        terms: { summary: "Ya firmado", signedAt: "2026-07-01", startsAt: "2026-08-01", endsAt: "2026-12-31" },
+        status: "active",
+      },
+    ]);
+  });
+
+  it("owner firma contrato draft → active", async () => {
+    const res = await signContract({ contractId: "contract_draft" }, ownerUser);
+    expect((res as { status: string }).status).toBe("active");
+    expect((res as { terms: { signedAt: string } }).terms.signedAt).toBeDefined();
+  });
+
+  it("tenant firma su propio contrato draft", async () => {
+    const res = await signContract({ contractId: "contract_draft" }, tenantUser);
+    expect((res as { status: string }).status).toBe("active");
+  });
+
+  it("contrato active → firmar lanza error", async () => {
+    try {
+      await signContract({ contractId: "contract_active" }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("draft");
+    }
+  });
+
+  it("usuario que NO es parte no puede firmar", async () => {
+    try {
+      await signContract({ contractId: "contract_draft" }, outsiderUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("No autorizado");
+    }
+  });
+
+  it("contrato inexistente lanza error", async () => {
+    try {
+      await signContract({ contractId: "contract_nonexistent" }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("no encontrado");
+    }
+  });
+
+  it("admin puede firmar contratos de otros", async () => {
+    const res = await signContract({ contractId: "contract_draft" }, adminUser);
+    expect((res as { status: string }).status).toBe("active");
+  });
+});

--- a/apps/mcp-server/src/tools/sign-contract.ts
+++ b/apps/mcp-server/src/tools/sign-contract.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import { Contract, AuditEvent } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { canReadContract } from "../permissions";
+
+const signContractInput = {
+  contractId: z.string().min(1).describe("ID del contrato a firmar"),
+};
+
+export type SignContractInput = z.infer<z.ZodObject<typeof signContractInput>>;
+
+export async function signContract(
+  rawInput: unknown,
+  actingUser: { id: string; role: string },
+): Promise<Record<string, unknown>> {
+  const schema = z.object(signContractInput);
+  const input = schema.parse(rawInput ?? {});
+
+  const contract = await Contract.findOne({ id: input.contractId }).lean();
+  if (!contract) throw new ToolError("Contrato no encontrado");
+
+  if (
+    !canReadContract(
+      actingUser as never,
+      { ownerId: contract.ownerId, tenantId: contract.tenantId } as never,
+    )
+  ) {
+    throw new ToolError("No autorizado para firmar este contrato");
+  }
+
+  if (contract.status !== "draft") {
+    throw new ToolError(
+      `Solo se pueden firmar contratos en borrador (draft). Estado actual: ${contract.status}`,
+    );
+  }
+
+  const updated = await Contract.findOneAndUpdate(
+    { id: input.contractId },
+    {
+      $set: {
+        status: "active",
+        "terms.signedAt": new Date().toISOString(),
+        updatedAt: new Date(),
+      },
+    },
+    { returnDocument: "after" },
+  );
+  if (!updated) throw new ToolError("Error al firmar el contrato");
+
+  await AuditEvent.create({
+    id: `audit_${crypto.randomUUID()}`,
+    actorId: actingUser.id,
+    actorRole: actingUser.role as "user" | "admin",
+    entity: "contract",
+    action: "signed",
+    entityId: input.contractId,
+    metadata: { from: "draft", to: "active" },
+  });
+
+  const { _id, __v, ...rest } = updated.toObject();
+  return rest;
+}
+
+export const signContractTool: ToolDefinition<typeof signContractInput> = {
+  name: "sign_contract",
+  title: "Firmar contrato",
+  description:
+    "Firma un contrato en borrador, pasándolo a estado activo. Cualquier parte del contrato (owner o tenant) puede firmarlo.",
+  inputSchema: signContractInput,
+  requires: "user",
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!;
+    return signContract(args, actingUser);
+  },
+};

--- a/apps/mcp-server/src/tools/sign-contract.ts
+++ b/apps/mcp-server/src/tools/sign-contract.ts
@@ -6,6 +6,7 @@ import { canReadContract } from "../permissions";
 
 const signContractInput = {
   contractId: z.string().min(1).describe("ID del contrato a firmar"),
+  confirm: z.boolean().optional().describe("Debe ser true para confirmar la firma"),
 };
 
 export type SignContractInput = z.infer<z.ZodObject<typeof signContractInput>>;
@@ -16,6 +17,10 @@ export async function signContract(
 ): Promise<Record<string, unknown>> {
   const schema = z.object(signContractInput);
   const input = schema.parse(rawInput ?? {});
+
+  if (input.confirm !== true) {
+    throw new ToolError("Debes confirmar la firma con confirm: true");
+  }
 
   const contract = await Contract.findOne({ id: input.contractId }).lean();
   if (!contract) throw new ToolError("Contrato no encontrado");


### PR DESCRIPTION
## Resumen

Implementa la tool MCP sign_contract (HU-74, issue #191) que permite firmar un contrato vía agente MCP.

## Cambios

- **pps/mcp-server/src/tools/sign-contract.ts**: Tool con transición draft→active, permisos canReadContract, y audit logging
- **pps/mcp-server/src/tools/sign-contract.test.ts**: 6 tests (owner, tenant, admin, no-parte, inexistente, ya-activo)
- **pps/mcp-server/src/server.ts**: Registro en el array TOOLS

## Funcionalidad

- Transición: draft → active (con 	erms.signedAt automático)
- Permisos: cualquier parte del contrato puede firmar (owner o tenant), o admin
- Audit: action signed con metadata { from: draft, to: active }

Closes #191