### PR TITLE
docs: nueva ronda funcional (HU 93-101) + specs de RF y seguridad MCP

### DIFF
--- a/docs/MCP_SECURITY_RULES.md
+++ b/docs/MCP_SECURITY_RULES.md
@@ -1,0 +1,100 @@
+# TerraShare — Reglas de seguridad para tools sensibles del MCP
+
+> Decisiones acordadas para **endurecer** (no eliminar) las tools del servidor MCP que ejecutan
+> acciones legales, financieras, de moderación o destructivas en nombre del usuario.
+> El objetivo es que un agente de IA no pueda ejecutar acciones irreversibles sin control humano.
+>
+> Grupo 1GS241 · Universidad Tecnológica de Panamá · Desarrollo de Software IX
+
+---
+
+## Capas de seguridad (legenda)
+
+| Capa | Nombre | Qué hace |
+|------|--------|----------|
+| **A** | Confirmación | Exige `confirm: true` en la llamada. Barrera mínima. |
+| **B** | Preview en 2 pasos | 1ª llamada devuelve un resumen de la acción + un `confirmationToken`; la acción solo procede si la 2ª llamada trae ese token. Evita ejecuciones "a ciegas". |
+| **C** | Restringir rol/ownership | Verificación estricta de que el `actingUser` es realmente la parte autorizada (owner/tenant/admin). |
+| **D** | Límites/umbrales | La acción se bloquea o exige doble confirmación por encima de cierto valor. |
+| **E** | Notificar al usuario | Cada ejecución dispara email/notificación a los afectados (defensa en profundidad + trazabilidad). |
+| **F** | Interruptor por config | Env var para desactivar la tool en despliegues sensibles. |
+| **G** | Solo-preparar | La tool no ejecuta la acción irreversible, solo la prepara (ej.: devolver un link, no cobrar). |
+
+> Estado base: cuatro tools ya implementan la capa **A** (`sign_contract`, `refund_payment`,
+> `manage_user_status`, `delete_land`) vía `confirm: true`.
+
+---
+
+## Reglas por tool
+
+### 🖋️ `sign_contract` (HU-74) — Firmar contrato
+**Capas: B + C + E + F**
+- **B:** la 1ª llamada devuelve los términos del contrato + `confirmationToken`; la firma solo procede con ese token.
+- **C:** verificar estrictamente que `actingUser` es `owner` o `tenant` del contrato.
+- **E:** email/notificación a ambas partes al firmarse vía agente.
+- **F:** env var (ej. `MCP_ALLOW_SIGN`) para desactivar la firma por MCP.
+
+### 💸 `refund_payment` (HU-80) — Reembolsar pago (admin)
+**Capas: A + B + D + E + F**
+- **A:** `confirm: true` (ya existe).
+- **B:** preview con el monto y el pago a reembolsar antes de ejecutar.
+- **D:** reembolsos por encima de un umbral configurable exigen doble confirmación.
+- **E:** notificar al usuario dueño del pago.
+- **F:** env var para desactivar reembolsos por MCP.
+
+### 💳 `create_payment_session` (HU-77) — Crear sesión de pago
+**Capas: A + C + G**
+- **A:** `confirm: true`.
+- **C:** verificar que `actingUser` es el arrendatario dueño de la solicitud a pagar.
+- **G:** la tool solo devuelve el `checkoutUrl`; nunca cobra ni expone secretos de Stripe (ya se cumple; dejarlo explícito y probado).
+
+### 🚫 `manage_user_status` (HU-91) — Bloquear/activar usuario (admin)
+**Capas: A + B + E**
+- **A:** `confirm: true` (ya existe).
+- **B:** preview ("vas a bloquear/activar a <usuario>") antes de ejecutar.
+- **E:** notificar al usuario afectado + registrar auditoría. (Ya es admin y no puede auto-modificarse.)
+
+### 🛡️ `moderate_land` (HU-90) — Moderar terreno (admin)
+**Capas: A + E**
+- **A:** añadir `confirm: true` (hoy no lo tiene).
+- **E:** notificar al dueño del terreno despublicado. (Ya es admin.)
+
+### 🗑️ `delete_land` (HU-69) — Eliminar terreno
+**Capas: A + B + E + soft-delete**
+- **A:** `confirm: true` (ya existe).
+- **B:** preview de lo que se eliminará.
+- **E:** notificar al dueño.
+- **soft-delete:** marcar como `deleted` (recuperable) en lugar de borrado físico.
+
+### 💬 `send_chat_message` (HU-83) — Enviar mensaje
+**Capas: A + marca de transparencia**
+- **A:** añadir `confirm: true` (hoy no lo tiene).
+- **Transparencia:** marcar el mensaje como "enviado vía asistente" (flag/metadata) para que el receptor sepa que no fue escrito a mano. Toque ligero (bajo riesgo).
+
+---
+
+## Resumen
+
+| HU | Tool | Capas |
+|----|------|-------|
+| 74 | `sign_contract` | B + C + E + F |
+| 80 | `refund_payment` | A + B + D + E + F |
+| 77 | `create_payment_session` | A + C + G |
+| 91 | `manage_user_status` | A + B + E |
+| 90 | `moderate_land` | A + E |
+| 69 | `delete_land` | A + B + E + soft-delete |
+| 83 | `send_chat_message` | A + transparencia |
+
+`get_payment_status` (HU-78) y el resto de tools de solo lectura no requieren cambios.
+
+---
+
+## Notas de implementación
+
+- El andamiaje `registerTool` (`define-tool.ts`) es el punto natural para estandarizar las capas
+  **A** (confirm) y **B** (token de preview), de modo que no se reimplementen en cada tool.
+- La capa **E** (notificaciones) puede reutilizar `apps/backend-api/src/lib/email.ts` y el modelo
+  de notificaciones existente.
+- La capa **F** (interruptores) se lee desde `apps/backend-api/src/config/env.ts`.
+- Añadir/actualizar tests por tool para cubrir: sin `confirm` → error, token inválido → error,
+  rol/ownership incorrecto → error, umbral superado → error.

