### PR TITLE
feat(mcp): andamiaje de confirmacion para tools sensibles (Fase 0)

### DIFF
--- a/apps/mcp-server/src/tools/confirmation-store.test.ts
+++ b/apps/mcp-server/src/tools/confirmation-store.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import {
+  _clearConfirmations,
+  consumeToken,
+  hashArgs,
+  issueToken,
+} from "./confirmation-store";
+
+describe("confirmation-store (#328)", () => {
+  beforeEach(() => {
+    _clearConfirmations();
+  });
+
+  it("emite un token y lo consume una sola vez con los mismos args", () => {
+    const args = { landId: "land_a", confirm: true };
+    const { token, ttlSeconds } = issueToken("delete_land", args);
+    expect(token).toStartWith("cfm_");
+    expect(ttlSeconds).toBeGreaterThan(0);
+
+    const first = consumeToken(token, "delete_land", args);
+    expect(first.ok).toBe(true);
+
+    // Un solo uso: la segunda vez ya no es válido.
+    const second = consumeToken(token, "delete_land", args);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.message).toContain("inválido");
+  });
+
+  it("el hash es estable ante el orden de las claves", () => {
+    expect(hashArgs({ a: 1, b: 2 })).toBe(hashArgs({ b: 2, a: 1 }));
+    expect(hashArgs({ a: 1 })).not.toBe(hashArgs({ a: 2 }));
+  });
+
+  it("rechaza el token si cambian los argumentos", () => {
+    const { token } = issueToken("refund_payment", { paymentId: "p1", amount: 10 });
+    const res = consumeToken(token, "refund_payment", { paymentId: "p1", amount: 999 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.message).toContain("cambiaron");
+  });
+
+  it("rechaza el token si es de otra tool", () => {
+    const args = { id: "x" };
+    const { token } = issueToken("sign_contract", args);
+    const res = consumeToken(token, "delete_land", args);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.message).toContain("no corresponde");
+  });
+
+  it("rechaza un token inexistente", () => {
+    const res = consumeToken("cfm_inexistente", "delete_land", {});
+    expect(res.ok).toBe(false);
+  });
+});

