### PR TITLE
feat(mcp): delete_land soft-delete + send_message transparencia (Fase 4)

### DIFF
--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -67,6 +67,8 @@ export interface ILand extends Document {
   features?: string[];
   /** Terreno verificado por TerraShare (identidad y linderos) (#150). */
   verified?: boolean;
+  /** Borrado lógico (soft-delete): fecha de borrado, o null/ausente si activo (#328). */
+  deletedAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -143,6 +145,8 @@ export interface IChatMessage extends Document {
   chatId: string;
   senderId: string;
   text: string;
+  /** Marca de transparencia: el mensaje se envió mediante un asistente/agente (#328). */
+  viaAssistant?: boolean;
   createdAt: Date;
 }
 
@@ -279,6 +283,7 @@ const LandSchema = new Schema<ILand>({
   access: String,
   features: [String],
   verified: { type: Boolean, default: false },
+  deletedAt: { type: Date, default: null },
 }, { timestamps: true });
 
 LandSchema.index({ title: "text", description: "text" });
@@ -355,6 +360,7 @@ const ChatMessageSchema = new Schema<IChatMessage>({
   chatId: { type: String, required: true },
   senderId: { type: String, required: true },
   text: { type: String, required: true },
+  viaAssistant: { type: Boolean, default: false },
   createdAt: { type: Date, default: Date.now },
 });
 

--- a/apps/mcp-server/src/tools/delete-land.test.ts
+++ b/apps/mcp-server/src/tools/delete-land.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "bun:test";
 
-import { Land, User } from "@backend/db/schemas";
-import { deleteLand } from "./delete-land";
+import { Land, Notification, User } from "@backend/db/schemas";
+import { deleteLand, deleteLandPreview } from "./delete-land";
 
 const ownerUser = { id: "user_seed", role: "user" };
 const adminUser = { id: "user_admin", role: "admin" };
@@ -16,34 +16,34 @@ describe("delete_land tool (HU-69 #186)", () => {
     );
   });
 