--- a/docs/REQUISITOS_FUNCIONALES_30.md
+++ b/docs/REQUISITOS_FUNCIONALES_30.md
@@ -1,0 +1,166 @@
+# TerraShare — 30 Requisitos Funcionales (RF)
+
+> Documento de trabajo. Consolida los **30 requisitos funcionales** exigidos por el curso,
+> distinguiendo lo que ya está implementado, las features construidas pendientes de documentar
+> y las **5 HU nuevas** a desarrollar. Excluye deliberadamente los requisitos **no funcionales**
+> (seguridad, observabilidad, CI/CD, pruebas, etc.) y las tools **peligrosas** del MCP.
+>
+> Grupo 1GS241 · Universidad Tecnológica de Panamá · Desarrollo de Software IX
+
+---
+
+## 1. Criterio de conteo
+
+Un **requisito funcional (RF)** describe *algo que el sistema hace para un usuario*.
+Quedan **fuera** del conteo:
+
+- **No funcionales (NFR):** atributos de calidad — HU 33, 34, 35, 36, 39, 40, 42, 44, 45, 46,
+  47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 61, 62 (seguridad, logs, métricas, pruebas, CI/CD…).
+- **Tools peligrosas del MCP:** acciones legales/financieras/de moderación de cuenta que un
+  agente de IA no debería ejecutar (ver §4).
+- **Técnicas internas:** HU-04 (bypass de auth en dev), HU-18 (regla de no solapamiento),
+  HU-24 (procesar webhook) — son de sistema, no de usuario.
+
+---
+
+## 2. Lista de los 30 RF
+
+| RF | Historia | Origen | Estado |
+|----|----------|--------|--------|
+| RF-01 | Registro e inicio de sesión | HU-01 | ✅ Implementado |
+| RF-02 | Explorar catálogo con paginación | HU-05 | ✅ Implementado |
+| RF-03 | Filtrar terrenos (uso, provincia, precio, fechas) | HU-06 | ✅ Implementado |
+| RF-04 | Ordenar resultados (fecha/precio/área) | HU-07 | ✅ Implementado |
+| RF-05 | Ver detalle de un terreno | HU-08 | ✅ Implementado |
+| RF-06 | Publicar un terreno | HU-09 | ✅ Implementado |
+| RF-07 | Editar mi terreno | HU-10 | ✅ Implementado |
+| RF-08 | Cambiar el estado del terreno | HU-11 | ✅ Implementado |
+| RF-09 | Eliminar mi terreno | HU-12 | ✅ Implementado |
+| RF-10 | Ver mis terrenos | HU-13 | ✅ Implementado |
+| RF-11 | Crear una solicitud de alquiler | HU-14 | ✅ Implementado |
+| RF-12 | Listar mis solicitudes | HU-15 | ✅ Implementado |
+| RF-13 | Aprobar / rechazar solicitudes | HU-17 | ✅ Implementado |
+| RF-14 | Generar un contrato | HU-19 | ✅ Implementado |
+| RF-15 | Firmar un contrato | HU-20 | ✅ Implementado |
+| RF-16 | Completar un contrato | HU-21 | ✅ Implementado |
+| RF-17 | Iniciar un pago (Stripe Checkout) | HU-23 | ✅ Implementado |
+| RF-18 | Ver mis pagos | HU-25 | ✅ Implementado |
+| RF-19 | Chat interno y mensajes | HU-26/27 | ✅ Implementado |
+| RF-20 | Gestión de usuarios (admin) | HU-29 | ✅ Implementado |
+| RF-21 | Analítica e indicadores | HU-32 | ✅ Implementado |
+| RF-22 | Guardar terrenos favoritos | HU-93 | ✅ Construido, sin documentar |
+| RF-23 | Reportar un terreno | HU-94 | ✅ Construido, sin documentar |
+| RF-24 | Moderar reportes (admin) | HU-95 | ✅ Construido, sin documentar |
+| RF-25 | Ver perfil público de un dueño | HU-96 | ✅ Construido, sin documentar |
+| RF-26 | Reseñas y calificaciones | HU-97 | 🆕 Nueva |
+| RF-27 | Comparador de terrenos | HU-98 | 🆕 Nueva |
+| RF-28 | Búsquedas guardadas y alertas | HU-99 | 🆕 Nueva |
+| RF-29 | Agendar visita a un terreno | HU-100 | 🆕 Nueva |
+| RF-30 | Exportar contrato a PDF | HU-101 | 🆕 Nueva |
+
+**Resumen:** 21 ya implementados (núcleo MVP) · 4 construidos sin documentar · 5 nuevos por desarrollar.
+
+---
+
+## 3. Historias de usuario nuevas (redacción completa)
+
+### Features ya construidas (documentar)
+
+#### HU-93 — Guardar terrenos favoritos
+Como **usuario autenticado**, quiero marcar terrenos como favoritos y verlos en una lista,
+para hacer seguimiento de los que me interesan.
+- `POST/DELETE /users/me/favorites/:landId` agrega o quita un favorito.
+- `GET /users/me/favorites` devuelve solo los favoritos del usuario.
+- El estado de favorito se refleja en catálogo, home y detalle.
+- *Evidencia:* `routes/favorites.ts`, `hooks/useFavorites.ts`.
+
+#### HU-94 — Reportar un terreno
+Como **usuario**, quiero reportar un terreno con contenido sospechoso o inválido,
+para ayudar a mantener la calidad del catálogo.
+- `POST /reports` registra el reporte con motivo y terreno asociado.
+- El reporte queda vinculado al usuario que lo levanta.
+- *Evidencia:* `routes/reports.ts`.
+
+#### HU-95 — Moderar reportes (admin)
+Como **administrador**, quiero revisar y resolver los reportes recibidos,
+para actuar sobre publicaciones denunciadas.
+- `GET /admin/reports` y `GET /admin/reports/:id` listan y detallan reportes.
+- `PATCH /admin/reports/:id` cambia el estado (revisado/resuelto).
+- *Evidencia:* `routes/reports.ts`, `AdminReportsPage.tsx`, `AdminReportDetailPage.tsx`.
+
+#### HU-96 — Ver perfil público de un dueño
+Como **visitante**, quiero ver el perfil público de un dueño con sus terrenos publicados,
+para evaluar su reputación antes de alquilar.
+- `GET /users/:userId/public` devuelve datos públicos del dueño y sus publicaciones activas.
+- Un usuario inexistente devuelve `404`.
+- *Evidencia:* endpoint `#150`, `public-owner.test.ts`.
+
+---
+
+### HU nuevas por desarrollar
+
+#### HU-97 — Reseñas y calificaciones
+Como **parte de un contrato completado** (dueño o arrendatario), quiero calificar y comentar
+a la otra parte, para construir reputación y confianza en la plataforma.
+- Solo se puede reseñar si existe un contrato en estado `completed` entre ambas partes.
+- Cada parte puede dejar **una sola** reseña por contrato: 1–5 estrellas + comentario opcional.
+- El promedio de calificación se muestra en el perfil público del dueño (HU-96) y en la ficha del terreno.
+- Endpoints sugeridos: `POST /reviews`, `GET /users/:userId/reviews`.
+
+#### HU-98 — Comparador de terrenos
+Como **visitante**, quiero seleccionar hasta 3 terrenos y compararlos lado a lado,
+para decidir mejor cuál me conviene.
+- Se pueden añadir/quitar terrenos de una lista de comparación (máx. 3).
+- La vista muestra en columnas: precio, área, provincia/distrito, usos permitidos y disponibilidad.
+- Mayormente frontend; reutiliza `GET /lands/:id`. La selección persiste en `localStorage`.
+
+#### HU-99 — Búsquedas guardadas y alertas
+Como **usuario autenticado**, quiero guardar un conjunto de filtros y recibir un email cuando
+aparezca un terreno que los cumpla, para no revisar el catálogo manualmente.
+- `POST /users/me/saved-searches` guarda los filtros con un nombre.
+- Un proceso periódico compara terrenos nuevos `active` contra las búsquedas guardadas y notifica por email (reutiliza `lib/email.ts`).
+- `GET` / `DELETE /users/me/saved-searches` gestionan la lista.
+
+#### HU-100 — Agendar visita a un terreno
+Como **arrendatario interesado**, quiero solicitar una cita para visitar un terreno,
+para conocerlo antes de reservar.
+- `POST /lands/:id/visits` crea una solicitud de visita con fecha/hora propuesta.
+- El dueño confirma, reprograma o rechaza (`PATCH /visits/:id`).
+- Ambas partes ven sus visitas agendadas; se genera una notificación.
+
+#### HU-101 — Exportar contrato a PDF
+Como **parte de un contrato**, quiero descargar el contrato en PDF,
+para tener un respaldo formal del acuerdo.
+- `GET /contracts/:id/pdf` genera un PDF con términos, fechas, partes y estado de firma.
+- Solo las partes del contrato o un admin pueden descargarlo.
+- Si el contrato está `active`/`completed`, el PDF incluye la evidencia de firma (nombre, fecha).
+
+---
+
+## 4. Decisión sobre las tools peligrosas del MCP
+
+El riesgo no es el código, sino **exponer estas acciones a un agente de IA** que actúa en nombre
+del usuario. Estas quedan **fuera** del conteo de RF y se recomienda sacarlas o restringirlas:
+
+| HU | Tool | Riesgo | Decisión |
+|----|------|--------|----------|
+| 74 | `sign_contract` | Firma legal vinculante | **Quitar del MCP.** La firma debe ser un acto humano en la web. |
+| 77 | `create_payment_session` | Inicia flujo de dinero | **Quitar o degradar** a solo entregar link con confirmación humana. |
+| 80 | `refund_payment` | Devuelve dinero | **Quitar del MCP.** Acción financiera de admin. |
+| 91 | `manage_user_status` | Bloquea/activa cuentas | **Quitar del MCP.** Moderación de cuentas debe ser humana. |
+| 69 | `delete_land` | Destructiva | **Mantener** con confirmación explícita obligatoria. |
+| 83 | `send_chat_message` | Habla por el usuario | **Mantener** con confirmación antes de enviar. |
+| 90 | `moderate_land` | Despublica a terceros | **Mantener** solo admin + confirmación. |
+| 78 | `get_payment_status` | Solo lectura | ✅ **Dejar.** No es peligrosa. |
+
+**Criterio general:** el agente puede *leer* casi todo; las acciones **legales, financieras y de
+moderación de cuentas** (74, 77, 80, 91) salen del MCP y quedan solo en la web con un humano al frente.
+
+---
+
+## 5. Próximos pasos
+
+1. Validar con el profesor que estos 30 RF cumplen el requisito.
+2. Documentar formalmente HU 93–101 en `docs/historias-usuario/index.html` (o mantener este archivo como fuente).
+3. Implementar las 5 HU nuevas (HU-97 a HU-101).
+4. Aplicar las decisiones del MCP (§4) sobre las tools peligrosas.