--- a/apps/mcp-server/src/tools/confirmation-store.ts
+++ b/apps/mcp-server/src/tools/confirmation-store.ts
@@ -1,0 +1,100 @@
+/**
+ * Store de tokens de confirmación para el flujo de "vista previa en 2 pasos"
+ * (capa B) de las tools sensibles (#328).
+ *
+ * Una tool sensible con `preview` responde a la 1ª llamada con un resumen de la
+ * acción y un `confirmationToken`, SIN ejecutar. La acción solo procede en una 2ª
+ * llamada que presente ese token. Los tokens son:
+ *  - de un solo uso (se consumen al validarse),
+ *  - efímeros (caducan tras `TTL_MS`),
+ *  - atados a la tool y a los argumentos exactos de la vista previa (hash), para
+ *    que no se puedan reutilizar para otra acción o con argumentos alterados.
+ *
+ * El store vive en memoria del proceso del servidor MCP (long-lived). Es suficiente
+ * para el transporte stdio (un proceso por cliente). Para un transporte remoto
+ * multi-cliente se sustituiría por un store compartido, manteniendo esta interfaz.
+ */
+
+export const TTL_MS = 5 * 60 * 1000; // 5 minutos
+
+interface PendingConfirmation {
+  tool: string;
+  argsHash: string;
+  expiresAt: number;
+}
+
+const store = new Map<string, PendingConfirmation>();
+
+/** Serialización estable (claves ordenadas) para que el orden de los args no afecte al hash. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+export function hashArgs(args: Record<string, unknown>): string {
+  return stableStringify(args);
+}
+
+/** Elimina tokens caducados para acotar el uso de memoria. */
+function pruneExpired(now: number): void {
+  for (const [token, entry] of store) {
+    if (entry.expiresAt < now) store.delete(token);
+  }
+}
+
+export interface IssuedToken {
+  token: string;
+  ttlSeconds: number;
+  expiresAt: number;
+}
+
+/** Emite un token para una acción sensible pendiente de confirmar. */
+export function issueToken(tool: string, args: Record<string, unknown>): IssuedToken {
+  const now = Date.now();
+  pruneExpired(now);
+  const token = `cfm_${crypto.randomUUID()}`;
+  const expiresAt = now + TTL_MS;
+  store.set(token, { tool, argsHash: hashArgs(args), expiresAt });
+  return { token, ttlSeconds: TTL_MS / 1000, expiresAt };
+}
+
+export type ConsumeResult = { ok: true } | { ok: false; message: string };
+
+/**
+ * Valida y consume (un solo uso) un token contra la tool y los argumentos de la
+ * 2ª llamada. Devuelve un mensaje legible si falla.
+ */
+export function consumeToken(
+  token: string,
+  tool: string,
+  args: Record<string, unknown>,
+): ConsumeResult {
+  const entry = store.get(token);
+  if (!entry) {
+    return { ok: false, message: "Token de confirmación inválido o ya utilizado." };
+  }
+  // Un solo uso: se elimina siempre, válido o no.
+  store.delete(token);
+
+  if (entry.expiresAt < Date.now()) {
+    return { ok: false, message: "El token de confirmación expiró. Vuelve a solicitar la acción." };
+  }
+  if (entry.tool !== tool) {
+    return { ok: false, message: "El token de confirmación no corresponde a esta acción." };
+  }
+  if (entry.argsHash !== hashArgs(args)) {
+    return {
+      ok: false,
+      message: "Los argumentos cambiaron respecto a la vista previa. Vuelve a solicitar la acción.",
+    };
+  }
+  return { ok: true };
+}
+
+/** Solo para tests: vacía el store. */
+export function _clearConfirmations(): void {
+  store.clear();
+}

--- a/apps/mcp-server/src/tools/define-tool.test.ts
+++ b/apps/mcp-server/src/tools/define-tool.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, beforeEach } from "bun:test";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { z } from "zod";
 
 import type { ActingUser, ToolContext } from "../context";
