### PR TITLE
feat(mcp): endurecer sign_contract (Fase 3)

### DIFF
--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -24,6 +24,13 @@ export const config = {
     return process.env.MCP_ALLOW_REFUND !== "false";
   },
   /**
+   * Interruptor (capa F, #328): permite firmar contratos vía MCP. Por defecto
+   * activado; `MCP_ALLOW_SIGN=false` desactiva la firma por MCP.
+   */
+  get allowSign(): boolean {
+    return process.env.MCP_ALLOW_SIGN !== "false";
+  },
+  /**
    * Límite (capa D, #328): importe máximo de reembolso permitido vía MCP.
    * `MCP_REFUND_MAX` sin definir → sin límite. Por encima, la tool remite al panel.
    */

--- a/apps/mcp-server/src/tools/sign-contract.test.ts
+++ b/apps/mcp-server/src/tools/sign-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "bun:test";
 
-import { Contract, User } from "@backend/db/schemas";
-import { signContract } from "./sign-contract";
+import { Contract, Notification, User } from "@backend/db/schemas";
+import { signContract, signContractPreview } from "./sign-contract";
 
 const ownerUser = { id: "user_seed", role: "user" };
 const tenantUser = { id: "user_regular", role: "user" };
@@ -84,21 +84,27 @@ describe("sign_contract tool (HU-74 #191)", () => {
     expect((res as { status: string }).status).toBe("active");
   });
 
