### PR TITLE
feat(mcp): endurecer tools financieras del MCP (Fase 1)

### DIFF
--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -16,6 +16,23 @@ export const config = {
   get authRequired(): boolean {
     return !!config.apiKey;
   },
+  /**
+   * Interruptor (capa F, #328): permite reembolsar vía MCP. Por defecto activado;
+   * `MCP_ALLOW_REFUND=false` lo desactiva en despliegues sensibles.
+   */
+  get allowRefund(): boolean {
+    return process.env.MCP_ALLOW_REFUND !== "false";
+  },
+  /**
+   * Límite (capa D, #328): importe máximo de reembolso permitido vía MCP.
+   * `MCP_REFUND_MAX` sin definir → sin límite. Por encima, la tool remite al panel.
+   */
+  get refundMaxAmount(): number | undefined {
+    const raw = process.env.MCP_REFUND_MAX;
+    if (!raw) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  },
   serverName: "terrashare-mcp",
   serverVersion: "0.1.0",
 };

--- a/apps/mcp-server/src/lib/notify.ts
+++ b/apps/mcp-server/src/lib/notify.ts
@@ -1,0 +1,27 @@
+import { Notification } from "@backend/db/schemas";
+
+/**
+ * Notificación a un usuario tras una acción sensible ejecutada vía MCP (capa E, #328).
+ *
+ * Escribe en el centro de notificaciones existente (modelo `Notification`), que el
+ * usuario ya consulta desde la app. Es defensa en profundidad + trazabilidad: si un
+ * agente ejecuta una acción en nombre del usuario, este se entera y puede reaccionar.
+ *
+ * Es un efecto secundario **no crítico**: quien la invoca debe envolver la llamada
+ * en try/catch para que un fallo de notificación no revierta la acción principal.
+ */
+export async function notifyUser(input: {
+  userId: string;
+  type: string;
+  title: string;
+  body?: string;
+}): Promise<void> {
+  await Notification.create({
+    id: `ntf_${crypto.randomUUID()}`,
+    userId: input.userId,
+    type: input.type,
+    title: input.title,
+    body: input.body,
+    read: false,
+  });
+}

--- a/apps/mcp-server/src/tools/create-payment-session.ts
+++ b/apps/mcp-server/src/tools/create-payment-session.ts
@@ -173,9 +173,12 @@ export const createPaymentSessionTool: ToolDefinition<typeof createPaymentSessio
   name: "create_payment_session",
   title: "Crear sesión de pago",
   description:
-    "Genera un enlace de pago (checkoutUrl) para una solicitud pagable, a nombre del arrendatario autenticado. No expone secretos de Stripe. Devuelve el checkoutUrl y el estado del pago.",
+    "Genera un enlace de pago (checkoutUrl) para una solicitud pagable, a nombre del arrendatario autenticado. No expone secretos de Stripe. Acción sensible: requiere confirm: true. Devuelve el checkoutUrl y el estado del pago.",
   inputSchema: createPaymentSessionInput,
   requires: "user",
