### PR TITLE
feat(mcp): implement get_external_contact tool (HU-84 #201)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
 import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
+import { getExternalContactTool } from "./tools/get-external-contact";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -29,6 +30,7 @@ const TOOLS = [
   moderateLandTool,
   manageUserStatusTool,
   getAnalyticsOverviewTool,
+  getExternalContactTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/get-external-contact.test.ts
+++ b/apps/mcp-server/src/tools/get-external-contact.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+
+import { Chat, User } from "@backend/db/schemas";
+import { getExternalContact } from "./get-external-contact";
+
+const ownerUser = { id: "user_seed", role: "user" };
+const tenantUser = { id: "user_regular", role: "user" };
+const outsiderUser = { id: "user_outsider", role: "user" };
+
+describe("get_external_contact tool (HU-84 #201)", () => {
+  const originalFlag = process.env.WHATSAPP_CONTACT_ENABLED;
+
+  beforeEach(async () => {
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_seed" },
+      { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Seed Owner", phone: "+50761234567" } },
+      { upsert: true },
+    );
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_outsider" },
+      { clerkUserId: "user_outsider", email: "outsider@test.com", role: "user", status: "active", profile: { fullName: "Outsider" } },
+      { upsert: true },
+    );
+    await Chat.deleteMany({});
+    await Chat.insertMany([
+      {
+        id: "chat_with_phone",
+        landId: "land_a",
+        participants: [
+          { userId: "user_seed", role: "owner" },
+          { userId: "user_regular", role: "tenant" },
+        ],
+        status: "active",
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    process.env.WHATSAPP_CONTACT_ENABLED = originalFlag;
+  });
+
+  it("devuelve contacto cuando WhatsApp está habilitado y owner tiene teléfono", async () => {
+    process.env.WHATSAPP_CONTACT_ENABLED = "true";
+    const res = await getExternalContact({ chatId: "chat_with_phone" }, tenantUser);
+    expect((res as { whatsappEnabled: boolean }).whatsappEnabled).toBe(true);
+    const contact = (res as { contact: { phone: string; displayName: string; available: boolean } }).contact;
+    expect(contact.phone).toBe("+50761234567");
+    expect(contact.displayName).toBe("Seed Owner");
+    expect(contact.available).toBe(true);
+  });
+
+  it("devuelve whatsappEnabled false cuando flag está deshabilitado", async () => {
+    process.env.WHATSAPP_CONTACT_ENABLED = "false";
+    const res = await getExternalContact({ chatId: "chat_with_phone" }, tenantUser);
+    expect((res as { whatsappEnabled: boolean }).whatsappEnabled).toBe(false);
+  });
+
+  it("devuelve whatsappEnabled false cuando flag no está definido", async () => {
+    delete process.env.WHATSAPP_CONTACT_ENABLED;
+    const res = await getExternalContact({ chatId: "chat_with_phone" }, tenantUser);
+    expect((res as { whatsappEnabled: boolean }).whatsappEnabled).toBe(false);
+  });
+
+  it("chat inexistente lanza error", async () => {
+    process.env.WHATSAPP_CONTACT_ENABLED = "true";
+    try {
+      await getExternalContact({ chatId: "chat_nonexistent" }, tenantUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("no encontrado");
+    }
+  });
+
+  it("usuario NO participante no puede ver contacto", async () => {
+    process.env.WHATSAPP_CONTACT_ENABLED = "true";
+    try {
+      await getExternalContact({ chatId: "chat_with_phone" }, outsiderUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("participante");
+    }
+  });
+
+  it("owner puede ver su propio contacto", async () => {
+    process.env.WHATSAPP_CONTACT_ENABLED = "true";
+    const res = await getExternalContact({ chatId: "chat_with_phone" }, ownerUser);
+    expect((res as { whatsappEnabled: boolean }).whatsappEnabled).toBe(true);
+  });
+});

--- a/apps/mcp-server/src/tools/get-external-contact.ts
+++ b/apps/mcp-server/src/tools/get-external-contact.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+import { Chat, User } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { canReadChat } from "../permissions";
+
+const getExternalContactInput = {
+  chatId: z.string().min(1).describe("ID del chat"),
+};
+
+export type GetExternalContactInput = z.infer<z.ZodObject<typeof getExternalContactInput>>;
+
+export async function getExternalContact(
+  rawInput: unknown,
+  actingUser: { id: string; role: string },
+): Promise<Record<string, unknown>> {
+  const schema = z.object(getExternalContactInput);
+  const input = schema.parse(rawInput ?? {});
+
+  const chat = await Chat.findOne({ id: input.chatId }).lean();
+  if (!chat) throw new ToolError("Chat no encontrado");
+
+  if (!canReadChat(actingUser as never, { participants: chat.participants } as never)) {
+    throw new ToolError("No eres participante de este chat");
+  }
+
+  if (process.env.WHATSAPP_CONTACT_ENABLED !== "true") {
+    return { whatsappEnabled: false };
+  }
+
+  const ownerParticipant = chat.participants.find((p) => p.role === "owner");
+  if (!ownerParticipant) {
+    throw new ToolError("No se encontró el propietario en este chat");
+  }
+
+  const owner = await User.findOne({ clerkUserId: ownerParticipant.userId }).lean();
+  if (!owner) {
+    throw new ToolError("Usuario propietario no encontrado");
+  }
+
+  const phone = owner.profile?.phone ?? null;
+  const displayName = owner.profile?.fullName ?? "Propietario";
+
+  return {
+    whatsappEnabled: true,
+    contact: {
+      phone,
+      displayName,
+      available: Boolean(phone),
+    },
+  };
+}
+
+export const getExternalContactTool: ToolDefinition<typeof getExternalContactInput> = {
+  name: "get_external_contact",
+  title: "Obtener contacto externo",
+  description:
+    "Obtiene el contacto externo (WhatsApp) del propietario en un chat. Requiere que la funcionalidad de WhatsApp esté habilitada.",
+  inputSchema: getExternalContactInput,
+  requires: "user",
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!;
+    return getExternalContact(args, actingUser);
+  },
+};


### PR DESCRIPTION
﻿## Resumen

Implementa la tool MCP get_external_contact (HU-84, issue #201) que permite obtener el contacto externo (WhatsApp) del propietario en un chat via agente MCP.

## Cambios

- **apps/mcp-server/src/tools/get-external-contact.ts**: Tool con feature flag, permisos canReadChat, y resolucion de usuario
- **apps/mcp-server/src/tools/get-external-contact.test.ts**: 6 tests
- **apps/mcp-server/src/server.ts**: Registro en el array TOOLS

## Funcionalidad

- Feature flag: WHATSAPP_CONTACT_ENABLED
- Resuelve el participant con role owner del chat
- Busca el usuario owner para obtener telefono y nombre

Closes #201
