### PR TITLE
feat(mcp): implement send_message tool (HU-83 #200)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
 import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
+import { sendMessageTool } from "./tools/send-message";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -29,6 +30,7 @@ const TOOLS = [
   moderateLandTool,
   manageUserStatusTool,
   getAnalyticsOverviewTool,
+  sendMessageTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/send-message.test.ts
+++ b/apps/mcp-server/src/tools/send-message.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { Chat, ChatMessage, User } from "@backend/db/schemas";
+import { sendMessage } from "./send-message";
+
+const ownerUser = { id: "user_seed", role: "user" };
+const tenantUser = { id: "user_regular", role: "user" };
+const outsiderUser = { id: "user_outsider", role: "user" };
+
+describe("send_message tool (HU-83 #200)", () => {
+  beforeEach(async () => {
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_seed" },
+      { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Seed Owner" } },
+      { upsert: true },
+    );
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_outsider" },
+      { clerkUserId: "user_outsider", email: "outsider@test.com", role: "user", status: "active", profile: { fullName: "Outsider" } },
+      { upsert: true },
+    );
+    await ChatMessage.deleteMany({});
+    await Chat.deleteMany({});
+    await Chat.insertMany([
+      {
+        id: "chat_1",
+        landId: "land_a",
+        participants: [
+          { userId: "user_seed", role: "owner" },
+          { userId: "user_regular", role: "tenant" },
+        ],
+        status: "active",
+      },
+    ]);
+  });
+
+  it("participante envía mensaje exitosamente", async () => {
+    const res = await sendMessage({ chatId: "chat_1", text: "Hola!" }, ownerUser);
+    expect((res as { text: string }).text).toBe("Hola!");
+    expect((res as { senderId: string }).senderId).toBe("user_seed");
+    expect((res as { chatId: string }).chatId).toBe("chat_1");
+    expect((res as { messageId: string }).messageId).toMatch(/^msg_/);
+  });
+
+  it("texto con espacios se trimea", async () => {
+    const res = await sendMessage({ chatId: "chat_1", text: "  Mensaje con espacios  " }, ownerUser);
+    expect((res as { text: string }).text).toBe("Mensaje con espacios");
+  });
+
+  it("texto vacío lanza error", async () => {
+    try {
+      await sendMessage({ chatId: "chat_1", text: "   " }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("vacío");
+    }
+  });
+
+  it("chat inexistente lanza error", async () => {
+    try {
+      await sendMessage({ chatId: "chat_nonexistent", text: "Hola" }, ownerUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("no encontrado");
+    }
+  });
+
+  it("usuario NO participante no puede enviar", async () => {
+    try {
+      await sendMessage({ chatId: "chat_1", text: "Hola" }, outsiderUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("participante");
+    }
+  });
+
+  it("ambos participantes pueden enviar", async () => {
+    const res1 = await sendMessage({ chatId: "chat_1", text: "Owner msg" }, ownerUser);
+    expect((res1 as { senderId: string }).senderId).toBe("user_seed");
+    const res2 = await sendMessage({ chatId: "chat_1", text: "Tenant msg" }, tenantUser);
+    expect((res2 as { senderId: string }).senderId).toBe("user_regular");
+  });
+});

--- a/apps/mcp-server/src/tools/send-message.ts
+++ b/apps/mcp-server/src/tools/send-message.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+import { Chat, ChatMessage, AuditEvent } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { canReadChat } from "../permissions";
+
+const sendMessageInput = {
+  chatId: z.string().min(1).describe("ID del chat"),
+  text: z.string().min(1).describe("Contenido del mensaje"),
+};
+
+export type SendMessageInput = z.infer<z.ZodObject<typeof sendMessageInput>>;
+
+export async function sendMessage(
+  rawInput: unknown,
+  actingUser: { id: string; role: string },
+): Promise<Record<string, unknown>> {
+  const schema = z.object(sendMessageInput);
+  const input = schema.parse(rawInput ?? {});
+
+  const trimmedText = input.text.trim();
+  if (trimmedText.length === 0) throw new ToolError("El mensaje no puede estar vacío");
+
+  const chat = await Chat.findOne({ id: input.chatId }).lean();
+  if (!chat) throw new ToolError("Chat no encontrado");
+
+  if (!canReadChat(actingUser as never, { participants: chat.participants } as never)) {
+    throw new ToolError("No eres participante de este chat");
+  }
+
+  const messageId = `msg_${crypto.randomUUID()}`;
+  const now = new Date();
+
+  await ChatMessage.create({
+    id: messageId,
+    chatId: input.chatId,
+    senderId: actingUser.id,
+    text: trimmedText,
+    createdAt: now,
+  });
+
+  await AuditEvent.create({
+    id: `audit_${crypto.randomUUID()}`,
+    actorId: actingUser.id,
+    actorRole: actingUser.role as "user" | "admin",
+    entity: "chat",
+    action: "updated",
+    entityId: input.chatId,
+    metadata: { messageId },
+  });
+
+  return {
+    messageId,
+    chatId: input.chatId,
+    senderId: actingUser.id,
+    text: trimmedText,
+    createdAt: now.toISOString(),
+  };
+}
+
+export const sendMessageTool: ToolDefinition<typeof sendMessageInput> = {
+  name: "send_message",
+  title: "Enviar mensaje",
+  description:
+    "Envía un mensaje de texto en un chat existente. El usuario debe ser participante del chat.",
+  inputSchema: sendMessageInput,
+  requires: "user",
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!;
+    return sendMessage(args, actingUser);
+  },
+};


### PR DESCRIPTION
## Resumen

Implementa la tool MCP send_message (HU-83, issue #200) que permite enviar mensajes de texto en un chat vía agente MCP.

## Cambios

- **pps/mcp-server/src/tools/send-message.ts**: Tool con validación de participantes, trim de texto, y audit logging
- **pps/mcp-server/src/tools/send-message.test.ts**: 6 tests (envío, trim, texto vacío, chat inexistente, no-participante, ambos participantes)
- **pps/mcp-server/src/server.ts**: Registro en el array TOOLS

## Funcionalidad

- Crea ChatMessage con ID único, senderId del usuario autenticado
- Texto se trimea automáticamente
- Valida que el usuario sea participante del chat (o admin)
- Audit: action updated en el chat con metadata { messageId }

Closes #200