--- a/docs/historias-usuario/index.html
+++ b/docs/historias-usuario/index.html
@@ -131,6 +131,7 @@
       <li><a href="#s1">Sección 1 — Inventario actual (implementado)</a> <span class="pill pill-count">HU 1–32</span></li>
       <li><a href="#s2">Sección 2 — Faltante / Production-Ready</a> <span class="pill pill-count">HU 33–62</span></li>
       <li><a href="#s3">Sección 3 — Servidor MCP sobre el comercio electrónico</a> <span class="pill pill-mcp">HU 63–92 · [MCP]</span></li>
+      <li><a href="#s4">Sección 4 — Nueva ronda de funcionalidades</a> <span class="pill pill-count">HU 93–101</span></li>
       <li><a href="#tabla">Anexo — Tabla resumen de herramientas (tools) MCP</a></li>
     </ol>
   </div>
@@ -159,8 +160,8 @@
     <b>Formato de cada historia:</b> «Como &lt;rol&gt;, quiero &lt;acción&gt;, para &lt;beneficio&gt;»,
     numerada, con 2–4 criterios de aceptación. Las historias <b>[MCP]</b> incluyen además:
     <b>tool</b> que la expone, <b>autenticación</b> requerida y <b>qué le permite hacer al agente</b>.
-    <br><b>Resumen de cobertura:</b> 32 implementadas · 30 nuevas production-ready · 30 vía MCP =
-    <b>92 historias</b> (≥30 etiquetadas <span class="tag tag-mcp">[MCP]</span>).
+    <br><b>Resumen de cobertura:</b> 32 implementadas · 30 nuevas production-ready · 30 vía MCP ·
+    9 nueva ronda funcional (HU 93–101) = <b>101 historias</b> (≥30 etiquetadas <span class="tag tag-mcp">[MCP]</span>).
   </div>
 </section>
 
