### PR TITLE
docs(mcp): completa la tabla de tools del README (31/31)

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -127,6 +127,14 @@ Tras reiniciar el cliente, la tool `search_lands` aparecerá disponible.
 | `list_audit_events` | HU-92 | #209 | ✅ implementada |
 | `list_notifications` | HU-90 | #202 | ✅ implementada |
 | `mark_notification_read` | HU-91 | #202 | ✅ implementada |
+| `update_land` | HU-66 | #183 | ✅ implementada |
+| `delete_land` | HU-69 | #186 | ✅ implementada |
+| `update_rental_request_status` | HU-72 | #189 | ✅ implementada |
+| `sign_contract` | HU-74 | #191 | ✅ implementada |
+| `complete_contract` | HU-75 | #192 | ✅ implementada |
+| `send_message` | HU-83 | #200 | ✅ implementada |
+| `get_external_contact` | HU-84 | #201 | ✅ implementada |
+| `get_owner_analytics` | HU-89 | #206 | ✅ implementada |
 
 ## Tests
 


### PR DESCRIPTION
## Contexto

La tabla de tools de `apps/mcp-server/README.md` tenía **23 filas pero hay 31 tools** registradas en `server.ts`. Las 8 faltantes ya estaban **implementadas, registradas y probadas** (mergeadas en sus PRs), solo faltaba su fila en la tabla — el último ítem pendiente del *Definition of Done* del track MCP (#276).

## Qué añade

Filas de: `update_land` (#183), `delete_land` (#186), `update_rental_request_status` (#189), `sign_contract` (#191), `complete_contract` (#192), `send_message` (#200), `get_external_contact` (#201), `get_owner_analytics` (#206).

Con esto la tabla refleja las **31 tools** (las 30 HU‑63…HU‑92, con #202 dividida en `list_notifications` + `mark_notification_read`).

## Verificación
- Filas de la tabla = tools registradas en `server.ts` (31/31).
- Cambio solo de documentación.

Closes #276