-  it("elimina un terreno existente con confirmación", async () => {
-    const res = await deleteLand({ landId: "land_a", confirm: true }, ownerUser);
-    expect(res).toEqual({ deleted: true, landId: "land_a" });
-    const gone = await Land.findOne({ id: "land_a" }).lean();
-    expect(gone).toBeNull();
+  it("soft-delete: retira el terreno (inactive + deletedAt) sin borrarlo físicamente", async () => {
+    const res = await deleteLand({ landId: "land_a" }, ownerUser);
+    expect(res.deleted).toBe(true);
+    expect(res.recoverable).toBe(true);
+    // El documento sigue existiendo (recuperable), pero inactivo y marcado.
+    const land = await Land.findOne({ id: "land_a" }).lean();
+    expect(land).not.toBeNull();
+    expect((land as { status: string }).status).toBe("inactive");
+    expect((land as { deletedAt: Date | null }).deletedAt).not.toBeNull();
   });
 
   it("admin puede eliminar terrenos de otros", async () => {
-    const res = await deleteLand({ landId: "land_b", confirm: true }, adminUser);
-    expect(res).toEqual({ deleted: true, landId: "land_b" });
+    const res = await deleteLand({ landId: "land_b" }, adminUser);
+    expect(res.deleted).toBe(true);
   });
 
-  it("sin confirm lanza error", async () => {
-    try {
-      await deleteLand({ landId: "land_a" } as never, ownerUser);
-      expect(true).toBe(false);
-    } catch (err) {
-      expect((err as Error).message).toContain("confirmar");
-    }
+  it("capa B: deleteLandPreview resume el terreno sin borrarlo", async () => {
+    const preview = await deleteLandPreview({ landId: "land_a" });
+    expect(preview.landId).toBe("land_a");
+    expect(preview.status).toBe("active");
+    const land = await Land.findOne({ id: "land_a" }).lean();
+    expect((land as { status: string }).status).toBe("active");
   });
 
-  it("confirm=false lanza error", async () => {
-    try {
-      await deleteLand({ landId: "land_a", confirm: false }, ownerUser);
-      expect(true).toBe(false);
-    } catch (err) {
-      expect((err as Error).message).toContain("confirmar");
-    }
+  it("capa E: notifica al dueño tras el retiro", async () => {
+    await deleteLand({ landId: "land_a" }, ownerUser);
+    const notif = await Notification.findOne({ userId: "user_seed", type: "land_deleted" }).lean();
+    expect(notif).not.toBeNull();
   });
 
   it("usuario regular NO puede eliminar terreno de otro", async () => {

--- a/apps/mcp-server/src/tools/delete-land.ts
+++ b/apps/mcp-server/src/tools/delete-land.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
 import { Land, AuditEvent } from "@backend/db/schemas";
+import { notifyUser } from "../lib/notify";
 import { ToolError, type ToolDefinition } from "./define-tool";
 import { canMutateLand } from "../permissions";
 
+// La confirmación (capa B, vista previa) la gestiona el andamiaje `registerTool`
+// vía `sensitive` — no se declara `confirm` aquí.
 const deleteLandInput = {
   landId: z.string().min(1).describe("ID del terreno a eliminar"),
-  confirm: z.boolean().optional().describe("Debe ser true para confirmar la eliminación"),
 };
 
 export type DeleteLandInput = z.infer<z.ZodObject<typeof deleteLandInput>>;
@@ -18,10 +20,6 @@ export async function deleteLand(
   const schema = z.object(deleteLandInput);
   const input = schema.parse(rawInput ?? {});
 
-  if (input.confirm !== true) {
-    throw new ToolError("Debes confirmar la eliminación con confirm: true");
-  }
-
   const current = await Land.findOne({ id: input.landId }).lean();
   if (!current) throw new ToolError("Terreno no encontrado");
 
@@ -29,7 +27,13 @@ export async function deleteLand(
     throw new ToolError("No autorizado para eliminar este terreno");
   }
 
-  await Land.deleteOne({ id: input.landId });
+  // Soft-delete (#328): no se borra físicamente. Se marca con `deletedAt` y se
+  // pasa a `inactive` (sale del catálogo público), de modo que sea recuperable.
+  const now = new Date();
+  await Land.updateOne(
+    { id: input.landId },
+    { $set: { status: "inactive", deletedAt: now, updatedAt: now } },
+  );
 
   await AuditEvent.create({
     id: `audit_${crypto.randomUUID()}`,
@@ -40,16 +44,49 @@ export async function deleteLand(
     entityId: input.landId,
   });
 
-  return { deleted: true, landId: input.landId };
+  // Capa E (#328): notifica al dueño que su terreno fue retirado.
+  try {
+    if (current.ownerId) {
+      await notifyUser({
+        userId: current.ownerId,
+        type: "land_deleted",
+        title: "Tu terreno fue retirado",
+        body: `El terreno "${current.title}" se retiró del catálogo (recuperable).`,
+      });
+    }
+  } catch (err) {
+    console.error("[mcp-server] delete_land: fallo al notificar al dueño", err);
+  }
+
+  return { deleted: true, landId: input.landId, recoverable: true };
+}
+
+/**
+ * Vista previa (capa B, #328): resume el terreno a eliminar SIN borrarlo.
+ */
+export async function deleteLandPreview(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const { landId } = z.object(deleteLandInput).parse(args ?? {});
+  const land = await Land.findOne({ id: landId }).lean();
+  if (!land) throw new ToolError("Terreno no encontrado");
+  return {
+    landId: land.id,
+    title: land.title,
+    status: land.status,
+    ownerId: land.ownerId,
+    note: "El borrado es lógico (soft-delete): el terreno se retira del catálogo pero es recuperable.",
+  };
 }
 
 export const deleteLandTool: ToolDefinition<typeof deleteLandInput> = {
   name: "delete_land",
   title: "Eliminar terreno",
   description:
-    "Elimina un terreno existente de forma permanente. Requiere confirmación explícita. Solo el propietario o un administrador pueden eliminarlo.",
+    "Retira un terreno del catálogo (borrado lógico recuperable). Solo el propietario o un administrador. Acción sensible: la 1ª llamada devuelve una vista previa y un confirmationToken; el retiro se aplica al repetir con ese token. Notifica al dueño.",
   inputSchema: deleteLandInput,
   requires: "user",
+  sensitive: {
+    preview: (args) => deleteLandPreview(args),
+  },
   handler: async (args, ctx) => {
     const actingUser = ctx.actingUser!;
     return deleteLand(args, actingUser);

--- a/apps/mcp-server/src/tools/send-message.test.ts
+++ b/apps/mcp-server/src/tools/send-message.test.ts
@@ -42,6 +42,13 @@ describe("send_message tool (HU-83 #200)", () => {
     expect((res as { messageId: string }).messageId).toMatch(/^msg_/);
   });
 
+  it("marca de transparencia: el mensaje queda marcado como enviado vía asistente", async () => {
+    const res = await sendMessage({ chatId: "chat_1", text: "Hola vía agente" }, ownerUser);
+    expect((res as { viaAssistant: boolean }).viaAssistant).toBe(true);
+    const saved = await ChatMessage.findOne({ id: (res as { messageId: string }).messageId }).lean();
+    expect((saved as { viaAssistant: boolean }).viaAssistant).toBe(true);
+  });
+
   it("texto con espacios se trimea", async () => {
     const res = await sendMessage({ chatId: "chat_1", text: "  Mensaje con espacios  " }, ownerUser);
     expect((res as { text: string }).text).toBe("Mensaje con espacios");

--- a/apps/mcp-server/src/tools/send-message.ts
+++ b/apps/mcp-server/src/tools/send-message.ts
@@ -36,6 +36,8 @@ export async function sendMessage(
     chatId: input.chatId,
     senderId: actingUser.id,
     text: trimmedText,
+    // Marca de transparencia (#328): enviado a través del asistente/agente.
+    viaAssistant: true,
     createdAt: now,
   });
 
@@ -54,6 +56,7 @@ export async function sendMessage(
     chatId: input.chatId,
     senderId: actingUser.id,
     text: trimmedText,
+    viaAssistant: true,
     createdAt: now.toISOString(),
   };
 }
@@ -62,9 +65,11 @@ export const sendMessageTool: ToolDefinition<typeof sendMessageInput> = {
   name: "send_message",
   title: "Enviar mensaje",
   description:
-    "Envía un mensaje de texto en un chat existente. El usuario debe ser participante del chat.",
+    "Envía un mensaje de texto en un chat existente. El usuario debe ser participante del chat. Acción sensible: requiere confirm: true. El mensaje se marca como enviado vía asistente (transparencia).",
   inputSchema: sendMessageInput,
   requires: "user",
+  // Capa A (#328): confirmación explícita. El mensaje queda marcado `viaAssistant`.
+  sensitive: { confirm: true },
   handler: async (args, ctx) => {
     const actingUser = ctx.actingUser!;
     return sendMessage(args, actingUser);


### PR DESCRIPTION
## Qué hace

Fase 4 (final) del endurecimiento del MCP (#328): tool destructiva y mensajería.

## `delete_land` (HU-69) → A + B + E + soft-delete
- **soft-delete:** nuevo campo `Land.deletedAt`; el borrado pasa a `status: inactive` + `deletedAt` → sale del catálogo público pero es **recuperable** (no borrado físico).
- **B (preview):** la 1ª llamada resume el terreno + `confirmationToken`; el retiro se aplica al repetir con el token. Elimina el `confirm` inline.
- **E (notificación):** avisa al dueño del terreno retirado.

## `send_message` (HU-83) → A + transparencia
- **A:** `sensitive.confirm`.
- **Transparencia:** nuevo campo `ChatMessage.viaAssistant`; el mensaje enviado vía agente queda marcado para que el receptor lo sepa.

## Esquema

Campos aditivos con default seguro: `Land.deletedAt` (null), `ChatMessage.viaAssistant` (false). No requieren migración destructiva.

## Pruebas

Casos por capa: soft-delete (inactive + deletedAt, documento preservado), preview, notificación, marca de transparencia. Backend: **301 pass**. MCP: **292 pass**. Typecheck limpio en ambos.

Refs #328. Closes #339.
