### PR TITLE
fix(mcp): filtrar soft-delete (deletedAt) en vistas de dueño/admin y tools MCP

### DIFF
--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -128,7 +128,8 @@ adminRoutes.get("/admin/lands", requireAuth, requireAdmin, async (c) => {
   const status = c.req.query("status");
   const search = c.req.query("search")?.toLowerCase();
 
-  const query: Record<string, any> = {};
+  // Excluye terrenos con borrado lógico (soft-delete, #328).
+  const query: Record<string, any> = { deletedAt: null };
   if (status && ["draft", "active", "inactive"].includes(status)) {
     query.status = status;
   }

--- a/apps/backend-api/src/routes/lands-extra.test.ts
+++ b/apps/backend-api/src/routes/lands-extra.test.ts
@@ -1,7 +1,37 @@
 import { describe, expect, it } from "bun:test";
 import { requestJson } from "../lib/http-test-utils";
+import { Land } from "../db/schemas";
 
 describe("lands routes - extended coverage", () => {
+  it("excludes soft-deleted lands from /lands/me and /admin/lands (#328 follow-up)", async () => {
+    await Land.create({
+      id: "land_softdel_01",
+      ownerId: "user_owner_01",
+      title: "Terreno retirado",
+      area: 10,
+      allowedUses: ["agricultura"],
+      location: { province: "Panama", district: "Panama" },
+      priceRule: { currency: "USD", pricePerMonth: 100 },
+      status: "inactive",
+      operation: "alquiler",
+      deletedAt: new Date(),
+    });
+
+    const mine = await requestJson("/api/v1/lands/me", {
+      headers: { "x-dev-user-id": "user_owner_01" },
+    });
+    expect(mine.response.status).toBe(200);
+    const mineIds = (mine.payload.data as { id: string }[]).map((l) => l.id);
+    expect(mineIds).not.toContain("land_softdel_01");
+
+    const admin = await requestJson("/api/v1/admin/lands", {
+      headers: { "x-dev-user-id": "user_admin_01", "x-dev-role": "admin" },
+    });
+    expect(admin.response.status).toBe(200);
+    const adminIds = (admin.payload.data.items as { id: string }[]).map((l) => l.id);
+    expect(adminIds).not.toContain("land_softdel_01");
+  });
+
   it("rejects land creation without required fields", async () => {
     const { response, payload } = await requestJson("/api/v1/lands", {
       method: "POST",

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -170,7 +170,9 @@ landRoutes.get("/lands", async (c) => {
 // landId and this route becomes unreachable (404).
 landRoutes.get("/lands/me", requireAuth, rateLimitByUser(200), async (c) => {
   const authUser = c.get("authUser");
-  const docs = (await Land.find({ ownerId: authUser.id }).lean()) as unknown as Record<string, unknown>[];
+  // Excluye terrenos con borrado lógico (soft-delete, #328). `deletedAt: null`
+  // en MongoDB también coincide con documentos que no tienen el campo (antiguos).
+  const docs = (await Land.find({ ownerId: authUser.id, deletedAt: null }).lean()) as unknown as Record<string, unknown>[];
   const lands = docs.map((d) => clean<LandRecord>(d)!);
   return success(c, lands);
 });

--- a/apps/mcp-server/src/tools/get-land.test.ts
+++ b/apps/mcp-server/src/tools/get-land.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { Land } from "@backend/db/schemas";
 import { getLand } from "./get-land";
 
 describe("get_land tool (HU-64 #181)", () => {
@@ -34,5 +36,29 @@ describe("get_land tool (HU-64 #181)", () => {
     const land = result as Record<string, unknown>;
     expect(land).not.toHaveProperty("_id");
     expect(land).not.toHaveProperty("__v");
+  });
+});
+
+// Follow-up soft-delete (#328): un terreno con `deletedAt` no debe encontrarse.
+// El terreno se siembra en beforeEach (write) y el test solo lee, para evitar el
+// patrón write-then-read en el cuerpo (que cuelga con bun:test + memory-server).
+describe("get_land — filtro soft-delete (#328 follow-up)", () => {
+  beforeEach(async () => {
+    await Land.create({
+      id: "land_gone",
+      ownerId: "user_seed",
+      title: "Terreno retirado",
+      area: 5,
+      allowedUses: ["agricultura"],
+      location: { province: "Panama", district: "Panama" },
+      priceRule: { currency: "USD", pricePerMonth: 100 },
+      status: "inactive",
+      operation: "alquiler",
+      deletedAt: new Date(),
+    });
+  });
+
+  it("no encuentra un terreno con soft-delete", async () => {
+    await expect(getLand({ landId: "land_gone" })).rejects.toThrow(/no encontrado/i);
   });
 });

--- a/apps/mcp-server/src/tools/get-land.ts
+++ b/apps/mcp-server/src/tools/get-land.ts
@@ -22,7 +22,8 @@ export type GetLandInput = z.infer<z.ZodObject<typeof getLandInput>>;
 export async function getLand(rawInput: unknown): Promise<Record<string, unknown>> {
   const input = z.object(getLandInput).parse(rawInput);
 
-  const land = await Land.findOne({ id: input.landId }).lean();
+  // Excluye terrenos con borrado lógico (soft-delete, #328).
+  const land = await Land.findOne({ id: input.landId, deletedAt: null }).lean();
   if (!land) throw new ToolError("Terreno no encontrado");
 
   const { _id, __v, ...rest } = land as unknown as Record<string, unknown>;

--- a/apps/mcp-server/src/tools/list-my-lands.test.ts
+++ b/apps/mcp-server/src/tools/list-my-lands.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, beforeEach } from "bun:test";
 
+import { Land } from "@backend/db/schemas";
 import { listMyLands } from "./list-my-lands";
 
 describe("list_my_lands tool (HU-68 #185)", () => {
@@ -47,5 +48,31 @@ describe("list_my_lands tool (HU-68 #185)", () => {
 
   it("lanza error si no hay usuario autenticado", async () => {
     await expect(listMyLands({ actingUserId: null })).rejects.toThrow("Se requiere un usuario autenticado");
+  });
+});
+
+// Follow-up soft-delete (#328): los terrenos con `deletedAt` no aparecen en la
+// lista del dueño. Sembrado en beforeEach (write); el test solo lee.
+describe("list_my_lands — filtro soft-delete (#328 follow-up)", () => {
+  beforeEach(async () => {
+    await Land.create({
+      id: "land_gone",
+      ownerId: "user_gone",
+      title: "Terreno retirado",
+      area: 5,
+      allowedUses: ["agricultura"],
+      location: { province: "Panama", district: "Panama" },
+      priceRule: { currency: "USD", pricePerMonth: 100 },
+      status: "inactive",
+      operation: "alquiler",
+      deletedAt: new Date(),
+    });
+  });
+
+  it("excluye los terrenos con soft-delete del dueño", async () => {
+    const result = await listMyLands({ actingUserId: "user_gone" });
+    const lands = (result as { items: { id: string }[] }).items;
+    expect(lands.some((l) => l.id === "land_gone")).toBe(false);
+    expect(lands.length).toBe(0);
   });
 });

--- a/apps/mcp-server/src/tools/list-my-lands.ts
+++ b/apps/mcp-server/src/tools/list-my-lands.ts
@@ -26,7 +26,8 @@ export async function listMyLands(rawInput: { actingUserId: string | null }): Pr
     throw new ToolError("Se requiere un usuario autenticado");
   }
 
-  const query = { ownerId: rawInput.actingUserId };
+  // Excluye terrenos con borrado lógico (soft-delete, #328).
+  const query = { ownerId: rawInput.actingUserId, deletedAt: null };
   const docs = await Land.find(query).sort({ createdAt: -1 }).lean();
 
   const items = (docs as unknown as Record<string, unknown>[]).map((d) => {


### PR DESCRIPTION
## Qué hace

Follow-up del soft-delete (#328 / PR #340). El borrado lógico de `delete_land` marca `Land.deletedAt` + `status: inactive`, pero las vistas de **dueño/admin** y dos tools MCP no filtraban `deletedAt`, así que un terreno "borrado" seguía apareciendo ahí.

## Cambios (filtro `deletedAt: null`)
- Backend `GET /lands/me` — vista del dueño.
- Backend `GET /admin/lands` — lista de moderación admin.
- MCP `get_land` — devuelve "no encontrado" si está borrado.
- MCP `list_my_lands` — excluye borrados.

Ya excluían sin cambios: catálogo público (`status: active`), detalle público (404 si `inactive`), `search_lands` (`status: active`).

`{ deletedAt: null }` en MongoDB también coincide con documentos sin el campo (terrenos antiguos), así que no rompe datos existentes.

## Pruebas
- Backend: un terreno sembrado con `deletedAt` no aparece en `/lands/me` ni en `/admin/lands`.
- MCP: `get_land` lo reporta no encontrado; `list_my_lands` lo excluye. Sembradas en `beforeEach` y leídas en el cuerpo (evita el patrón write-then-read que cuelga con bun:test + memory-server).
- Backend **302 pass**, MCP **294 pass**, typecheck limpio en ambos.

Closes #341.