@@ -1122,6 +1123,97 @@
   </div>
 </section>
 
+<!-- ====================== SECCIÓN 4 — NUEVA RONDA FUNCIONAL ====================== -->
+<section class="page">
+  <h2 id="s4">Sección 4 — Nueva ronda de funcionalidades</h2>
+  <p class="section-intro">9 historias <b>funcionales</b> añadidas como nueva ronda: <b>4</b> ya
+  construidas en el código pero que faltaban por documentar (<span class="tag" style="background:var(--green);color:#fff">CONSTRUIDA</span>)
+  y <b>5</b> nuevas por desarrollar (<span class="tag" style="background:var(--amber);color:#fff">NUEVA</span>),
+  con su issue de GitHub asignado. Todas son requisitos funcionales (no incluyen atributos de calidad).</p>
+
+  <h3>Features ya construidas (a documentar)</h3>
+
+  <div class="story"><div class="h"><span class="num">HU-93</span><span class="tag" style="background:var(--green);color:#fff">CONSTRUIDA</span><span class="title">Guardar terrenos favoritos</span></div>
+    <p class="us">Como <span class="r">usuario autenticado</span>, quiero marcar terrenos como favoritos y verlos en una lista, para hacer seguimiento de los que me interesan.</p>
+    <ul class="ac">
+      <li><code>POST/DELETE /users/me/favorites/:landId</code> agrega o quita un favorito.</li>
+      <li><code>GET /users/me/favorites</code> devuelve solo los favoritos del usuario.</li>
+      <li>El estado de favorito se refleja en catálogo, home y detalle.</li>
+    </ul>
+  </div>
+
+  <div class="story"><div class="h"><span class="num">HU-94</span><span class="tag" style="background:var(--green);color:#fff">CONSTRUIDA</span><span class="title">Reportar un terreno</span></div>
+    <p class="us">Como <span class="r">usuario</span>, quiero reportar un terreno con contenido sospechoso o inválido, para ayudar a mantener la calidad del catálogo.</p>
+    <ul class="ac">
+      <li><code>POST /reports</code> registra el reporte con motivo y terreno asociado.</li>
+      <li>El reporte queda vinculado al usuario que lo levanta.</li>
+    </ul>
+  </div>
+
+  <div class="story"><div class="h"><span class="num">HU-95</span><span class="tag" style="background:var(--green);color:#fff">CONSTRUIDA</span><span class="title">Moderar reportes (admin)</span></div>
+    <p class="us">Como <span class="r">administrador</span>, quiero revisar y resolver los reportes recibidos, para actuar sobre publicaciones denunciadas.</p>
+    <ul class="ac">
+      <li><code>GET /admin/reports</code> y <code>GET /admin/reports/:id</code> listan y detallan reportes.</li>
+      <li><code>PATCH /admin/reports/:id</code> cambia el estado (revisado/resuelto).</li>
+    </ul>
+  </div>
+
+  <div class="story"><div class="h"><span class="num">HU-96</span><span class="tag" style="background:var(--green);color:#fff">CONSTRUIDA</span><span class="title">Ver perfil público de un dueño</span></div>
+    <p class="us">Como <span class="r">visitante</span>, quiero ver el perfil público de un dueño con sus terrenos publicados, para evaluar su reputación antes de alquilar.</p>
+    <ul class="ac">
+      <li><code>GET /users/:userId/public</code> devuelve datos públicos del dueño y sus publicaciones activas.</li>
+      <li>Un usuario inexistente devuelve <code>404</code>.</li>
+    </ul>
+  </div>
+
+  <h3>Historias nuevas por desarrollar</h3>
+
+  <div class="story"><div class="h"><span class="num">HU-97</span><span class="tag" style="background:var(--amber);color:#fff">NUEVA</span><span class="title">Reseñas y calificaciones</span><span class="tag" style="background:var(--muted);color:#fff">#323</span></div>
+    <p class="us">Como <span class="r">parte de un contrato completado</span>, quiero calificar y comentar a la otra parte, para construir reputación y confianza en la plataforma.</p>
+    <ul class="ac">
+      <li>Solo se puede reseñar si existe un contrato en estado <code>completed</code> entre ambas partes.</li>
+      <li>Cada parte puede dejar una sola reseña por contrato: 1–5 estrellas + comentario opcional.</li>
+      <li>El promedio de calificación se muestra en el perfil público del dueño (HU-96) y en la ficha del terreno.</li>
+    </ul>
+  </div>
+
+  <div class="story"><div class="h"><span class="num">HU-98</span><span class="tag" style="background:var(--amber);color:#fff">NUEVA</span><span class="title">Comparador de terrenos</span><span class="tag" style="background:var(--muted);color:#fff">#324</span></div>
+    <p class="us">Como <span class="r">visitante</span>, quiero seleccionar hasta 3 terrenos y compararlos lado a lado, para decidir mejor cuál me conviene.</p>
+    <ul class="ac">
+      <li>Se pueden añadir/quitar terrenos de una lista de comparación (máx. 3).</li>
+      <li>La vista muestra en columnas: precio, área, provincia/distrito, usos permitidos y disponibilidad.</li>
+      <li>La selección persiste en <code>localStorage</code> (no requiere login).</li>
+    </ul>
+  </div>
+
+  <div class="story"><div class="h"><span class="num">HU-99</span><span class="tag" style="background:var(--amber);color:#fff">NUEVA</span><span class="title">Búsquedas guardadas y alertas</span><span class="tag" style="background:var(--muted);color:#fff">#325</span></div>
+    <p class="us">Como <span class="r">usuario autenticado</span>, quiero guardar un conjunto de filtros y recibir un email cuando aparezca un terreno que los cumpla, para no revisar el catálogo manualmente.</p>
+    <ul class="ac">
+      <li><code>POST /users/me/saved-searches</code> guarda los filtros con un nombre.</li>
+      <li>Un proceso periódico compara terrenos nuevos <code>active</code> contra las búsquedas guardadas y notifica por email.</li>
+      <li><code>GET</code> / <code>DELETE /users/me/saved-searches</code> gestionan la lista.</li>
+    </ul>
+  </div>
+
+  <div class="story"><div class="h"><span class="num">HU-100</span><span class="tag" style="background:var(--amber);color:#fff">NUEVA</span><span class="title">Agendar visita a un terreno</span><span class="tag" style="background:var(--muted);color:#fff">#326</span></div>
+    <p class="us">Como <span class="r">arrendatario interesado</span>, quiero solicitar una cita para visitar un terreno, para conocerlo antes de reservar.</p>
+    <ul class="ac">
+      <li><code>POST /lands/:id/visits</code> crea una solicitud de visita con fecha/hora propuesta.</li>
+      <li>El dueño confirma, reprograma o rechaza (<code>PATCH /visits/:id</code>).</li>
+      <li>Ambas partes ven sus visitas agendadas; se genera una notificación.</li>
+    </ul>
+  </div>
+
+  <div class="story"><div class="h"><span class="num">HU-101</span><span class="tag" style="background:var(--amber);color:#fff">NUEVA</span><span class="title">Exportar contrato a PDF</span><span class="tag" style="background:var(--muted);color:#fff">#327</span></div>
+    <p class="us">Como <span class="r">parte de un contrato</span>, quiero descargar el contrato en PDF, para tener un respaldo formal del acuerdo.</p>
+    <ul class="ac">
+      <li><code>GET /contracts/:id/pdf</code> genera un PDF con términos, fechas, partes y estado de firma.</li>
+      <li>Solo las partes del contrato o un admin pueden descargarlo.</li>
+      <li>Si el contrato está <code>active</code>/<code>completed</code>, el PDF incluye la evidencia de firma (nombre, fecha).</li>
+    </ul>
+  </div>
+</section>
+
 <!-- ====================== ANEXO — TABLA MCP ====================== -->
 <section class="page">
   <h2 id="tabla">Anexo — Tabla resumen de herramientas (tools) MCP</h2>
