### PR TITLE
feat(compare): HU-98 Comparador de terrenos (#324)

### DIFF
--- a/apps/web/src/hooks/useCompareLands.ts
+++ b/apps/web/src/hooks/useCompareLands.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from "react";
+
+/** Clave de localStorage para la lista de comparación (HU-98 / #324). */
+export const COMPARE_STORAGE_KEY = "terrashare-compare-ids";
+export const COMPARE_MAX = 3;
+
+/** Evento same-tab para sincronizar instancias del hook en la misma pestaña. */
+const COMPARE_CHANGE_EVENT = "terrashare-compare-change";
+
+function readIds(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(COMPARE_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string").slice(0, COMPARE_MAX);
+  } catch {
+    return [];
+  }
+}
+
+function writeIds(ids: string[]): void {
+  window.localStorage.setItem(COMPARE_STORAGE_KEY, JSON.stringify(ids));
+  window.dispatchEvent(new CustomEvent(COMPARE_CHANGE_EVENT));
+}
+
+export interface ToggleCompareResult {
+  ok: boolean;
+  /** true si no se pudo añadir porque ya hay 3. */
+  full?: boolean;
+  ids: string[];
+}
+
+export interface UseCompareLandsResult {
+  ids: string[];
+  count: number;
+  max: number;
+  isFull: boolean;
+  isCompared: (landId: string) => boolean;
+  /** Añade o quita. Si la lista está llena y el id no está, no añade. */
+  toggle: (landId: string) => ToggleCompareResult;
+  remove: (landId: string) => void;
+  clear: () => void;
+}
+
+/**
+ * Lista de comparación de terrenos (HU-98). Persiste en localStorage;
+ * no requiere login. Máximo 3 ids.
+ */
+export function useCompareLands(): UseCompareLandsResult {
+  const [ids, setIds] = useState<string[]>(() => readIds());
+
+  useEffect(() => {
+    const sync = () => setIds(readIds());
+    window.addEventListener("storage", sync);
+    window.addEventListener(COMPARE_CHANGE_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(COMPARE_CHANGE_EVENT, sync);
+    };
+  }, []);
+
+  const isCompared = useCallback((landId: string) => ids.includes(landId), [ids]);
+
+  const toggle = useCallback((landId: string): ToggleCompareResult => {
+    const current = readIds();
+    if (current.includes(landId)) {
+      const next = current.filter((id) => id !== landId);
+      writeIds(next);
+      setIds(next);
+      return { ok: true, ids: next };
+    }
+    if (current.length >= COMPARE_MAX) {
+      return { ok: false, full: true, ids: current };
+    }
+    const next = [...current, landId];
+    writeIds(next);
+    setIds(next);
+    return { ok: true, ids: next };
+  }, []);
+
+  const remove = useCallback((landId: string) => {
+    const next = readIds().filter((id) => id !== landId);
+    writeIds(next);
+    setIds(next);
+  }, []);
+
+  const clear = useCallback(() => {
+    writeIds([]);
+    setIds([]);
+  }, []);
+
+  return {
+    ids,
+    count: ids.length,
+    max: COMPARE_MAX,
+    isFull: ids.length >= COMPARE_MAX,
+    isCompared,
+    toggle,
+    remove,
+    clear,
+  };
+}

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -1,12 +1,26 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { LandDto } from "@terrashare/shared";
-import { Search, Sprout, MapPin, DollarSign, Tag, ChevronDown, ImageIcon, SearchX, Heart } from "lucide-react";
+import {
+  Search,
+  Sprout,
+  MapPin,
+  DollarSign,
+  Tag,
+  ChevronDown,
+  ImageIcon,
+  SearchX,
+  Heart,
+  Columns2,
+  ArrowRight,
+} from "lucide-react";
 import { listLands, photoSrc } from "../services/api";
 import PanamaMap from "../components/PanamaMap";
 import EmptyState from "../components/EmptyState";
 import { useFavorites } from "../hooks/useFavorites";
+import { useCompareLands } from "../hooks/useCompareLands";
 import "./catalog.css";
+import "./compare.css";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -40,12 +54,35 @@ export default function CatalogPage() {
 
   // Favoritos (#147): el catálogo vive tras login, así que siempre habilitado.
   const { isFavorite, toggle: toggleFavorite } = useFavorites();
+  // Comparador (HU-98 / #324): localStorage, máx. 3, sin backend.
+  const {
+    ids: compareIds,
+    count: compareCount,
+    max: compareMax,
+    isCompared,
+    toggle: toggleCompare,
+    clear: clearCompare,
+  } = useCompareLands();
+  const [compareToast, setCompareToast] = useState<string | null>(null);
 
   const [query, setQuery] = useState("");
   const [use, setUse] = useState("todos");
   const [province, setProvince] = useState("todas");
   const [maxPrice, setMaxPrice] = useState(1_000_000);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!compareToast) return;
+    const t = window.setTimeout(() => setCompareToast(null), 2400);
+    return () => window.clearTimeout(t);
+  }, [compareToast]);
+
+  const handleToggleCompare = (landId: string) => {
+    const result = toggleCompare(landId);
+    if (!result.ok && result.full) {
+      setCompareToast(`Solo puedes comparar hasta ${compareMax} terrenos`);
+    }
+  };
 
   useEffect(() => {
     let active = true;
@@ -237,6 +274,28 @@ export default function CatalogPage() {
                     <span
                       role="button"
                       tabIndex={0}
+                      className={`cat-card__cmp${isCompared(land.id) ? " is-active" : ""}`}
+                      aria-label={
+                        isCompared(land.id) ? "Quitar de comparación" : "Añadir a comparación"
+                      }
+                      aria-pressed={isCompared(land.id)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleToggleCompare(land.id);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleToggleCompare(land.id);
+                        }
+                      }}
+                    >
+                      <Columns2 size={15} />
+                    </span>
+                    <span
+                      role="button"
+                      tabIndex={0}
                       className={`cat-card__fav${isFavorite(land.id) ? " is-active" : ""}`}
                       aria-label={isFavorite(land.id) ? "Quitar de guardados" : "Guardar terreno"}
                       aria-pressed={isFavorite(land.id)}
@@ -301,13 +360,51 @@ export default function CatalogPage() {
                     : ""}
                 </div>
               </div>
-              <Link to="/lands/$id" params={{ id: selectedLand.id }} className="cat-mapcard__go">
-                Ver
-              </Link>
+              <div className="cat-mapcard__actions">
+                <button
+                  type="button"
+                  className={`cat-mapcard__cmp${isCompared(selectedLand.id) ? " is-active" : ""}`}
+                  onClick={() => handleToggleCompare(selectedLand.id)}
+                >
+                  <Columns2 size={15} />
+                  {isCompared(selectedLand.id) ? "En comparación" : "Comparar"}
+                </button>
+                <Link to="/lands/$id" params={{ id: selectedLand.id }} className="cat-mapcard__go">
+                  Ver
+                </Link>
+              </div>
             </div>
           )}
         </div>
       </div>
