### PR TITLE
feat(mcp): implement complete_contract tool (HU-75 #192)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
 import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
+import { completeContractTool } from "./tools/complete-contract";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -29,6 +30,7 @@ const TOOLS = [
   moderateLandTool,
   manageUserStatusTool,
   getAnalyticsOverviewTool,
+  completeContractTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/complete-contract.test.ts
+++ b/apps/mcp-server/src/tools/complete-contract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { Contract, User } from "@backend/db/schemas";
+import { completeContract } from "./complete-contract";
+
+const ownerUser = { id: "user_seed", role: "user" };
+const tenantUser = { id: "user_regular", role: "user" };
+const adminUser = { id: "user_admin", role: "admin" };
+
+describe("complete_contract tool (HU-75 #192)", () => {
+  beforeEach(async () => {
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_seed" },
+      { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Seed Owner" } },
+      { upsert: true },
+    );
+    await Contract.deleteMany({});
+    await Contract.insertMany([
+      {
+        id: "contract_active",
+        rentalRequestId: "req_1",
+        ownerId: "user_seed",
+        tenantId: "user_regular",
+        terms: { summary: "Alquiler activo", signedAt: "2026-07-01", startsAt: "2026-08-01", endsAt: "2026-12-31" },
+        status: "active",
+      },
+      {
+        id: "contract_draft",
+        rentalRequestId: "req_2",
+        ownerId: "user_seed",
+        tenantId: "user_regular",
+        terms: { summary: "Borrador", startsAt: "2026-08-01", endsAt: "2026-12-31" },
+        status: "draft",
+      },
+    ]);
+  });
+
+  it("owner completa contrato activo → completed", async () => {
+    const res = await completeContract({ contractId: "contract_active" }, ownerUser);
+    expect((res as { status: string }).status).toBe("completed");
+  });
+
+  it("admin puede completar contratos de otros", async () => {
+    const res = await completeContract({ contractId: "contract_active" }, adminUser);
+    expect((res as { status: string }).status).toBe("completed");
+  });
+
+  it("tenant NO puede completar (solo owner/admin)", async () => {
+    try {
+      await completeContract({ contractId: "contract_active" }, tenantUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("Solo el propietario");
+    }
+  });
+
+  it("draft → complete lanza error", async () => {
+    try {
+      await completeContract({ contractId: "contract_draft" }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("activos");
+    }
+  });
+
+  it("contrato inexistente lanza error", async () => {
+    try {
+      await completeContract({ contractId: "contract_nonexistent" }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("no encontrado");
+    }
+  });
+});

--- a/apps/mcp-server/src/tools/complete-contract.ts
+++ b/apps/mcp-server/src/tools/complete-contract.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+import { Contract, AuditEvent } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { canMutateContract } from "../permissions";
+
+const completeContractInput = {
+  contractId: z.string().min(1).describe("ID del contrato a completar"),
+};
+
+export type CompleteContractInput = z.infer<z.ZodObject<typeof completeContractInput>>;
+
+export async function completeContract(
+  rawInput: unknown,
+  actingUser: { id: string; role: string },
+): Promise<Record<string, unknown>> {
+  const schema = z.object(completeContractInput);
+  const input = schema.parse(rawInput ?? {});
+
+  const contract = await Contract.findOne({ id: input.contractId }).lean();
+  if (!contract) throw new ToolError("Contrato no encontrado");
+
+  if (!canMutateContract(actingUser as never, { ownerId: contract.ownerId } as never)) {
+    throw new ToolError("Solo el propietario o un administrador pueden completar contratos");
+  }
+
+  if (contract.status !== "active") {
+    throw new ToolError(
+      `Solo se pueden completar contratos activos. Estado actual: ${contract.status}`,
+    );
+  }
+
+  const updated = await Contract.findOneAndUpdate(
+    { id: input.contractId },
+    { $set: { status: "completed", updatedAt: new Date() } },
+    { returnDocument: "after" },
+  );
+  if (!updated) throw new ToolError("Error al completar el contrato");
+
+  await AuditEvent.create({
+    id: `audit_${crypto.randomUUID()}`,
+    actorId: actingUser.id,
+    actorRole: actingUser.role as "user" | "admin",
+    entity: "contract",
+    action: "completed",
+    entityId: input.contractId,
+    metadata: { from: "active", to: "completed" },
+  });
+
+  const { _id, __v, ...rest } = updated.toObject();
+  return rest;
+}
+
+export const completeContractTool: ToolDefinition<typeof completeContractInput> = {
+  name: "complete_contract",
+  title: "Completar contrato",
+  description:
+    "Marca un contrato activo como completado. Solo el propietario o un administrador pueden ejecutar esta acción.",
+  inputSchema: completeContractInput,
+  requires: "user",
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!;
+    return completeContract(args, actingUser);
+  },
+};


### PR DESCRIPTION
## Resumen

Implementa la tool MCP complete_contract (HU-75, issue #192) que permite marcar un contrato como completado vía agente MCP.

## Cambios

- **pps/mcp-server/src/tools/complete-contract.ts**: Tool con transición active→completed, permisos canMutateContract, y audit logging
- **pps/mcp-server/src/tools/complete-contract.test.ts**: 5 tests (owner, admin, tenant-no-owner, draft→complete, inexistente)
- **pps/mcp-server/src/server.ts**: Registro en el array TOOLS

## Funcionalidad

- Transición: active → completed
- Permisos: solo owner o admin (tenant NO puede completar)
- Audit: action completed con metadata { from: active, to: completed }

Closes #192