@@ -1174,7 +1266,7 @@
 
   <footer>
     TerraShare · Grupo 1GS241 · Universidad Tecnológica de Panamá · Desarrollo de Software IX ·
-    22 de junio de 2026 · 92 historias de usuario (32 implementadas · 30 production-ready · 30 [MCP]).
+    22 de junio de 2026 · 101 historias de usuario (32 implementadas · 30 production-ready · 30 [MCP] · 9 nueva ronda funcional).
     <br>Documento HTML — para entregar como PDF: abrir en el navegador → Imprimir → «Guardar como PDF».
   </footer>
 </section>


### PR DESCRIPTION
## Qué hace

Documenta la **nueva ronda de funcionalidades funcionales** para completar los **30 RF** que exige el curso, más las especificaciones de requisitos y de seguridad del MCP.

## Cambios

- **`docs/historias-usuario/index.html`** — nueva **Sección 4 — Nueva ronda de funcionalidades** (HU 93–101): 4 features ya construidas (favoritos, reportes, moderación de reportes, perfil público de dueño) + 5 nuevas por desarrollar. Índice y conteos actualizados (92 → 101 historias).
- **`docs/REQUISITOS_FUNCIONALES_30.md`** — lista de los 30 RF (21 MVP + 4 construidos + 5 nuevos), excluyendo NFR y tools peligrosas del MCP.
- **`docs/MCP_SECURITY_RULES.md`** — capas de seguridad acordadas para las 7 tools sensibles del MCP (endurecer, no eliminar).

## Contexto / seguimiento

- Implementación de las 5 HU nuevas: issues #323–#327.
- Endurecimiento del MCP: issue #328.

## Pruebas

Cambio **solo de documentación** (no toca código de aplicación), por lo que no requiere pruebas unitarias. `typecheck`/`build` no se ven afectados.

Closes #329.