-import { registerTool, ToolError, type ToolAccess } from "./define-tool";
+import { registerTool, ToolError, type ToolAccess, type SensitiveConfig } from "./define-tool";
+import { _clearConfirmations } from "./confirmation-store";
 
 function actingUser(overrides: Partial<ActingUser>): ActingUser {
   return {
@@ -84,5 +85,123 @@ describe("registerTool / defineTool (#234)", () => {
     const r = await call(await clientWithTool({ actingUser: null }, { requires: "public", throws: true }));
     expect(r.isError).toBe(true);
     expect(r.text).toContain("fallo de negocio");
+  });
+});
+
+/** Cliente con una tool sensible "danger"; `executed` cuenta las ejecuciones reales del handler. */
+async function sensitiveClient(
+  sensitive: SensitiveConfig,
+  executed: { count: number },
+): Promise<Client> {
+  const server = new McpServer({ name: "t", version: "1.0.0" });
+  registerTool(
+    server,
+    { actingUser: actingUser({}) },
+    {
+      name: "danger",
+      title: "Danger",
+      description: "acción sensible de prueba",
+      inputSchema: { landId: z.string() },
+      requires: "user",
+      sensitive,
+      handler: () => {
+        executed.count += 1;
+        return { done: true };
+      },
+    },
+  );
+  const client = new Client({ name: "c", version: "1.0.0" });
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(st), client.connect(ct)]);
+  return client;
+}
+
+async function callArgs(
+  client: Client,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean; text: string; data: Record<string, unknown> | null }> {
+  const res = await client.callTool({ name: "danger", arguments: args });
+  const content = res.content as { type: string; text: string }[];
+  const text = content[0]?.text ?? "";
+  let data: Record<string, unknown> | null = null;
+  try {
+    data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    /* no era JSON */
+  }
+  return { isError: res.isError === true, text, data };
+}
+
+describe("registerTool sensible (#328)", () => {
+  beforeEach(() => {
+    _clearConfirmations();
+  });
+
+  it("capa A (confirm): sin confirm no ejecuta y devuelve error", async () => {
+    const executed = { count: 0 };
+    const client = await sensitiveClient({ confirm: true }, executed);
+    const r = await callArgs(client, { landId: "land_a" });
+    expect(r.isError).toBe(true);
+    expect(r.text).toContain("confirm");
+    expect(executed.count).toBe(0);
+  });
+
+  it("capa A (confirm): con confirm:true ejecuta el handler", async () => {
+    const executed = { count: 0 };
+    const client = await sensitiveClient({ confirm: true }, executed);
+    const r = await callArgs(client, { landId: "land_a", confirm: true });
+    expect(r.isError).toBe(false);
+    expect(executed.count).toBe(1);
+  });
+
+  it("capa F (enabled): si está desactivada devuelve error y no ejecuta", async () => {
+    const executed = { count: 0 };
+    const client = await sensitiveClient({ confirm: true, enabled: () => false }, executed);
+    const r = await callArgs(client, { landId: "land_a", confirm: true });
+    expect(r.isError).toBe(true);
+    expect(r.text).toContain("desactivada");
+    expect(executed.count).toBe(0);
+  });
+
+  it("capa B (preview): 1ª llamada devuelve preview + token sin ejecutar", async () => {
+    const executed = { count: 0 };
+    const preview = { warning: "vas a borrar land_a" };
+    const client = await sensitiveClient({ preview: () => preview }, executed);
+    const r = await callArgs(client, { landId: "land_a" });
+    expect(r.isError).toBe(false);
+    expect(executed.count).toBe(0);
+    expect(r.data?.requiresConfirmation).toBe(true);
+    expect(typeof r.data?.confirmationToken).toBe("string");
+    expect((r.data?.preview as Record<string, unknown>)?.warning).toBe("vas a borrar land_a");
+  });
+
+  it("capa B (preview): 2ª llamada con token válido ejecuta", async () => {
+    const executed = { count: 0 };
+    const client = await sensitiveClient({ preview: () => ({ ok: true }) }, executed);
+    const step1 = await callArgs(client, { landId: "land_a" });
+    const token = step1.data?.confirmationToken as string;
+    const step2 = await callArgs(client, { landId: "land_a", confirmationToken: token });
+    expect(step2.isError).toBe(false);
+    expect(step2.data?.done).toBe(true);
+    expect(executed.count).toBe(1);
+  });
+
+  it("capa B (preview): token inválido no ejecuta", async () => {
+    const executed = { count: 0 };
+    const client = await sensitiveClient({ preview: () => ({ ok: true }) }, executed);
+    const r = await callArgs(client, { landId: "land_a", confirmationToken: "cfm_falso" });
+    expect(r.isError).toBe(true);
+    expect(executed.count).toBe(0);
+  });
+
+  it("capa B (preview): token válido pero args cambiados no ejecuta", async () => {
+    const executed = { count: 0 };
+    const client = await sensitiveClient({ preview: () => ({ ok: true }) }, executed);
+    const step1 = await callArgs(client, { landId: "land_a" });
+    const token = step1.data?.confirmationToken as string;
+    const step2 = await callArgs(client, { landId: "land_DISTINTO", confirmationToken: token });
+    expect(step2.isError).toBe(true);
+    expect(step2.text).toContain("cambiaron");
+    expect(executed.count).toBe(0);
   });
 });

--- a/apps/mcp-server/src/tools/define-tool.ts
+++ b/apps/mcp-server/src/tools/define-tool.ts
@@ -1,8 +1,9 @@
 import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { ZodRawShape } from "zod";
+import { z, type ZodRawShape } from "zod";
 
 import type { ToolContext } from "../context";