+  // Capa A (#328): confirmación explícita. La propiedad (C) ya la aplica
+  // `canInitiatePayment`; el resultado nunca incluye secretos de Stripe (G).
+  sensitive: { confirm: true },
   handler: (args, ctx) => {
     const actingUser = ctx.actingUser as ActingUser;
     return createPaymentSession(args, { id: actingUser.id, role: actingUser.role });

--- a/apps/mcp-server/src/tools/refund-payment.test.ts
+++ b/apps/mcp-server/src/tools/refund-payment.test.ts
@@ -1,19 +1,25 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 
 import mongoose from "@backend/db/mongoose";
-import { AuditEvent, Payment } from "@backend/db/schemas";
-import { refundPayment } from "./refund-payment";
+import { AuditEvent, Notification, Payment, RentalRequest } from "@backend/db/schemas";
+import { refundPayment, refundPreview } from "./refund-payment";
 
 const ADMIN = { id: "user_admin", role: "admin" as const };
 
 function refundInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return { paymentId: "pay_paid", confirm: true, ...overrides };
+  return { paymentId: "pay_paid", ...overrides };
 }
 
 // Pagos sembrados con el driver nativo en beforeEach (no en el cuerpo del test).
 beforeEach(async () => {
   await Payment.deleteMany({});
   await AuditEvent.deleteMany({});
+  await Notification.deleteMany({});
+  await RentalRequest.deleteMany({});
+  // Solicitud del pago pay_paid (rr_1): arrendatario user_tenant → destinatario de la notificación (E).
+  await mongoose.connection.db!.collection("rentalrequests").insertMany([
+    { id: "rr_1", landId: "land_a", tenantId: "user_tenant", operation: "alquiler", status: "paid" },
+  ]);
   await mongoose.connection.db!.collection("payments").insertMany([
     // Pagado, sin reembolsos (reembolsable 300).
     { id: "pay_paid", rentalRequestId: "rr_1", amount: 300, currency: "USD", status: "paid", refundedAmount: 0, refunds: [] },
@@ -62,9 +68,34 @@ describe("refund_payment tool (HU-80 #197)", () => {
     expect(refunds[0].amount).toBe(120);
   });
 
-  it("exige confirmación explícita (confirm: true)", async () => {
-    await expect(refundPayment({ paymentId: "pay_paid", confirm: false }, ADMIN)).rejects.toThrow(/confirm/i);
-    await expect(refundPayment({ paymentId: "pay_paid" }, ADMIN)).rejects.toThrow(/confirm/i);
+  it("capa D: bloquea reembolsos por encima del límite configurado (MCP_REFUND_MAX)", async () => {
+    process.env.MCP_REFUND_MAX = "100";
+    try {
+      await expect(refundPayment(refundInput({ amount: 300 }), ADMIN)).rejects.toThrow(/límite/i);
+      // Por debajo del límite sí procede.
+      const res = await refundPayment(refundInput({ amount: 50 }), ADMIN);
+      expect(res.refund.amount).toBe(50);
+    } finally {
+      delete process.env.MCP_REFUND_MAX;
+    }
+  });
+
+  it("capa E: notifica al arrendatario tras el reembolso", async () => {
+    await refundPayment(refundInput({ amount: 120 }), ADMIN);
+    const notif = await Notification.findOne({ userId: "user_tenant", type: "payment_refunded" }).lean();
+    expect(notif).not.toBeNull();
+    expect((notif as { title: string }).title).toContain("Reembolso");
+  });
+
+  it("capa B: refundPreview resume el reembolso sin ejecutarlo", async () => {
+    const preview = await refundPreview({ paymentId: "pay_paid", amount: 120 });
+    expect(preview.paymentId).toBe("pay_paid");
+    expect(preview.refundable).toBe(300);
+    expect(preview.requested).toBe(120);
+    // No debe haber tocado el pago.
+    const payment = await Payment.findOne({ id: "pay_paid" }).lean();
+    expect((payment as { refundedAmount: number }).refundedAmount).toBe(0);
+    expect((payment as { status: string }).status).toBe("paid");
   });
 
   it("falla si el pago no existe", async () => {

--- a/apps/mcp-server/src/tools/refund-payment.ts
+++ b/apps/mcp-server/src/tools/refund-payment.ts
@@ -1,10 +1,12 @@
 import { z, type ZodRawShape } from "zod";
 import { CreateRefundSchema } from "@terrashare/shared";
 
-import { Payment } from "@backend/db/schemas";
+import { Payment, RentalRequest } from "@backend/db/schemas";
 import { createAuditEvent } from "@backend/store/audit";
+import { config } from "../config";
 import type { ActingUser } from "../context";
 import { getStripeClient } from "../lib/stripe";
+import { notifyUser } from "../lib/notify";
 import { ToolError, type ToolDefinition } from "./define-tool";
 
 /**
@@ -17,6 +19,8 @@ import { ToolError, type ToolDefinition } from "./define-tool";
 // El `inputSchema` que anuncia el SDK se declara con el Zod local (con
 // `.describe()`); el importe/razón se validan con `CreateRefundSchema.parse`.
 // Tipado como `ZodRawShape` para que `TOOLS` unifique en server.ts.
+// La confirmación (capa A/B) la gestiona el andamiaje `registerTool` vía
+// `sensitive`, que inyecta `confirm`/`confirmationToken` — no se declara aquí.
 export const refundPaymentInput: ZodRawShape = {
   paymentId: z.string().min(1).describe("ID del pago a reembolsar"),
   amount: z
@@ -25,9 +29,6 @@ export const refundPaymentInput: ZodRawShape = {
     .optional()
     .describe("Importe a reembolsar; si se omite, reembolsa el saldo pendiente (total)"),
   reason: z.string().max(500).optional().describe("Motivo del reembolso (auditoría)"),
-  confirm: z
-    .boolean()
-    .describe("Confirmación explícita obligatoria de esta acción sensible (debe ser true)"),
 };
 
 function round2(n: number): number {
@@ -54,11 +55,6 @@ export async function refundPayment(
 ): Promise<RefundResult> {
   const input = (rawInput ?? {}) as Record<string, unknown>;
 
-  // Acción sensible: exige confirmación explícita.
-  if (input.confirm !== true) {
-    throw new ToolError("Esta acción sensible requiere confirmación explícita (confirm: true)");
-  }
-
   const paymentId = typeof input.paymentId === "string" ? input.paymentId : "";
   if (!paymentId) throw new ToolError("paymentId es requerido");
 
@@ -81,6 +77,14 @@ export async function refundPayment(
   const requested = body.amount != null ? round2(body.amount) : refundable;
   if (requested <= 0) throw new ToolError("El importe del reembolso debe ser positivo");
   if (requested > refundable) throw new ToolError("El importe excede el saldo reembolsable");
+
+  // Capa D (#328): límite configurable de reembolso vía MCP.
+  const maxAmount = config.refundMaxAmount;
+  if (maxAmount != null && requested > maxAmount) {
+    throw new ToolError(
+      `El reembolso (${requested}) supera el límite permitido vía MCP (${maxAmount}). Procésalo desde el panel de administración.`,
+    );
+  }
 
   const refundId = `rf_${crypto.randomUUID()}`;
   let stripeRefundId: string | undefined;
@@ -140,6 +144,22 @@ export async function refundPayment(
     },
   });
 
+  // Capa E (#328): notifica al arrendatario (pagador) que su pago fue reembolsado.
+  // Efecto secundario no crítico: un fallo aquí no revierte el reembolso ya aplicado.
+  try {
+    const request = await RentalRequest.findOne({ id: payment.rentalRequestId }).lean();
+    if (request?.tenantId) {
+      await notifyUser({
+        userId: request.tenantId,
+        type: "payment_refunded",
+        title: "Reembolso procesado",
+        body: `Se reembolsaron ${requested} ${payment.currency} de tu pago ${payment.id}.`,
+      });
+    }
+  } catch (err) {
+    console.error("[mcp-server] refund_payment: fallo al notificar al arrendatario", err);
+  }
+
   return {
     paymentId: payment.id,
     status: newStatus,
@@ -151,16 +171,50 @@ export async function refundPayment(
 }
 
 /**
- * Definición de la tool. `requires: "admin"` → solo administradores; el
- * andamiaje aplica la puerta. Acción sensible: exige `confirm: true`.
+ * Vista previa (capa B, #328): resume el reembolso a confirmar SIN ejecutarlo.
+ * Se muestra al agente en el 1er paso para que el humano vea monto y saldo.
+ */
+export async function refundPreview(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const paymentId = typeof args.paymentId === "string" ? args.paymentId : "";
+  if (!paymentId) throw new ToolError("paymentId es requerido");
+
+  const payment = await Payment.findOne({ id: paymentId }).lean();
+  if (!payment) throw new ToolError("Pago no encontrado");
+
+  const alreadyRefunded = payment.refundedAmount ?? 0;
+  const refundable = round2(payment.amount - alreadyRefunded);
+  const requested = typeof args.amount === "number" ? round2(args.amount) : refundable;
+  const maxAmount = config.refundMaxAmount;
+
+  return {
+    paymentId: payment.id,
+    currency: payment.currency,
+    amount: payment.amount,
+    alreadyRefunded,
+    refundable,
+    requested,
+    reason: typeof args.reason === "string" ? args.reason : undefined,
+    exceedsLimit: maxAmount != null && requested > maxAmount,
+    limit: maxAmount ?? null,
+  };
+}
+
+/**
+ * Definición de la tool. `requires: "admin"` → solo administradores; el andamiaje
+ * aplica la puerta. Acción sensible (#328): flujo de vista previa en 2 pasos (B),
+ * con interruptor de configuración (F) y límite de importe (D, en la lógica).
  */
 export const refundPaymentTool: ToolDefinition<typeof refundPaymentInput> = {
   name: "refund_payment",
   title: "Reembolsar pago (admin)",
   description:
-    "Emite un reembolso total o parcial de un pago pagado (solo admin). Acción sensible: requiere confirm: true. Devuelve el estado del pago y el reembolso aplicado.",
+    "Emite un reembolso total o parcial de un pago pagado (solo admin). Acción sensible: la 1ª llamada devuelve una vista previa y un confirmationToken; el reembolso se aplica al repetir la llamada con ese token. Devuelve el estado del pago y el reembolso aplicado.",
   inputSchema: refundPaymentInput,
   requires: "admin",
+  sensitive: {
+    preview: (args) => refundPreview(args),
+    enabled: () => config.allowRefund,
+  },
   handler: (args, ctx) => {
     const actingUser = ctx.actingUser as ActingUser;
     return refundPayment(args, { id: actingUser.id, role: actingUser.role });


### PR DESCRIPTION
## Qué hace

Fase 1 del endurecimiento del MCP (#328): aplica capas de seguridad a las dos tools **financieras**, apoyándose en el andamiaje `sensitive` de la Fase 0 (#331).

## `refund_payment` (HU-80) → A + B + D + E + F

- **B (preview 2 pasos):** la 1ª llamada devuelve un resumen (monto, saldo reembolsable, importe solicitado) + `confirmationToken`; el reembolso solo se aplica al repetir con el token. Reemplaza al antiguo `confirm: true` inline.
- **D (límite):** `MCP_REFUND_MAX` — reembolsos por encima se bloquean y remiten al panel.
- **E (notificación):** avisa al arrendatario (pagador) tras el reembolso, vía el modelo `Notification`.
- **F (interruptor):** `MCP_ALLOW_REFUND=false` desactiva la tool.

## `create_payment_session` (HU-77) → A + C + G

- **A:** `sensitive.confirm` (confirmación explícita).
- **C:** propiedad ya aplicada por `canInitiatePayment` (arrendatario o admin).
- **G:** el resultado nunca incluye secretos de Stripe (solo `checkoutUrl`) — ya cubierto por test.

## Infra añadida

- `config.allowRefund` / `config.refundMaxAmount`.
- `lib/notify.ts` — helper de notificación (capa E), efecto secundario no crítico.

## Pruebas

Casos nuevos por capa: preview sin ejecutar, límite `MCP_REFUND_MAX`, notificación al arrendatario. Suite MCP completa: **289 pass / 0 fail**. Typecheck limpio.

Refs #328. Closes #333.
