### PR TITLE
feat(mcp): endurecer tools de moderación admin (Fase 2)

### DIFF
--- a/apps/mcp-server/src/tools/manage-user-status.test.ts
+++ b/apps/mcp-server/src/tools/manage-user-status.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 
-import { AuditEvent, User } from "@backend/db/schemas";
-import { manageUserStatus } from "./manage-user-status";
+import { AuditEvent, Notification, User } from "@backend/db/schemas";
+import { manageUserStatus, manageUserStatusPreview } from "./manage-user-status";
 
 const ADMIN = { id: "user_admin", role: "admin" as const };
 
@@ -43,13 +43,24 @@ describe("manage_user_status tool (HU-91 #208)", () => {
     ).rejects.toThrow(/propia cuenta/i);
   });
 
-  it("exige confirmación explícita (confirm: true)", async () => {
-    await expect(
-      manageUserStatus({ userId: "user_regular", status: "blocked", confirm: false }, ADMIN),
-    ).rejects.toThrow(/confirm/i);
-    await expect(
-      manageUserStatus({ userId: "user_regular", status: "blocked" }, ADMIN),
-    ).rejects.toThrow(/confirm/i);
+  it("capa B: manageUserStatusPreview resume el cambio sin ejecutarlo", async () => {
+    const preview = await manageUserStatusPreview({ userId: "user_regular", status: "blocked" });
+    expect(preview.userId).toBe("user_regular");
+    expect(preview.currentStatus).toBe("active");
+    expect(preview.newStatus).toBe("blocked");
+    // No debe haber tocado al usuario.
+    const user = await User.findOne({ clerkUserId: "user_regular" }).lean();
+    expect((user as { status: string }).status).toBe("active");
+  });
+
+  it("capa E: notifica al usuario afectado el cambio de estado", async () => {
+    await manageUserStatus({ userId: "user_regular", status: "blocked", reason: "abuso" }, ADMIN);
+    const notif = await Notification.findOne({
+      userId: "user_regular",
+      type: "account_status_changed",
+    }).lean();
+    expect(notif).not.toBeNull();
+    expect((notif as { title: string }).title).toContain("bloqueada");
   });
 
   it("falla si el usuario no existe", async () => {
@@ -77,14 +88,6 @@ describe("manage_user_status tool (HU-91 #208)", () => {
   });
 
   it("rechaza cuando falta userId", async () => {
-    await expect(manageUserStatus({ status: "blocked", confirm: true }, ADMIN)).rejects.toThrow();
-  });
-
-  it("no modifica el usuario si la confirmación falta", async () => {
-    await expect(
-      manageUserStatus({ userId: "user_regular", status: "blocked" }, ADMIN),
-    ).rejects.toThrow();
-    const user = await User.findOne({ clerkUserId: "user_regular" }).lean();
-    expect((user as { status: string }).status).toBe("active");
+    await expect(manageUserStatus({ status: "blocked" }, ADMIN)).rejects.toThrow();
   });
 });

--- a/apps/mcp-server/src/tools/manage-user-status.ts
+++ b/apps/mcp-server/src/tools/manage-user-status.ts
@@ -3,6 +3,7 @@ import { z, type ZodRawShape } from "zod";
 import { User } from "@backend/db/schemas";
 import { createAuditEvent } from "@backend/store/audit";
 import type { ActingUser } from "../context";
+import { notifyUser } from "../lib/notify";
 import { ToolError, type ToolDefinition } from "./define-tool";
 
 /**
@@ -12,13 +13,12 @@ import { ToolError, type ToolDefinition } from "./define-tool";
  * una acción sensible exige **confirmación explícita** (`confirm: true`).
  */
 
+// La confirmación (capa B, vista previa) la gestiona el andamiaje `registerTool`
+// vía `sensitive` — no se declara `confirm` aquí.
 const manageUserStatusShape = {
   userId: z.string().min(1).describe("clerkUserId del usuario a activar/bloquear"),
   status: z.enum(["active", "blocked"]).describe("Nuevo estado de la cuenta"),
   reason: z.string().max(500).optional().describe("Motivo (auditoría)"),
-  confirm: z
-    .boolean()
-    .describe("Confirmación explícita obligatoria de esta acción sensible (debe ser true)"),
 };
 const ManageUserStatusSchema = z.object(manageUserStatusShape);
 
@@ -43,11 +43,6 @@ export async function manageUserStatus(
 ): Promise<ManageUserStatusResult> {
   const data = ManageUserStatusSchema.parse(rawInput ?? {});
 
-  // Acción sensible: exige confirmación explícita.
-  if (data.confirm !== true) {
-    throw new ToolError("Esta acción sensible requiere confirmación explícita (confirm: true)");
-  }
-
   // Regla del backend: un admin no puede modificar su propia cuenta.
   if (data.userId === actingUser.id) {
     throw new ToolError("No puedes modificar el estado de tu propia cuenta");
@@ -66,6 +61,18 @@ export async function manageUserStatus(
     metadata: { email: user.email, reason: data.reason, from: user.status, to: data.status },
   });
 
+  // Capa E (#328): notifica al usuario afectado el cambio de estado de su cuenta.
+  try {
+    await notifyUser({
+      userId: data.userId,
+      type: "account_status_changed",
+      title: data.status === "blocked" ? "Tu cuenta fue bloqueada" : "Tu cuenta fue reactivada",
+      body: data.reason ? `Motivo: ${data.reason}` : undefined,
+    });
+  } catch (err) {
+    console.error("[mcp-server] manage_user_status: fallo al notificar al usuario", err);
+  }
+
   return {
     userId: data.userId,
     status: data.status,
@@ -75,16 +82,38 @@ export async function manageUserStatus(
 }
 
 /**
- * Definición de la tool. `requires: "admin"` → solo administradores; el
- * andamiaje aplica la puerta. Acción sensible: exige `confirm: true`.
+ * Vista previa (capa B, #328): resume el cambio de estado SIN ejecutarlo.
+ */
+export async function manageUserStatusPreview(
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const data = ManageUserStatusSchema.parse(args ?? {});
+  const user = await User.findOne({ clerkUserId: data.userId }).lean();
+  if (!user) throw new ToolError("Usuario no encontrado");
+  return {
+    userId: data.userId,
+    email: user.email,
+    currentStatus: user.status,
+    newStatus: data.status,
+    reason: data.reason,
+  };
+}
+
+/**
+ * Definición de la tool. `requires: "admin"` → solo administradores; el andamiaje
+ * aplica la puerta. Acción sensible (#328): vista previa en 2 pasos (B) + notifica
+ * al usuario afectado (E).
  */
 export const manageUserStatusTool: ToolDefinition<typeof manageUserStatusInput> = {
   name: "manage_user_status",
   title: "Gestionar estado de usuario (admin)",
   description:
-    "Activa o bloquea una cuenta de usuario (solo admin). No permite modificar la propia cuenta. Acción sensible: requiere confirm: true. Registra auditoría y devuelve el estado anterior y el nuevo.",
+    "Activa o bloquea una cuenta de usuario (solo admin). No permite modificar la propia cuenta. Acción sensible: la 1ª llamada devuelve una vista previa y un confirmationToken; el cambio se aplica al repetir con ese token. Registra auditoría, notifica al usuario y devuelve el estado anterior y el nuevo.",
   inputSchema: manageUserStatusInput,
   requires: "admin",
+  sensitive: {
+    preview: (args) => manageUserStatusPreview(args),
+  },
   handler: (args, ctx) => {
     const actingUser = ctx.actingUser as ActingUser;
     return manageUserStatus(args, { id: actingUser.id, role: actingUser.role });

--- a/apps/mcp-server/src/tools/moderate-land.test.ts
+++ b/apps/mcp-server/src/tools/moderate-land.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 
-import { AuditEvent, Land } from "@backend/db/schemas";
+import { AuditEvent, Land, Notification } from "@backend/db/schemas";
 import { moderateLand } from "./moderate-land";
 
 const ADMIN = { id: "user_admin", role: "admin" as const };
@@ -45,6 +45,14 @@ describe("moderate_land tool (HU-90 #207)", () => {
     await moderateLand({ landId: "land_inactive", status: "active" }, ADMIN);
     const audit = await AuditEvent.findOne({ entityId: "land_inactive", action: "approved" }).lean();
     expect(audit).not.toBeNull();
+  });
+
+  it("capa E: notifica al dueño del terreno moderado", async () => {
+    // land_a lo posee user_seed (ver preload).
+    await moderateLand({ landId: "land_a", status: "inactive", reason: "Spam" }, ADMIN);
+    const notif = await Notification.findOne({ userId: "user_seed", type: "land_moderated" }).lean();
+    expect(notif).not.toBeNull();
+    expect((notif as { title: string }).title).toContain("despublicado");
   });
 
   it("falla si el terreno no existe", async () => {

--- a/apps/mcp-server/src/tools/moderate-land.ts
+++ b/apps/mcp-server/src/tools/moderate-land.ts
@@ -3,6 +3,7 @@ import { z, type ZodRawShape } from "zod";
 import { Land } from "@backend/db/schemas";
 import { createAuditEvent } from "@backend/store/audit";
 import type { ActingUser } from "../context";
+import { notifyUser } from "../lib/notify";
 import { ToolError, type ToolDefinition } from "./define-tool";
 
 /**
@@ -59,6 +60,20 @@ export async function moderateLand(
     metadata: { title: land.title, reason: data.reason, from: land.status, to: data.status },
   });
 
+  // Capa E (#328): notifica al dueño del terreno la acción de moderación.
+  try {
+    if (land.ownerId) {
+      await notifyUser({
+        userId: land.ownerId as string,
+        type: "land_moderated",
+        title: data.status === "inactive" ? "Tu terreno fue despublicado" : "Tu terreno fue reactivado",
+        body: data.reason ? `Motivo: ${data.reason}` : undefined,
+      });
+    }
+  } catch (err) {
+    console.error("[mcp-server] moderate_land: fallo al notificar al dueño", err);
+  }
+
   return {
     landId: data.landId,
     status: data.status,
@@ -68,16 +83,18 @@ export async function moderateLand(
 }
 
 /**
- * Definición de la tool. `requires: "admin"` → solo administradores; el
- * andamiaje aplica la puerta.
+ * Definición de la tool. `requires: "admin"` → solo administradores; el andamiaje
+ * aplica la puerta. Acción sensible (#328): confirmación explícita (A) + notifica
+ * al dueño del terreno (E).
  */
 export const moderateLandTool: ToolDefinition<typeof moderateLandInput> = {
   name: "moderate_land",
   title: "Moderar terreno (admin)",
   description:
-    "Cambia el estado de un terreno (solo admin): 'inactive' lo despublica, 'active' lo reactiva. Registra la acción en auditoría. Devuelve el estado anterior y el nuevo.",
+    "Cambia el estado de un terreno (solo admin): 'inactive' lo despublica, 'active' lo reactiva. Requiere confirm: true. Registra auditoría, notifica al dueño y devuelve el estado anterior y el nuevo.",
   inputSchema: moderateLandInput,
   requires: "admin",
+  sensitive: { confirm: true },
   handler: (args, ctx) => {
     const actingUser = ctx.actingUser as ActingUser;
     return moderateLand(args, { id: actingUser.id, role: actingUser.role });


### PR DESCRIPTION
## Qué hace

Fase 2 del endurecimiento del MCP (#328): capas de seguridad a las tools de **moderación admin**.

## `manage_user_status` (HU-91) → A + B + E
- **B:** vista previa en 2 pasos (`manageUserStatusPreview`); reemplaza al `confirm` inline.
- **E:** notifica al usuario afectado el cambio de estado (`Notification`).
- Se mantiene la regla de no modificar la propia cuenta.

## `moderate_land` (HU-90) → A + E
- **A:** `sensitive.confirm`.
- **E:** notifica al dueño del terreno despublicado/reactivado.

## Pruebas

Casos por capa: preview sin ejecutar, notificaciones. Suite MCP: **290 pass / 0 fail**. Typecheck limpio.

Refs #328. Closes #335.