+import { consumeToken, issueToken } from "./confirmation-store";
 
 /**
  * Andamiaje común para definir tools MCP (#234).
@@ -23,6 +24,25 @@ export class ToolError extends Error {}
 
 export type ToolAccess = "public" | "user" | "admin";
 
+/**
+ * Configuración de seguridad de una tool sensible (#328). Se aplica en el
+ * andamiaje `registerTool`, de forma que las capas comunes no se reimplementan
+ * por tool:
+ *  - **A (confirm):** exige `confirm: true` en la llamada.
+ *  - **B (preview 2 pasos):** si se define `preview`, la 1ª llamada devuelve un
+ *    resumen + `confirmationToken` sin ejecutar; la acción solo procede en una 2ª
+ *    llamada con ese token. Cuando hay `preview`, `confirm` es redundante y se ignora.
+ *  - **F (interruptor):** si `enabled()` devuelve `false`, la tool queda desactivada.
+ */
+export interface SensitiveConfig {
+  /** Capa A: exige `confirm: true`. Ignorado si se define `preview`. */
+  confirm?: boolean;
+  /** Capa B: genera un resumen legible de la acción a confirmar. Activa el flujo de 2 pasos. */
+  preview?: (args: Record<string, unknown>, ctx: ToolContext) => Promise<unknown> | unknown;
+  /** Capa F: si devuelve `false`, la tool está desactivada por configuración. */
+  enabled?: () => boolean;
+}
+
 export interface ToolDefinition<Shape extends ZodRawShape> {
   name: string;
   title: string;
@@ -30,6 +50,8 @@ export interface ToolDefinition<Shape extends ZodRawShape> {
   inputSchema: Shape;
   /** Acceso requerido: `public` (por defecto), `user` (autenticado) o `admin`. */
   requires?: ToolAccess;
+  /** Configuración de seguridad para acciones sensibles (confirmación / preview / interruptor). */
+  sensitive?: SensitiveConfig;
   /** Lógica de la tool. Recibe los args validados y el contexto (usuario que actúa). */
   handler: (args: Record<string, unknown>, ctx: ToolContext) => Promise<unknown> | unknown;
 }
@@ -63,6 +85,68 @@ function checkAccess(requires: ToolAccess, ctx: ToolContext): string | null {
   return null;
 }
 
+/** Parámetros que el andamiaje añade al `inputSchema` de una tool sensible. */
+const SENSITIVE_FIELDS = {
+  confirm: z
+    .boolean()
+    .optional()
+    .describe("Confirmación explícita de la acción sensible (debe ser true)."),
+  confirmationToken: z
+    .string()
+    .optional()
+    .describe("Token devuelto por la vista previa; requerido para ejecutar la acción."),
+};
+
+/**
+ * Aplica las capas de seguridad declaradas en `def.sensitive` (#328) y, si todo
+ * pasa, ejecuta el handler. Devuelve un `ToolResult`: la vista previa (paso 1),
+ * un error legible, o el resultado del handler (paso 2 / acción confirmada).
+ */
+async function runSensitive<Shape extends ZodRawShape>(
+  def: ToolDefinition<Shape>,
+  s: SensitiveConfig,
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): Promise<ToolResult> {
+  if (s.enabled && !s.enabled()) {
+    return fail(`La tool '${def.name}' está desactivada por configuración.`);
+  }
+
+  // Separa los parámetros del andamiaje de los argumentos propios de la tool.
+  const { confirm, confirmationToken, ...toolArgs } = args as {
+    confirm?: unknown;
+    confirmationToken?: unknown;
+    [k: string]: unknown;
+  };
+
+  if (s.preview) {
+    const token = typeof confirmationToken === "string" ? confirmationToken.trim() : "";
+    if (!token) {
+      // Paso 1: devuelve la vista previa + token, SIN ejecutar la acción.
+      const preview = await s.preview(toolArgs, ctx);
+      const issued = issueToken(def.name, toolArgs);
+      return ok({
+        requiresConfirmation: true,
+        action: def.name,
+        preview,
+        confirmationToken: issued.token,
+        expiresInSeconds: issued.ttlSeconds,
+        hint: "Vuelve a llamar a esta tool con los mismos argumentos más 'confirmationToken' para ejecutar la acción.",
+      });
+    }
+    // Paso 2: valida el token (un solo uso, no expirado, mismos args) y ejecuta.
+    const check = consumeToken(token, def.name, toolArgs);
+    if (!check.ok) return fail(check.message);
+    return ok(await def.handler(toolArgs, ctx));
+  }
+
+  // Solo capa A (confirmación) sin vista previa.
+  if (s.confirm && confirm !== true) {
+    return fail("Esta acción sensible requiere confirmación explícita (confirm: true).");
+  }
+  return ok(await def.handler(toolArgs, ctx));
+}
+
 /** Registra una tool en el servidor MCP aplicando el andamiaje común. */
 export function registerTool<Shape extends ZodRawShape>(
   server: McpServer,
@@ -71,6 +155,12 @@ export function registerTool<Shape extends ZodRawShape>(
 ): void {
   const requires = def.requires ?? "public";
 
+  // Las tools sensibles anuncian además `confirm` y `confirmationToken`. El cast
+  // acompaña al del callback: el SDK valida los args contra este shape en runtime.
+  const inputSchema = (
+    def.sensitive ? { ...def.inputSchema, ...SENSITIVE_FIELDS } : def.inputSchema
+  ) as unknown as Shape;
+
   // El SDK ya valida los args contra `inputSchema` antes de llamar al callback;
   // aquí los tratamos como `Record<string, unknown>` (las tools los consumen con
   // su propio tipado). El cast salva la varianza del genérico del SDK.
@@ -78,6 +168,10 @@ export function registerTool<Shape extends ZodRawShape>(
     try {
       const denied = checkAccess(requires, ctx);
       if (denied) return fail(denied);
+
+      if (def.sensitive) {
+        return await runSensitive(def, def.sensitive, args ?? {}, ctx);
+      }
 
       const data = await def.handler(args, ctx);
       return ok(data);
@@ -95,7 +189,7 @@ export function registerTool<Shape extends ZodRawShape>(
 
   server.registerTool(
     def.name,
-    { title: def.title, description: def.description, inputSchema: def.inputSchema },
+    { title: def.title, description: def.description, inputSchema },
     callback,
   );
 }


### PR DESCRIPTION
## Qué hace

Fase 0 del endurecimiento del MCP (#328): añade la **infraestructura transversal** de seguridad para tools sensibles, de forma **declarativa** en el andamiaje `registerTool`, para que las fases 1–4 la reutilicen sin duplicar lógica.

## Cambios

- **`confirmation-store.ts`** — store en memoria de tokens de confirmación: emisión, TTL (5 min), un solo uso, y validación atada a la tool + hash estable de los argumentos.
- **`define-tool.ts`** — `ToolDefinition.sensitive`:
  - **A** `confirm` → exige `confirm: true`.
  - **B** `preview` → 1ª llamada devuelve `{ requiresConfirmation, preview, confirmationToken }` **sin ejecutar**; la acción solo procede en la 2ª llamada con el token.
  - **F** `enabled()` → interruptor para desactivar la tool.
  - `registerTool` inyecta `confirm`/`confirmationToken` en el `inputSchema` anunciado y orquesta el flujo.

## No incluye

Cambios en las tools existentes: son **aditivos** y se migran en las fases 1–4. Comportamiento actual intacto.

## Pruebas

- `confirmation-store.test.ts` — emisión/consumo único, hash estable, rechazo por args cambiados / otra tool / token inexistente.
- `define-tool.test.ts` — capa A (con/sin confirm), capa F (enabled=false), capa B (preview sin ejecutar, 2º paso con token válido, token inválido, args cambiados).
- Suite MCP completa: **287 pass / 0 fail**. Typecheck limpio.

Refs #328. Closes #331.
