### PR TITLE
test(mcp): add unit tests for get_land tool (HU-64 #181)

### DIFF
--- a/apps/mcp-server/src/tools/get-land.test.ts
+++ b/apps/mcp-server/src/tools/get-land.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { getLand } from "./get-land";
+
+describe("get_land tool (HU-64 #181)", () => {
+  it("devuelve la ficha completa de un terreno existente", async () => {
+    const result = await getLand({ landId: "land_a" });
+    expect(result).toBeDefined();
+    expect((result as { id: string }).id).toBe("land_a");
+    expect((result as { title: string }).title).toBe("Finca agrícola en Chiriquí");
+  });
+
+  it("incluye ubicación, área, usos y precio (criterios HU-64)", async () => {
+    const result = await getLand({ landId: "land_a" });
+    const land = result as Record<string, unknown>;
+    expect(land).toHaveProperty("location");
+    expect(land).toHaveProperty("area");
+    expect(land).toHaveProperty("allowedUses");
+    expect(land).toHaveProperty("priceRule");
+    expect((land.location as { province: string }).province).toBe("Chiriqui");
+    expect(land.allowedUses).toEqual(["agricultura"]);
+    expect((land.priceRule as { pricePerMonth: number }).pricePerMonth).toBe(300);
+  });
+
+  it("lanza error controlado cuando el terreno no existe", async () => {
+    await expect(getLand({ landId: "nonexistent" })).rejects.toThrow("Terreno no encontrado");
+  });
+
+  it("lanza error de validación cuando falta el landId", async () => {
+    await expect(getLand({})).rejects.toThrow();
+  });
+
+  it("no expone campos internos de Mongo (_id, __v)", async () => {
+    const result = await getLand({ landId: "land_a" });
+    const land = result as Record<string, unknown>;
+    expect(land).not.toHaveProperty("_id");
+    expect(land).not.toHaveProperty("__v");
+  });
+});


### PR DESCRIPTION
## Contexto

El tool `get_land` (HU-64) **ya estaba implementado, registrado y verificado por E2E** en `main` — se entregó dentro del PR #285 (junto con `list_my_lands`), pero ese PR solo referenció "Closes #185", por lo que el issue #181 quedó abierto.

Este PR completa el vertical añadiendo la **cobertura unitaria dedicada** que faltaba y cierra formalmente la HU.

## Qué añade

`apps/mcp-server/src/tools/get-land.test.ts` — 5 tests:
- Devuelve la ficha completa por ID.
- Incluye ubicación, área, usos y precio (criterios de aceptación).
- Error controlado cuando el terreno no existe (`Terreno no encontrado`).
- Error de validación cuando falta `landId`.
- No expone campos internos de Mongo (`_id`, `__v`).

## Verificación
- `bun test src/tools/get-land.test.ts`: 5/5.
- Suite completa mcp-server: 275/0.
- Typecheck limpio.

Closes #181