-  it("sin confirmacion lanza error", async () => {
-    try {
-      await signContract({ contractId: "contract_draft" } as never, ownerUser);
-      expect(true).toBe(false);
-    } catch (err) {
-      expect((err as Error).message).toContain("confirmar");
-    }
+  it("capa B: signContractPreview resume el contrato sin firmarlo", async () => {
+    const preview = await signContractPreview({ contractId: "contract_draft" }, ownerUser);
+    expect(preview.contractId).toBe("contract_draft");
+    expect(preview.status).toBe("draft");
+    expect(preview.willBecome).toBe("active");
+    // No debe haber firmado.
+    const contract = await Contract.findOne({ id: "contract_draft" }).lean();
+    expect((contract as { status: string }).status).toBe("draft");
   });
 
-  it("confirm=false lanza error", async () => {
-    try {
-      await signContract({ contractId: "contract_draft", confirm: false }, ownerUser);
-      expect(true).toBe(false);
-    } catch (err) {
-      expect((err as Error).message).toContain("confirmar");
-    }
+  it("capa C: la vista previa también bloquea a quien no es parte", async () => {
+    await expect(
+      signContractPreview({ contractId: "contract_draft" }, outsiderUser),
+    ).rejects.toThrow(/No autorizado/i);
+  });
+
+  it("capa E: notifica a ambas partes tras la firma", async () => {
+    await signContract({ contractId: "contract_draft" }, ownerUser);
+    const forOwner = await Notification.findOne({ userId: "user_seed", type: "contract_signed" }).lean();
+    const forTenant = await Notification.findOne({ userId: "user_regular", type: "contract_signed" }).lean();
+    expect(forOwner).not.toBeNull();
+    expect(forTenant).not.toBeNull();
   });
 });

--- a/apps/mcp-server/src/tools/sign-contract.ts
+++ b/apps/mcp-server/src/tools/sign-contract.ts
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
 import { Contract, AuditEvent } from "@backend/db/schemas";
+import { config } from "../config";
+import { notifyUser } from "../lib/notify";
+import type { ActingUser } from "../context";
 import { ToolError, type ToolDefinition } from "./define-tool";
 import { canReadContract } from "../permissions";
 
+// La confirmación (capa B, vista previa) la gestiona el andamiaje `registerTool`
+// vía `sensitive` — no se declara `confirm` aquí.
 const signContractInput = {
   contractId: z.string().min(1).describe("ID del contrato a firmar"),
-  confirm: z.boolean().optional().describe("Debe ser true para confirmar la firma"),
 };
 
 export type SignContractInput = z.infer<z.ZodObject<typeof signContractInput>>;
@@ -17,10 +21,6 @@ export async function signContract(
 ): Promise<Record<string, unknown>> {
   const schema = z.object(signContractInput);
   const input = schema.parse(rawInput ?? {});
-
-  if (input.confirm !== true) {
-    throw new ToolError("Debes confirmar la firma con confirm: true");
-  }
 
   const contract = await Contract.findOne({ id: input.contractId }).lean();
   if (!contract) throw new ToolError("Contrato no encontrado");
@@ -63,17 +63,66 @@ export async function signContract(
     metadata: { from: "draft", to: "active" },
   });
 
+  // Capa E (#328): notifica a ambas partes que el contrato quedó firmado/activo.
+  try {
+    for (const userId of [contract.ownerId, contract.tenantId]) {
+      if (userId) {
+        await notifyUser({
+          userId,
+          type: "contract_signed",
+          title: "Contrato firmado",
+          body: `El contrato ${input.contractId} fue firmado y está activo.`,
+        });
+      }
+    }
+  } catch (err) {
+    console.error("[mcp-server] sign_contract: fallo al notificar a las partes", err);
+  }
+
   const { _id, __v, ...rest } = updated.toObject();
   return rest;
+}
+
+/**
+ * Vista previa (capa B, #328): resume el contrato a firmar SIN firmarlo. Aplica
+ * la misma restricción de propiedad (C): solo una parte (owner/tenant) o admin.
+ */
+export async function signContractPreview(
+  args: Record<string, unknown>,
+  actingUser: Pick<ActingUser, "id" | "role">,
+): Promise<Record<string, unknown>> {
+  const { contractId } = z.object(signContractInput).parse(args ?? {});
+  const contract = await Contract.findOne({ id: contractId }).lean();
+  if (!contract) throw new ToolError("Contrato no encontrado");
+  if (
+    !canReadContract(
+      actingUser as never,
+      { ownerId: contract.ownerId, tenantId: contract.tenantId } as never,
+    )
+  ) {
+    throw new ToolError("No autorizado para firmar este contrato");
+  }
+  return {
+    contractId: contract.id,
+    status: contract.status,
+    ownerId: contract.ownerId,
+    tenantId: contract.tenantId,
+    terms: contract.terms,
+    willBecome: "active",
+  };
 }
 
 export const signContractTool: ToolDefinition<typeof signContractInput> = {
   name: "sign_contract",
   title: "Firmar contrato",
   description:
-    "Firma un contrato en borrador, pasándolo a estado activo. Cualquier parte del contrato (owner o tenant) puede firmarlo.",
+    "Firma un contrato en borrador, pasándolo a estado activo. Solo una parte del contrato (owner o tenant) o un admin puede firmarlo. Acción sensible: la 1ª llamada devuelve una vista previa de los términos y un confirmationToken; la firma se aplica al repetir con ese token. Notifica a ambas partes.",
   inputSchema: signContractInput,
   requires: "user",
+  sensitive: {
+    preview: (args, ctx) => signContractPreview(args, ctx.actingUser!),
+    enabled: () => config.allowSign,
+  },
   handler: async (args, ctx) => {
     const actingUser = ctx.actingUser!;
     return signContract(args, actingUser);


### PR DESCRIPTION
## Qué hace

Fase 3 del endurecimiento del MCP (#328): asegura `sign_contract` (HU-74), la tool más sensible (firma legal vinculante).

## Capas → B + C + E + F
- **B (preview):** la 1ª llamada devuelve los términos del contrato + `confirmationToken`; la firma solo procede al repetir con el token. Elimina el `confirm` inline.
- **C (ownership):** tanto la vista previa como la firma aplican `canReadContract` — solo una parte (owner/tenant) o admin.
- **E (notificación):** avisa a ambas partes que el contrato quedó firmado/activo.
- **F (interruptor):** `MCP_ALLOW_SIGN=false` desactiva la firma vía MCP.

## Pruebas

Casos por capa: preview sin firmar, preview bloquea a terceros (C), notificación a ambas partes. Suite MCP: **291 pass / 0 fail**. Typecheck limpio.

Refs #328. Closes #337.
