### PR TITLE
feat(mcp): implement get_owner_analytics tool (HU-89 #206)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { refundPaymentTool } from "./tools/refund-payment";
 import { moderateLandTool } from "./tools/moderate-land";
 import { manageUserStatusTool } from "./tools/manage-user-status";
 import { getAnalyticsOverviewTool } from "./tools/get-analytics-overview";
+import { getOwnerAnalyticsTool } from "./tools/get-owner-analytics";
 import { searchLandsTool } from "./tools/search-lands";
 
 /**
@@ -29,6 +30,7 @@ const TOOLS = [
   moderateLandTool,
   manageUserStatusTool,
   getAnalyticsOverviewTool,
+  getOwnerAnalyticsTool,
   // HU-64..HU-92: añadir aquí cada nueva tool.
 ];
 

--- a/apps/mcp-server/src/tools/get-owner-analytics.test.ts
+++ b/apps/mcp-server/src/tools/get-owner-analytics.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { Land, RentalRequest, Payment, User } from "@backend/db/schemas";
+import { getOwnerAnalytics } from "./get-owner-analytics";
+
+const ownerUser = { id: "user_seed", role: "user" };
+const adminUser = { id: "user_admin", role: "admin" };
+const outsiderUser = { id: "user_regular", role: "user" };
+
+describe("get_owner_analytics tool (HU-89 #206)", () => {
+  beforeEach(async () => {
+    await User.findOneAndUpdate(
+      { clerkUserId: "user_seed" },
+      { clerkUserId: "user_seed", email: "seed@test.com", role: "user", status: "active", profile: { fullName: "Seed Owner" } },
+      { upsert: true },
+    );
+    await Payment.deleteMany({});
+    await RentalRequest.deleteMany({});
+    await Land.deleteMany({});
+    await Land.insertMany([
+      { id: "land_a", ownerId: "user_seed", title: "Finca A", area: 10, allowedUses: ["agricultura"], location: { province: "Chiriqui", district: "David" }, priceRule: { currency: "USD", pricePerMonth: 300 }, status: "active", operation: "alquiler" },
+      { id: "land_b", ownerId: "user_seed", title: "Finca B", area: 20, allowedUses: ["ganaderia"], location: { province: "Chiriqui", district: "Boquete" }, priceRule: { currency: "USD", pricePerMonth: 800 }, status: "active", operation: "alquiler" },
+      { id: "land_c", ownerId: "other_owner", title: "Finca C", area: 15, allowedUses: ["forestal"], location: { province: "Cocle", district: "Penonome" }, priceRule: { currency: "USD", pricePerMonth: 500 }, status: "active", operation: "alquiler" },
+    ]);
+    await RentalRequest.insertMany([
+      { id: "req_1", landId: "land_a", tenantId: "user_regular", operation: "alquiler", status: "approved", createdAt: new Date("2026-07-01"), updatedAt: new Date("2026-07-02") },
+      { id: "req_2", landId: "land_a", tenantId: "user_regular", operation: "alquiler", status: "pending_owner", createdAt: new Date("2026-07-10") },
+      { id: "req_3", landId: "land_b", tenantId: "user_regular", operation: "alquiler", status: "paid", createdAt: new Date("2026-07-05"), updatedAt: new Date("2026-07-06") },
+      { id: "req_4", landId: "land_b", tenantId: "user_regular", operation: "alquiler", status: "rejected", createdAt: new Date("2026-07-08"), updatedAt: new Date("2026-07-09") },
+    ]);
+    await Payment.insertMany([
+      { id: "pay_1", rentalRequestId: "req_3", amount: 800, currency: "USD", status: "paid" },
+    ]);
+  });
+
+  it("devuelve metricas correctas para el dueño", async () => {
+    const res = await getOwnerAnalytics({}, ownerUser);
+    expect((res as { totalLands: number }).totalLands).toBe(2);
+    expect((res as { totalRequests: number }).totalRequests).toBe(4);
+    expect((res as { pendingOwner: number }).pendingOwner).toBe(1);
+    expect((res as { approved: number }).approved).toBe(1);
+    expect((res as { totalRevenue: number }).totalRevenue).toBe(800);
+  });
+
+  it(" landsByCategory cuenta por uso", async () => {
+    const res = await getOwnerAnalytics({}, ownerUser);
+    const cats = (res as { landsByCategory: Record<string, number> }).landsByCategory;
+    expect(cats["agricultura"]).toBe(1);
+    expect(cats["ganaderia"]).toBe(1);
+  });
+
+  it("requestApprovalRate calcula correctamente", async () => {
+    const res = await getOwnerAnalytics({}, ownerUser);
+    expect((res as { requestApprovalRate: number }).requestApprovalRate).toBe(0.5);
+  });
+
+  it("admin puede ver analytics de otro usuario", async () => {
+    const res = await getOwnerAnalytics({ ownerId: "user_seed" }, adminUser);
+    expect((res as { totalLands: number }).totalLands).toBe(2);
+  });
+
+  it("usuario regular NO puede ver analytics de otro", async () => {
+    try {
+      await getOwnerAnalytics({ ownerId: "user_seed" }, outsiderUser);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as Error).message).toContain("No autorizado");
+    }
+  });
+
+  it("owner sin datos devuelve ceros", async () => {
+    const emptyOwner = { id: "empty_owner", role: "user" };
+    const res = await getOwnerAnalytics({}, emptyOwner);
+    expect((res as { totalLands: number }).totalLands).toBe(0);
+    expect((res as { totalRequests: number }).totalRequests).toBe(0);
+    expect((res as { totalRevenue: number }).totalRevenue).toBe(0);
+  });
+});

--- a/apps/mcp-server/src/tools/get-owner-analytics.ts
+++ b/apps/mcp-server/src/tools/get-owner-analytics.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+import { Land, RentalRequest, Payment } from "@backend/db/schemas";
+import { ToolError, type ToolDefinition } from "./define-tool";
+import { isOwnerOrAdmin } from "../permissions";
+
+const getOwnerAnalyticsInput = {
+  ownerId: z.string().optional().describe("ID del dueño (default: el usuario autenticado)"),
+};
+
+export type GetOwnerAnalyticsInput = z.infer<z.ZodObject<typeof getOwnerAnalyticsInput>>;
+
+export async function getOwnerAnalytics(
+  rawInput: unknown,
+  actingUser: { id: string; role: string },
+): Promise<Record<string, unknown>> {
+  const schema = z.object(getOwnerAnalyticsInput);
+  const input = schema.parse(rawInput ?? {});
+
+  const targetOwnerId = input.ownerId ?? actingUser.id;
+
+  if (!isOwnerOrAdmin(actingUser as never, targetOwnerId)) {
+    throw new ToolError("No autorizado para ver analiticas de otro usuario");
+  }
+
+  const activeLands = await Land.find({ ownerId: targetOwnerId, status: "active" }).lean();
+  const landIds = activeLands.map((l) => l.id);
+
+  const requests = landIds.length > 0
+    ? await RentalRequest.find({ landId: { $in: landIds } }).lean()
+    : [];
+
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  const pendingOwner = requests.filter((r) => r.status === "pending_owner").length;
+  const approved = requests.filter((r) => r.status === "approved").length;
+  const rejected = requests.filter((r) => r.status === "rejected").length;
+  const totalRequests = requests.length;
+
+  const requestsLast30Days = requests.filter(
+    (r) => new Date(r.createdAt) >= thirtyDaysAgo,
+  ).length;
+  const requestsLast7Days = requests.filter(
+    (r) => new Date(r.createdAt) >= sevenDaysAgo,
+  ).length;
+
+  const decidedRequests = requests.filter(
+    (r) => r.status === "approved" || r.status === "rejected",
+  );
+  let avgTimeToDecisionHours = 0;
+  if (decidedRequests.length > 0) {
+    const totalHours = decidedRequests.reduce((sum, r) => {
+      const created = new Date(r.createdAt).getTime();
+      const updated = new Date(r.updatedAt).getTime();
+      return sum + (updated - created) / (1000 * 60 * 60);
+    }, 0);
+    avgTimeToDecisionHours = Math.round((totalHours / decidedRequests.length) * 10) / 10;
+  }
+
+  const requestApprovalRate = (approved + rejected) > 0
+    ? Math.round((approved / (approved + rejected)) * 100) / 100
+    : 0;
+
+  const landsByCategory: Record<string, number> = {};
+  for (const land of activeLands) {
+    for (const use of land.allowedUses) {
+      landsByCategory[use] = (landsByCategory[use] ?? 0) + 1;
+    }
+  }
+
+  let totalRevenue = 0;
+  if (requests.length > 0) {
+    const requestIds = requests.map((r) => r.id);
+    const paidRequests = requests.filter(
+      (r) => r.status === "paid" || r.status === "approved" || r.status === "pending_payment",
+    );
+    const paidRequestIds = paidRequests.map((r) => r.id);
+
+    if (paidRequestIds.length > 0) {
+      const payments = await Payment.find({
+        rentalRequestId: { $in: paidRequestIds },
+        status: "paid",
+      }).lean();
+      totalRevenue = payments.reduce((sum, p) => sum + p.amount, 0);
+    }
+  }
+
+  return {
+    totalLands: activeLands.length,
+    landsByCategory,
+    totalRequests,
+    pendingOwner,
+    approved,
+    rejected,
+    requestApprovalRate,
+    requestsLast30Days,
+    requestsLast7Days,
+    avgTimeToDecisionHours,
+    totalRevenue,
+  };
+}
+
+export const getOwnerAnalyticsTool: ToolDefinition<typeof getOwnerAnalyticsInput> = {
+  name: "get_owner_analytics",
+  title: "Analiticas del dueño",
+  description:
+    "Obtiene metricas de analiticas para un propietario: terrenos activos, solicitudes, tasa de aprobacion, ingresos y mas.",
+  inputSchema: getOwnerAnalyticsInput,
+  requires: "user",
+  handler: async (args, ctx) => {
+    const actingUser = ctx.actingUser!;
+    return getOwnerAnalytics(args, actingUser);
+  },
+};


### PR DESCRIPTION
﻿## Resumen

Implementa la tool MCP get_owner_analytics (HU-89, issue #206) que permite obtener metricas de analiticas para un propietario.

## Cambios

- **apps/mcp-server/src/tools/get-owner-analytics.ts**: Tool con agregaciones sobre Land, RentalRequest y Payment
- **apps/mcp-server/src/tools/get-owner-analytics.test.ts**: 6 tests
- **apps/mcp-server/src/server.ts**: Registro en el array TOOLS

## Funcionalidad

- Metricas: terrenos activos, solicitudes por estado, tasa de aprobacion, ingresos totales
- Agrega por categorias de uso del terreno
- Calcula tiempo promedio de decision y solicitudes en los ultimos 7/30 dias
- Solo el owner o un admin pueden ver las analiticas

Closes #206