+
+      {compareCount > 0 && (
+        <div className="cmp-bar" role="status">
+          <div className="cmp-bar__text">
+            {compareCount} de {compareMax} en comparación{" "}
+            <span>
+              ·{" "}
+              {compareIds.length === 1
+                ? "añade otro para comparar"
+                : "listo para ver lado a lado"}
+            </span>
+          </div>
+          <div className="cmp-bar__actions">
+            <button type="button" className="cmp-bar__clear" onClick={clearCompare}>
+              Vaciar
+            </button>
+            <Link to="/compare" className="cmp-bar__go">
+              Comparar <ArrowRight size={15} />
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {compareToast && (
+        <div className="cmp-toast" role="status">
+          {compareToast}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/ComparePage.tsx
+++ b/apps/web/src/pages/ComparePage.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import type { LandDto } from "@terrashare/shared";
+import {
+  ArrowLeft,
+  Columns2,
+  ImageIcon,
+  MapPin,
+  Sprout,
+  X,
+} from "lucide-react";
+import { getLandById, photoSrc } from "../services/api";
+import { useCompareLands } from "../hooks/useCompareLands";
+import EmptyState from "../components/EmptyState";
+import "./compare.css";
+
+const USE_LABELS: Record<string, string> = {
+  agricultura: "Agricultura",
+  ganaderia: "Ganadería",
+  forestal: "Forestal",
+  acuicultura: "Acuicultura",
+  mixto: "Mixto",
+  otro: "Otro",
+};
+
+function formatUse(use?: string): string {
+  if (!use) return "—";
+  return USE_LABELS[use] ?? use;
+}
+
+function formatUses(uses?: string[]): string {
+  if (!uses?.length) return "—";
+  return uses.map((u) => formatUse(u)).join(", ");
+}
+
+function formatAvailable(iso?: string): string {
+  if (!iso) return "Ahora";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "Ahora";
+  return d.toLocaleDateString("es-PA", { day: "numeric", month: "short", year: "numeric" });
+}
+
+function formatPrice(land: LandDto): string {
+  const monthly = land.priceRule?.pricePerMonth;
+  if (typeof monthly === "number") {
+    return `$${monthly.toLocaleString("es-PA")}/mes`;
+  }
+  if (typeof land.salePrice === "number") {
+    return `$${land.salePrice.toLocaleString("es-PA")}`;
+  }
+  return "A consultar";
+}
+
+function formatLocation(land: LandDto): string {
+  const parts = [land.location?.province, land.location?.district].filter(Boolean);
+  return parts.length ? parts.join(" · ") : "—";
+}
+
+type LoadState = "loading" | "ready" | "error";
+
+export default function ComparePage() {
+  const { ids, remove, clear, max } = useCompareLands();
+  const [lands, setLands] = useState<LandDto[]>([]);
+  const [status, setStatus] = useState<LoadState>("loading");
+
+  useEffect(() => {
+    if (ids.length === 0) {
+      setLands([]);
+      setStatus("ready");
+      return;
+    }
+
+    let active = true;
+    setStatus("loading");
+
+    Promise.all(ids.map((id) => getLandById(id)))
+      .then((results) => {
+        if (!active) return;
+        // Solo los que siguen existiendo; si un id murió, lo quitamos de la lista.
+        const found = results.filter((l): l is LandDto => l != null);
+        const foundIds = new Set(found.map((l) => l.id));
+        for (const id of ids) {
+          if (!foundIds.has(id)) remove(id);
+        }
+        setLands(found);
+        setStatus("ready");
+      })
+      .catch((err) => {
+        console.error("Error cargando comparación:", err);
+        if (active) setStatus("error");
+      });
+
+    return () => {
+      active = false;
+    };
+    // remove es estable; ids es la dependencia real.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reload when ids change
+  }, [ids.join(",")]);
+
+  const rows: { label: string; value: (land: LandDto) => string }[] = [
+    { label: "Precio", value: formatPrice },
+    { label: "Área", value: (l) => (typeof l.area === "number" ? `${l.area} ha` : "—") },
+    { label: "Provincia / distrito", value: formatLocation },
+    { label: "Usos permitidos", value: (l) => formatUses(l.allowedUses) },
+    {
+      label: "Disponibilidad",
+      value: (l) => formatAvailable(l.availability?.availableFrom),
+    },
+  ];
+
+  return (
+    <div className="cmp">
+      <nav className="cmp-nav">
+        <Link to="/catalog" className="cmp-nav__back">
+          <ArrowLeft size={17} /> Catálogo
+        </Link>
+        <span className="cmp-nav__brand">
+          <span className="cmp-nav__brand-mark">
+            <Sprout size={22} strokeWidth={1.8} />
+          </span>
+          <span className="cmp-nav__brand-name">TerraShare</span>
+        </span>
+        <span className="cmp-nav__meta">
+          {ids.length}/{max} terrenos
+        </span>
+      </nav>
+
+      <main id="contenido" className="cmp-wrap">
+        <header className="cmp-header">
+          <div>
+            <h1 className="cmp-title">Comparar terrenos</h1>
+            <p className="cmp-lead">
+              Hasta {max} terrenos lado a lado. La selección se guarda en este navegador.
+            </p>
+          </div>
+          {ids.length > 0 && (
+            <button type="button" className="cmp-clear" onClick={clear}>
+              Vaciar lista
+            </button>
+          )}
+        </header>
+
+        {status === "loading" ? (
+          <div className="cmp-state">Cargando comparación…</div>
+        ) : status === "error" ? (
+          <div className="cmp-state cmp-state--error">
+            No pudimos cargar los terrenos. Vuelve a intentarlo.
+          </div>
+        ) : lands.length === 0 ? (
+          <EmptyState
+            icon={Columns2}
+            title="Nada que comparar todavía"
+            description="Añade hasta 3 terrenos desde el catálogo o la ficha de detalle."
+            action={{ label: "Ir al catálogo", to: "/catalog" }}
+          />
+        ) : (
+          <div className="cmp-table-wrap">
+            <table className="cmp-table">
+              <thead>
+                <tr>
+                  <th scope="col" className="cmp-table__attr">
+                    Atributo
+                  </th>
+                  {lands.map((land) => (
+                    <th key={land.id} scope="col" className="cmp-table__col">
+                      <div className="cmp-colhead">
+                        <div className="cmp-colhead__thumb">
+                          {land.photos?.[0] ? (
+                            <img
+                              src={photoSrc(land.photos[0])}
+                              alt=""
+                              loading="lazy"
+                            />
+                          ) : (
+                            <ImageIcon size={22} strokeWidth={1.5} aria-hidden="true" />
+                          )}
+                        </div>
+                        <div className="cmp-colhead__body">
+                          <Link
+                            to="/lands/$id"
+                            params={{ id: land.id }}
+                            className="cmp-colhead__title"
+                          >
+                            {land.title}
+                          </Link>
+                          <span className="cmp-colhead__loc">
+                            <MapPin size={12} /> {formatLocation(land)}
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          className="cmp-colhead__remove"
+                          aria-label={`Quitar ${land.title} de la comparación`}
+                          onClick={() => remove(land.id)}
+                        >
+                          <X size={16} />
+                        </button>
+                      </div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.label}>
+                    <th scope="row" className="cmp-table__attr">
+                      {row.label}
+                    </th>
+                    {lands.map((land) => (
+                      <td key={land.id}>{row.value(land)}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {lands.length > 0 && lands.length < max && (
+          <p className="cmp-hint">
+            Puedes añadir {max - lands.length} terreno{max - lands.length === 1 ? "" : "s"} más desde el{" "}
+            <Link to="/catalog">catálogo</Link>.
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -109,10 +109,10 @@
 }
 .cat-card:hover { transform: translateY(-3px); box-shadow: 0 26px 44px -30px rgba(36, 49, 42, 0.4); }
 .cat-card.is-active { border-color: var(--ts-green); box-shadow: 0 0 0 1px var(--ts-green); }
-.cat-card__fav {
+.cat-card__fav,
+.cat-card__cmp {
   position: absolute;
   bottom: 12px;
-  right: 12px;
   width: 34px;
   height: 34px;
   display: flex;
@@ -125,9 +125,14 @@
   cursor: pointer;
   transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
-.cat-card__fav:hover { color: var(--ts-clay); border-color: var(--ts-clay); }
-.cat-card__fav.is-active { color: var(--ts-clay); border-color: var(--ts-clay); background: var(--ts-surface); }
-.cat-card__fav:focus-visible { outline: 2px solid var(--ts-green); outline-offset: 2px; }
+.cat-card__fav { right: 12px; }
+.cat-card__cmp { right: 52px; }
+.cat-card__fav:hover,
+.cat-card__cmp:hover { color: var(--ts-clay); border-color: var(--ts-clay); }
+.cat-card__fav.is-active,
+.cat-card__cmp.is-active { color: var(--ts-clay); border-color: var(--ts-clay); background: var(--ts-surface); }
+.cat-card__fav:focus-visible,
+.cat-card__cmp:focus-visible { outline: 2px solid var(--ts-green); outline-offset: 2px; }
 .cat-card__thumb {
   width: 130px;
   height: 104px;
@@ -207,6 +212,33 @@
 }
 .cat-mapcard__title { font-family: var(--ts-font-serif); font-weight: 600; font-size: 16px; }
 .cat-mapcard__sub { font-size: 12.5px; color: var(--ts-sage); }
+.cat-mapcard__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+.cat-mapcard__cmp {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--ts-green);
+  background: transparent;
+  border: 1px solid #cdd6c8;
+  padding: 8px 12px;
+  border-radius: 9px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.cat-mapcard__cmp:hover { background: var(--ts-tint-green); }
+.cat-mapcard__cmp.is-active {
+  color: var(--ts-clay);
+  border-color: var(--ts-clay);
+  background: var(--ts-clay-tint, #f3e4dc);
+}
 .cat-mapcard__go {
   font-size: 13px;
   font-weight: 600;

--- a/apps/web/src/pages/compare.css
+++ b/apps/web/src/pages/compare.css
@@ -1,0 +1,310 @@
+/* TerraShare — Comparador de terrenos (HU-98 / #324). Prefijo `cmp-`. */
+
+.cmp {
+  font-family: var(--ts-font-sans);
+  color: var(--ts-text);
+  min-height: 100vh;
+  background: var(--ts-bg);
+}
+
+.cmp-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 28px;
+  border-bottom: 1px solid var(--ts-border);
+  background: var(--ts-surface-alt);
+}
+.cmp-nav__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ts-text-secondary, var(--ts-sage));
+  text-decoration: none;
+}
+.cmp-nav__back:hover { color: var(--ts-clay); }
+.cmp-nav__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.cmp-nav__brand-mark {
+  display: inline-flex;
+  color: var(--ts-green);
+}
+.cmp-nav__brand-name {
+  font-family: var(--ts-font-serif);
+  font-weight: 600;
+  font-size: 18px;
+}
+.cmp-nav__meta {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ts-sage);
+}
+
+.cmp-wrap {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 28px 70px;
+}
+
+.cmp-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+.cmp-title {
+  font-family: var(--ts-font-serif);
+  font-size: 32px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+.cmp-lead {
+  margin: 0;
+  font-size: 15px;
+  color: var(--ts-sage);
+  max-width: 42ch;
+}
+.cmp-clear {
+  flex: 0 0 auto;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--ts-clay);
+  background: transparent;
+  border: 1px solid var(--ts-clay-tint, #f3e4dc);
+  border-radius: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.cmp-clear:hover { background: var(--ts-clay-tint, #f3e4dc); }
+
+.cmp-state {
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-beige);
+  border-radius: 16px;
+  padding: 28px;
+  font-size: 14px;
+  color: var(--ts-sage-2);
+}
+.cmp-state--error { color: #a5573a; }
+
+.cmp-table-wrap {
+  overflow-x: auto;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-beige);
+  border-radius: 16px;
+}
+
+.cmp-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+.cmp-table th,
+.cmp-table td {
+  padding: 14px 16px;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--ts-beige);
+  font-size: 14.5px;
+}
+.cmp-table thead th {
+  border-bottom: 1px solid var(--ts-border);
+  background: var(--ts-surface-alt);
+}
+.cmp-table tbody tr:last-child th,
+.cmp-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.cmp-table__attr {
+  width: 160px;
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ts-sage);
+  background: var(--ts-surface-alt);
+}
+.cmp-table tbody .cmp-table__attr {
+  vertical-align: middle;
+}
+.cmp-table__col {
+  min-width: 180px;
+  max-width: 260px;
+}
+
+.cmp-colhead {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  position: relative;
+  padding-right: 28px;
+}
+.cmp-colhead__thumb {
+  width: 52px;
+  height: 52px;
+  border-radius: 10px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #e9e3d3, #dfe4d6);
+  color: var(--ts-sage-3);
+  overflow: hidden;
+}
+.cmp-colhead__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.cmp-colhead__body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.cmp-colhead__title {
+  font-family: var(--ts-font-serif);
+  font-weight: 600;
+  font-size: 16px;
+  color: var(--ts-text);
+  text-decoration: none;
+  line-height: 1.25;
+}
+.cmp-colhead__title:hover { color: var(--ts-green); }
+.cmp-colhead__loc {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ts-sage);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.cmp-colhead__remove {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  border: 1px solid var(--ts-beige);
+  background: var(--ts-surface);
+  color: var(--ts-sage-3);
+  cursor: pointer;
+  padding: 0;
+}
+.cmp-colhead__remove:hover {
+  color: var(--ts-clay);
+  border-color: var(--ts-clay);
+}
+
+.cmp-hint {
+  margin: 20px 0 0;
+  font-size: 13.5px;
+  color: var(--ts-sage);
+}
+.cmp-hint a {
+  color: var(--ts-green);
+  font-weight: 600;
+  text-decoration: none;
+}
+.cmp-hint a:hover { text-decoration: underline; }
+
+/* Barra flotante del catálogo (también en catalog.css vía clases cmp-bar) */
+.cmp-bar {
+  position: sticky;
+  bottom: 18px;
+  z-index: 40;
+  margin: 0 24px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 16px;
+  background: var(--ts-green-ink);
+  color: var(--ts-on-ink, #fffdf8);
+  border-radius: 14px;
+  box-shadow: 0 18px 40px -20px rgba(36, 49, 42, 0.55);
+}
+.cmp-bar__text {
+  font-size: 14px;
+  font-weight: 600;
+}
+.cmp-bar__text span {
+  font-weight: 500;
+  opacity: 0.85;
+}
+.cmp-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+.cmp-bar__clear {
+  font-size: 13px;
+  font-weight: 600;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  opacity: 0.85;
+  font-family: inherit;
+  padding: 8px 4px;
+}
+.cmp-bar__clear:hover { opacity: 1; text-decoration: underline; }
+.cmp-bar__go {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--ts-green-ink);
+  background: #fffdf8;
+  padding: 10px 14px;
+  border-radius: 10px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.cmp-bar__go:hover { background: #f4efe4; }
+
+.cmp-toast {
+  position: fixed;
+  bottom: 88px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  background: var(--ts-green-ink);
+  color: #fffdf8;
+  font-size: 13.5px;
+  font-weight: 600;
+  padding: 10px 16px;
+  border-radius: 10px;
+  box-shadow: 0 12px 28px -16px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+}
+
+@media (max-width: 700px) {
+  .cmp-nav { padding: 14px 16px; }
+  .cmp-wrap { padding: 24px 16px 56px; }
+  .cmp-title { font-size: 26px; }
+  .cmp-header { flex-direction: column; }
+  .cmp-bar {
+    margin: 0 12px 12px;
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .cmp-bar__actions { justify-content: space-between; }
+}

--- a/apps/web/src/routes/compare.tsx
+++ b/apps/web/src/routes/compare.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+import ComparePage from "../pages/ComparePage";
+
+/** Comparador de terrenos (HU-98). Público: la lista vive en localStorage. */
+export const Route = createFileRoute("/compare")({
+  component: ComparePage,
+});


### PR DESCRIPTION
## Resumen
Comparador de terrenos: permite a los visitantes seleccionar hasta 3 terrenos desde el catalogo y compararlos lado a lado en una tabla con precio, area, provincia/distrito, usos permitidos y disponibilidad. La seleccion se persiste en localStorage (no requiere login).

## Issue relacionado
Closes #324

## Tipo de cambio
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Documentacion

## Checklist
- [x] Cumple criterios de aceptacion del issue
- [x] No rompe funcionalidad existente
- [ ] Incluye/actualiza pruebas necesarias
- [ ] CI en verde
- [ ] Documentacion actualizada

## Evidencia
Frontend-only feature. Se anadio boton de comparar en el catalogo, barra flotante con contador, y pagina /compare con tabla responsive. useCompareLands hook sincroniza entre pestanas via localStorage + CustomEvent.

## Riesgos y rollback
- Riesgo principal: Ninguno significativo. Todo es frontend con localStorage.
- Plan de rollback: Eliminar route /compare, hook useCompareLands, y estilos cmp-* del catalogo.
