### PR TITLE
feat(backend): HU-99 búsquedas guardadas, HU-100 visitas y HU-101 PDF (consolidado)

### DIFF
--- a/apps/backend-api/bun.lock
+++ b/apps/backend-api/bun.lock
@@ -11,11 +11,13 @@
         "jose": "^5.9.6",
         "mongodb": "^7.2.0",
         "mongoose": "^9.5.0",
+        "pdfkit": "^0.19.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^25.6.0",
+        "@types/pdfkit": "^0.17.6",
         "@types/stripe": "^8.0.417",
         "mongodb-memory-server": "^11.2.0",
         "stripe": "^22.0.2",
@@ -30,13 +32,21 @@
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.9", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA=="],
 
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/pdfkit": ["@types/pdfkit@0.17.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig=="],
 
     "@types/stripe": ["@types/stripe@8.0.417", "", { "dependencies": { "stripe": "*" } }, "sha512-PTuqskh9YKNENnOHGVJBm4sM0zE8B1jZw1JIskuGAPkMB+OH236QeN8scclhYGPA4nG6zTtPXgwpXdp+HPDTVw=="],
 
@@ -62,11 +72,19 @@
 
     "bare-url": ["bare-url@2.4.5", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ=="],
 
+    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
+    "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
+    "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
+
     "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
 
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
@@ -74,7 +92,11 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
+    "dfa": ["dfa@1.2.0", "", {}, "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="],
+
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
@@ -86,6 +108,8 @@
 
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
+    "fontkit": ["fontkit@2.0.4", "", { "dependencies": { "@swc/helpers": "^0.5.12", "brotli": "^1.3.2", "clone": "^2.1.2", "dfa": "^1.2.0", "fast-deep-equal": "^3.1.3", "restructure": "^3.0.0", "tiny-inflate": "^1.0.3", "unicode-properties": "^1.4.0", "unicode-trie": "^2.0.0" } }, "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g=="],
+
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
@@ -96,7 +120,11 @@
 
     "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
+    "js-md5": ["js-md5@0.8.3", "", {}, "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="],
+
     "kareem": ["kareem@3.3.0", "", {}, "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw=="],
+
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -128,13 +156,21 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
+    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "pdfkit": ["pdfkit@0.19.1", "", { "dependencies": { "@noble/ciphers": "^1.0.0", "@noble/hashes": "^1.6.0", "fontkit": "^2.0.4", "js-md5": "^0.8.3", "linebreak": "^1.1.0", "png-js": "^1.1.0" } }, "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
+    "png-js": ["png-js@1.1.0", "", { "dependencies": { "browserify-zlib": "^0.2.0" } }, "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -154,6 +190,8 @@
 
     "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -161,6 +199,10 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unicode-properties": ["unicode-properties@1.4.1", "", { "dependencies": { "base64-js": "^1.3.0", "unicode-trie": "^2.0.0" } }, "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -170,8 +212,14 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "brotli/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "browserify-zlib/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "mongoose/mongodb": ["mongodb@7.1.1", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w=="],
+
+    "unicode-properties/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
   }
 }

--- a/apps/backend-api/package.json
+++ b/apps/backend-api/package.json
@@ -19,11 +19,13 @@
     "jose": "^5.9.6",
     "mongodb": "^7.2.0",
     "mongoose": "^9.5.0",
+    "pdfkit": "^0.19.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/node": "^25.6.0",
+    "@types/pdfkit": "^0.17.6",
     "@types/stripe": "^8.0.417",
     "mongodb-memory-server": "^11.2.0",
     "stripe": "^22.0.2",

--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -26,6 +26,8 @@ import { privacyRoutes } from "./routes/privacy";
 import { reportRoutes } from "./routes/reports";
 import { backupRoutes } from "./routes/backups";
 import { reviewRoutes } from "./routes/reviews";
+import { savedSearchRoutes } from "./routes/saved-searches";
+import { visitRoutes } from "./routes/visits";
 import type { AppEnv } from "./types";
 import { corsAllowHeaders, resolveCorsOrigin } from "./config/env";
 
@@ -83,6 +85,8 @@ export function createApp() {
   app.route("/api/v1", privacyRoutes);
   app.route("/api/v1", reportRoutes);
   app.route("/api/v1", reviewRoutes);
+  app.route("/api/v1", savedSearchRoutes);
+  app.route("/api/v1", visitRoutes);
 
   app.notFound((c) => failure(c, 404, "NOT_FOUND", "Route not found"));
 

--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -513,3 +513,61 @@ const NotificationSchema = new Schema<INotification>({
 }, { timestamps: false });
 
 export const Notification = mongoose.models.Notification || mongoose.model<INotification>("Notification", NotificationSchema);
+
+/** Búsqueda guardada de un usuario; alimenta las alertas de nuevos terrenos (HU-99 #325). */
+export interface ISavedSearch extends Document {
+  id: string;
+  userId: string;
+  name: string;
+  filters: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const SavedSearchSchema = new Schema<ISavedSearch>({
+  id: { type: String, required: true, unique: true },
+  userId: { type: String, required: true },
+  name: { type: String, required: true },
+  filters: { type: Schema.Types.Mixed, required: true },
+}, { timestamps: true });
+
+SavedSearchSchema.index({ userId: 1 });
+
+export const SavedSearch = mongoose.models.SavedSearch
+  || mongoose.model<ISavedSearch>("SavedSearch", SavedSearchSchema);
+
+/** Solicitud de visita a un terreno, propuesta por un interesado (HU-100 #326). */
+export type VisitStatus = "pending" | "confirmed" | "rescheduled" | "rejected";
+
+export interface IVisit extends Document {
+  id: string;
+  landId: string;
+  tenantId: string;
+  ownerId: string;
+  proposedDate: string;
+  proposedTime: string;
+  message?: string;
+  status: VisitStatus;
+  responseMessage?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const VisitSchema = new Schema<IVisit>({
+  id: { type: String, required: true, unique: true },
+  landId: { type: String, required: true },
+  tenantId: { type: String, required: true },
+  ownerId: { type: String, required: true },
+  proposedDate: { type: String, required: true },
+  proposedTime: { type: String, required: true },
+  message: String,
+  status: { type: String, enum: ["pending", "confirmed", "rescheduled", "rejected"], default: "pending" },
+  responseMessage: String,
+}, { timestamps: true });
+
+VisitSchema.index({ landId: 1 });
+VisitSchema.index({ tenantId: 1 });
+VisitSchema.index({ ownerId: 1 });
+
+export const Visit = mongoose.models.Visit
+  || mongoose.model<IVisit>("Visit", VisitSchema);

--- a/apps/backend-api/src/lib/match-saved-searches.ts
+++ b/apps/backend-api/src/lib/match-saved-searches.ts
@@ -1,0 +1,62 @@
+import { SavedSearch, Notification, User } from "../db/schemas";
+import type { ILand, LandUse } from "../db/schemas";
+import { sendEmail } from "./email";
+
+function matchesFilters(land: ILand, filters: Record<string, unknown>): boolean {
+  if (filters.province && land.location?.province !== filters.province) return false;
+  if (filters.district && land.location?.district !== filters.district) return false;
+  if (filters.use && land.allowedUses && !land.allowedUses.includes(filters.use as LandUse)) return false;
+  if (typeof filters.priceMin === "number" && land.priceRule?.pricePerMonth != null) {
+    if (land.priceRule.pricePerMonth < filters.priceMin) return false;
+  }
+  if (typeof filters.priceMax === "number" && land.priceRule?.pricePerMonth != null) {
+    if (land.priceRule.pricePerMonth > filters.priceMax) return false;
+  }
+  return true;
+}
+
+/**
+ * Avisa a los usuarios cuyas búsquedas guardadas coinciden con un terreno recién
+ * publicado (HU-99 #325). Se invoca cuando el terreno pasa a `active` — no al
+ * crearlo en `draft`, porque un borrador aún no es visible en el catálogo.
+ *
+ * Cada coincidencia se procesa de forma aislada: un fallo (p. ej. de correo) se
+ * registra pero no interrumpe el aviso al resto de usuarios.
+ */
+export async function matchSavedSearches(newLand: ILand): Promise<void> {
+  const searches = await SavedSearch.find().lean();
+
+  for (const search of searches) {
+    // No tiene sentido avisar al dueño sobre su propia publicación.
+    if (search.userId === newLand.ownerId) continue;
+    if (!matchesFilters(newLand, search.filters as Record<string, unknown>)) continue;
+
+    try {
+      await Notification.create({
+        id: `ntf_${crypto.randomUUID()}`,
+        userId: search.userId,
+        type: "saved_search_match",
+        title: "Nuevo terreno coincide con tu busqueda",
+        body: `El terreno "${newLand.title}" coincide con tu busqueda guardada "${search.name}".`,
+        read: false,
+      });
+
+      // El identificador de usuario es el `clerkUserId` (no existe campo `id`).
+      const user = await User.findOne({ clerkUserId: search.userId }).lean();
+      if (user?.email) {
+        await sendEmail({
+          to: user.email,
+          subject: `Nuevo terreno: ${newLand.title}`,
+          html: `<p>El terreno <strong>${newLand.title}</strong> coincide con tu busqueda guardada "<em>${search.name}</em>".</p>`,
+        });
+      }
+    } catch (err) {
+      console.error({
+        level: "error",
+        message: "Failed to notify saved search match",
+        savedSearchId: search.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/apps/backend-api/src/routes/contracts.test.ts
+++ b/apps/backend-api/src/routes/contracts.test.ts
@@ -70,3 +70,43 @@ describe("contracts and audit routes", () => {
     expect(Array.isArray(payload.data)).toBe(true);
   });
 });
+
+describe("contract PDF export (HU-101 #327)", () => {
+  it("exports contract as PDF for owner", async () => {
+    const res = await requestJson("/api/v1/contracts/contract_seed_01/pdf", {
+      headers: { "x-dev-user-id": "user_owner_01" },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.response.headers.get("content-type")).toContain("application/pdf");
+  });
+
+  it("tenant can download contract PDF", async () => {
+    const res = await requestJson("/api/v1/contracts/contract_seed_01/pdf", {
+      headers: { "x-dev-user-id": "user_tenant_01" },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.response.headers.get("content-type")).toContain("application/pdf");
+  });
+
+  it("admin can download contract PDF", async () => {
+    const res = await requestJson("/api/v1/contracts/contract_seed_01/pdf", {
+      headers: { "x-dev-user-id": "user_admin_01", "x-dev-role": "admin" },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.response.headers.get("content-type")).toContain("application/pdf");
+  });
+
+  it("rejects PDF export for non-party", async () => {
+    const res = await requestJson("/api/v1/contracts/contract_seed_01/pdf", {
+      headers: { "x-dev-user-id": "random_stranger" },
+    });
+    expect(res.response.status).toBe(403);
+  });
+
+  it("returns 404 for non-existent contract PDF", async () => {
+    const res = await requestJson("/api/v1/contracts/nonexistent/pdf", {
+      headers: { "x-dev-user-id": "user_owner_01" },
+    });
+    expect(res.response.status).toBe(404);
+  });
+});

--- a/apps/backend-api/src/routes/contracts.ts
+++ b/apps/backend-api/src/routes/contracts.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import PDFDocument from "pdfkit";
 import { CreateContractSchema, UpdateContractStatusSchema } from "@terrashare/shared";
 
 import { failure, success } from "../lib/api-response";
@@ -10,7 +11,7 @@ import {
 } from "../lib/auth-helpers";
 import { requireAdmin, requireAuth } from "../middleware/require-auth";
 import { createAuditEvent } from "../store/audit";
-import { Contract, AuditEvent, RentalRequest, Land } from "../db/schemas";
+import { Contract, AuditEvent, RentalRequest, Land, User } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const contractRoutes = new Hono<AppEnv>();
@@ -221,4 +222,75 @@ contractRoutes.get("/audit-events/:eventId", requireAuth, requireAdmin, async (c
   }
 
   return success(c, event);
+});
+
+// ─── PDF Export (HU-101 / #327) ──────────────────────────────────────────────
+
+contractRoutes.get("/contracts/:id/pdf", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const contractId = c.req.param("id");
+
+  const contract = await Contract.findOne({ id: contractId }).lean();
+  if (!contract) {
+    return failure(c, 404, "NOT_FOUND", "Contract not found");
+  }
+
+  if (!canReadContract(authUser, contract)) {
+    return failure(c, 403, "FORBIDDEN", "You are not a party to this contract");
+  }
+
+  const doc = new PDFDocument({ size: "letter", margin: 50 });
+
+  const chunks: Buffer[] = [];
+  doc.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+  const pdfReady = new Promise<Buffer>((resolve) => {
+    doc.on("end", () => resolve(Buffer.concat(chunks)));
+  });
+
+  doc.fontSize(20).text("TerraShare - Contrato de Arrendamiento", { align: "center" });
+  doc.moveDown();
+  doc.fontSize(12).text(`Contrato #: ${contract.id}`);
+  doc.text(`Estado: ${contract.status}`);
+  doc.moveDown();
+
+  const owner = await User.findOne({ clerkUserId: contract.ownerId }).lean();
+  const tenant = await User.findOne({ clerkUserId: contract.tenantId }).lean();
+
+  doc.fontSize(14).text("Partes");
+  doc.fontSize(12);
+  doc.text(`Propietario: ${owner?.profile?.fullName ?? contract.ownerId}`);
+  doc.text(`Arrendatario: ${tenant?.profile?.fullName ?? contract.tenantId}`);
+  doc.moveDown();
+
+  doc.fontSize(14).text("Terminos");
+  doc.fontSize(12);
+  if (contract.terms?.summary) doc.text(`Resumen: ${contract.terms.summary}`);
+  if (contract.terms?.startsAt) doc.text(`Inicio: ${new Date(contract.terms.startsAt).toLocaleDateString("es-PA")}`);
+  if (contract.terms?.endsAt) doc.text(`Fin: ${new Date(contract.terms.endsAt).toLocaleDateString("es-PA")}`);
+  doc.moveDown();
+
+  if (contract.status === "active" || contract.status === "completed") {
+    doc.fontSize(14).text("Firma");
+    doc.fontSize(12);
+    doc.text("Ambas partes han firmado electronicamente este contrato.");
+    if (contract.terms?.signedAt) {
+      doc.text(`Fecha de firma: ${new Date(contract.terms.signedAt).toLocaleDateString("es-PA")}`);
+    }
+  }
+
+  doc.moveDown(2);
+  doc.fontSize(10).text("Generado por TerraShare", { align: "center" });
+
+  doc.end();
+
+  const pdfBuffer = await pdfReady;
+
+  return new Response(new Uint8Array(pdfBuffer), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="contrato-${contract.id}.pdf"`,
+    },
+  });
 });

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -8,7 +8,8 @@ import { getNumericQuery, getOptionalNumericQuery } from "../lib/request-utils";
 import { requireAuth } from "../middleware/require-auth";
 import { rateLimitByUser } from "../middleware/rate-limit";
 import { createAuditEvent as createAudit } from "../store/audit";
-import { Land } from "../db/schemas";
+import { Land, type ILand } from "../db/schemas";
+import { matchSavedSearches } from "../lib/match-saved-searches";
 import {
   ALLOWED_CONTENT_TYPES,
   MAX_PHOTO_BYTES,
@@ -407,6 +408,20 @@ landRoutes.patch("/lands/:landId/status", requireAuth, rateLimitByUser(200), asy
   };
 
   await Land.findOneAndUpdate({ id: landId }, { $set: { status, updatedAt: updated.updatedAt } });
+
+  // Alertas de búsquedas guardadas (HU-99 #325): se disparan al PUBLICARSE el
+  // terreno (transición a `active`), no al crearlo en `draft`, y solo cuando
+  // realmente cambia de estado, para no repetir avisos.
+  if (status === "active" && current.status !== "active") {
+    matchSavedSearches(updated as unknown as ILand).catch((err) =>
+      console.error({
+        level: "error",
+        message: "Failed to match saved searches",
+        landId,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
 
   await createAudit({
     actor: authUser,

--- a/apps/backend-api/src/routes/saved-searches.test.ts
+++ b/apps/backend-api/src/routes/saved-searches.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import mongoose from "mongoose";
+import { requestJson, resetStore } from "../lib/http-test-utils";
+import { Notification } from "../db/schemas";
+
+beforeEach(async () => {
+  resetStore();
+  await mongoose.connection.collections.savedsearches?.drop().catch(() => {});
+  await Notification.deleteMany({ type: "saved_search_match" }).catch(() => {});
+});
+
+describe("saved-searches routes", () => {
+  const userId = "ss_user_01";
+
+  it("creates a saved search", async () => {
+    const res = await requestJson("/api/v1/users/me/saved-searches", {
+      method: "POST",
+      headers: { "x-dev-user-id": userId },
+      body: { name: "Terrenos en Panama", filters: { province: "Panamá", priceMax: 5000 } },
+    });
+    expect(res.response.status).toBe(201);
+    expect(res.payload.data.name).toBe("Terrenos en Panama");
+    expect(res.payload.data.filters.province).toBe("Panamá");
+  });
+
+  it("lists saved searches", async () => {
+    await requestJson("/api/v1/users/me/saved-searches", {
+      method: "POST",
+      headers: { "x-dev-user-id": userId },
+      body: { name: "Search 1", filters: { province: "Panamá" } },
+    });
+    const res = await requestJson("/api/v1/users/me/saved-searches", {
+      headers: { "x-dev-user-id": userId },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.payload.data.length).toBe(1);
+  });
+
+  it("deletes a saved search", async () => {
+    const created = await requestJson("/api/v1/users/me/saved-searches", {
+      method: "POST",
+      headers: { "x-dev-user-id": userId },
+      body: { name: "To delete", filters: {} },
+    });
+    const id = created.payload.data.id;
+    const res = await requestJson(`/api/v1/users/me/saved-searches/${id}`, {
+      method: "DELETE",
+      headers: { "x-dev-user-id": userId },
+    });
+    expect(res.response.status).toBe(200);
+  });
+
+  it("rejects nameless search", async () => {
+    const res = await requestJson("/api/v1/users/me/saved-searches", {
+      method: "POST",
+      headers: { "x-dev-user-id": userId },
+      body: { name: "", filters: {} },
+    });
+    expect(res.response.status).toBe(400);
+  });
+
+  it("does not return other user searches", async () => {
+    await requestJson("/api/v1/users/me/saved-searches", {
+      method: "POST",
+      headers: { "x-dev-user-id": "ss_user_02" },
+      body: { name: "Other", filters: {} },
+    });
+    const res = await requestJson("/api/v1/users/me/saved-searches", {
+      headers: { "x-dev-user-id": userId },
+    });
+    expect(res.payload.data.length).toBe(0);
+  });
+
+  it("returns 404 deleting non-existent search", async () => {
+    const res = await requestJson("/api/v1/users/me/saved-searches/nonexistent", {
+      method: "DELETE",
+      headers: { "x-dev-user-id": userId },
+    });
+    expect(res.response.status).toBe(404);
+  });
+});
+
+describe("saved-search alerts (#325)", () => {
+  const seeker = "ss_seeker_01";
+  const owner = "ss_owner_01";
+
+  /** Crea un terreno en `draft` que casa con la búsqueda guardada. */
+  async function createDraftLand(): Promise<string> {
+    const res = await requestJson("/api/v1/lands", {
+      method: "POST",
+      headers: { "x-dev-user-id": owner },
+      body: {
+        title: "Finca alertas",
+        area: 20,
+        allowedUses: ["agricultura"],
+        location: { province: "Chiriqui", district: "David" },
+        priceRule: { currency: "USD", pricePerMonth: 400 },
+      },
+    });
+    return res.payload.data.id as string;
+  }
+
+  /**
+   * Las alertas se persisten en el modelo `Notification` de Mongo. Nota: hoy
+   * `GET /notifications` lee del store en memoria, así que se consulta el modelo
+   * directamente (ver follow-up de unificación del centro de notificaciones).
+   */
+  async function notifCount(userId: string = seeker): Promise<number> {
+    return Notification.countDocuments({ userId, type: "saved_search_match" });
+  }
+
+  it("no alerta mientras el terreno sigue en borrador, y alerta al publicarlo", async () => {
+    await requestJson("/api/v1/users/me/saved-searches", {
+      method: "POST",
+      headers: { "x-dev-user-id": seeker },
+      body: { name: "Chiriqui barato", filters: { province: "Chiriqui", priceMax: 1000 } },
+    });
+
+    const landId = await createDraftLand();
+    // Crear en draft NO debe alertar: el terreno aún no es visible.
+    expect(await notifCount()).toBe(0);
+
+    await requestJson(`/api/v1/lands/${landId}/status`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": owner },
+      body: { status: "active" },
+    });
+
+    // Al publicarse sí alerta (el aviso es asíncrono: damos margen).
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await notifCount()).toBe(1);
+  });
+
+  it("no alerta al dueño sobre su propia publicación", async () => {
+    await requestJson("/api/v1/users/me/saved-searches", {
+      method: "POST",
+      headers: { "x-dev-user-id": owner },
+      body: { name: "Mis propios", filters: { province: "Chiriqui" } },
+    });
+
+    const landId = await createDraftLand();
+    await requestJson(`/api/v1/lands/${landId}/status`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": owner },
+      body: { status: "active" },
+    });
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await notifCount(owner)).toBe(0);
+  });
+});

--- a/apps/backend-api/src/routes/saved-searches.ts
+++ b/apps/backend-api/src/routes/saved-searches.ts
@@ -1,0 +1,55 @@
+import { Hono } from "hono";
+import { requireAuth } from "../middleware/require-auth";
+import { success, failure } from "../lib/api-response";
+import { SavedSearch } from "../db/schemas";
+import type { AppEnv } from "../types";
+
+const MAX_SAVED_SEARCHES = 10;
+
+export const savedSearchRoutes = new Hono<AppEnv>();
+
+savedSearchRoutes.get("/users/me/saved-searches", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const searches = await SavedSearch.find({ userId: authUser.id })
+    .sort({ createdAt: -1 })
+    .lean();
+  return success(c, searches);
+});
+
+savedSearchRoutes.post("/users/me/saved-searches", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const body = await c.req.json<{ name: string; filters: Record<string, unknown> }>();
+
+  if (!body.name || body.name.trim().length === 0) {
+    return failure(c, 400, "VALIDATION_ERROR", "Name is required");
+  }
+  if (!body.filters || typeof body.filters !== "object") {
+    return failure(c, 400, "VALIDATION_ERROR", "Filters are required");
+  }
+
+  const count = await SavedSearch.countDocuments({ userId: authUser.id });
+  if (count >= MAX_SAVED_SEARCHES) {
+    return failure(c, 400, "VALIDATION_ERROR", `Maximum ${MAX_SAVED_SEARCHES} saved searches allowed`);
+  }
+
+  const search = await SavedSearch.create({
+    id: crypto.randomUUID(),
+    userId: authUser.id,
+    name: body.name.trim(),
+    filters: body.filters,
+  });
+
+  return success(c, search, 201);
+});
+
+savedSearchRoutes.delete("/users/me/saved-searches/:id", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const id = c.req.param("id");
+
+  const search = await SavedSearch.findOneAndDelete({ id, userId: authUser.id });
+  if (!search) {
+    return failure(c, 404, "NOT_FOUND", "Saved search not found");
+  }
+
+  return success(c, { deleted: true });
+});

--- a/apps/backend-api/src/routes/visits.test.ts
+++ b/apps/backend-api/src/routes/visits.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import mongoose from "mongoose";
+import { requestJson, resetStore } from "../lib/http-test-utils";
+
+beforeEach(async () => {
+  resetStore();
+  await mongoose.connection.collections.visits?.drop().catch(() => {});
+  await mongoose.connection.collections.notifications?.drop().catch(() => {});
+});
+
+describe("visits routes", () => {
+  it("creates a visit request", async () => {
+    const res = await requestJson("/api/v1/lands/land_seed_01/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00", message: "Quiero visitar" },
+    });
+    expect(res.response.status).toBe(201);
+    expect(res.payload.data.status).toBe("pending");
+    expect(res.payload.data.proposedDate).toBe("2026-08-15");
+  });
+
+  it("rejects visit to own land", async () => {
+    const res = await requestJson("/api/v1/lands/land_seed_01/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_owner_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00" },
+    });
+    expect(res.response.status).toBe(403);
+  });
+
+  it("returns 404 for non-existent land", async () => {
+    const res = await requestJson("/api/v1/lands/nonexistent/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00" },
+    });
+    expect(res.response.status).toBe(404);
+  });
+
+  it("lists visits as tenant", async () => {
+    await requestJson("/api/v1/lands/land_seed_01/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00" },
+    });
+    const res = await requestJson("/api/v1/users/me/visits", {
+      headers: { "x-dev-user-id": "user_tenant_01" },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.payload.data.length).toBe(1);
+  });
+
+  it("lists visits as owner", async () => {
+    await requestJson("/api/v1/lands/land_seed_01/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00" },
+    });
+    const res = await requestJson("/api/v1/users/me/visits", {
+      headers: { "x-dev-user-id": "user_owner_01" },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.payload.data.length).toBe(1);
+  });
+
+  it("owner can confirm a visit", async () => {
+    const created = await requestJson("/api/v1/lands/land_seed_01/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00" },
+    });
+    const visitId = created.payload.data.id;
+    const res = await requestJson(`/api/v1/visits/${visitId}`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_owner_01" },
+      body: { status: "confirmed" },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.payload.data.status).toBe("confirmed");
+  });
+
+  it("tenant cannot confirm a visit", async () => {
+    const created = await requestJson("/api/v1/lands/land_seed_01/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00" },
+    });
+    const visitId = created.payload.data.id;
+    const res = await requestJson(`/api/v1/visits/${visitId}`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { status: "confirmed" },
+    });
+    expect(res.response.status).toBe(403);
+  });
+
+  it("owner can reject a visit", async () => {
+    const created = await requestJson("/api/v1/lands/land_seed_01/visits", {
+      method: "POST",
+      headers: { "x-dev-user-id": "user_tenant_01" },
+      body: { proposedDate: "2026-08-15", proposedTime: "10:00" },
+    });
+    const visitId = created.payload.data.id;
+    const res = await requestJson(`/api/v1/visits/${visitId}`, {
+      method: "PATCH",
+      headers: { "x-dev-user-id": "user_owner_01" },
+      body: { status: "rejected", responseMessage: "No disponible" },
+    });
+    expect(res.response.status).toBe(200);
+    expect(res.payload.data.status).toBe("rejected");
+  });
+});

--- a/apps/backend-api/src/routes/visits.ts
+++ b/apps/backend-api/src/routes/visits.ts
@@ -1,0 +1,118 @@
+import { Hono } from "hono";
+import { requireAuth } from "../middleware/require-auth";
+import { success, failure } from "../lib/api-response";
+import { Visit, Land, Notification } from "../db/schemas";
+import type { AppEnv } from "../types";
+
+export const visitRoutes = new Hono<AppEnv>();
+
+/** Estados con los que el dueño puede responder a una solicitud de visita. */
+const VISIT_RESPONSE_STATUSES = ["confirmed", "rescheduled", "rejected"] as const;
+type VisitResponseStatus = (typeof VISIT_RESPONSE_STATUSES)[number];
+
+visitRoutes.post("/lands/:id/visits", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const landId = c.req.param("id");
+  const body = await c.req.json<{ proposedDate: string; proposedTime: string; message?: string }>();
+
+  if (!body.proposedDate || !body.proposedTime) {
+    return failure(c, 400, "VALIDATION_ERROR", "proposedDate and proposedTime are required");
+  }
+
+  const land = await Land.findOne({ id: landId }).lean();
+  if (!land) {
+    return failure(c, 404, "NOT_FOUND", "Land not found");
+  }
+  if (land.ownerId === authUser.id) {
+    return failure(c, 403, "FORBIDDEN", "Cannot schedule a visit to your own land");
+  }
+
+  const visit = await Visit.create({
+    id: crypto.randomUUID(),
+    landId,
+    tenantId: authUser.id,
+    ownerId: land.ownerId,
+    proposedDate: body.proposedDate,
+    proposedTime: body.proposedTime,
+    message: body.message,
+    status: "pending",
+  });
+
+  await Notification.create({
+    id: crypto.randomUUID(),
+    userId: land.ownerId,
+    type: "visit_request",
+    title: "Nueva solicitud de visita",
+    body: `Un usuario quiere visitar "${land.title}" el ${body.proposedDate} a las ${body.proposedTime}.`,
+    read: false,
+  });
+
+  return success(c, visit, 201);
+});
+
+visitRoutes.get("/users/me/visits", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const visits = await Visit.find({
+    $or: [{ tenantId: authUser.id }, { ownerId: authUser.id }],
+  }).sort({ createdAt: -1 }).lean();
+  return success(c, visits);
+});
+
+visitRoutes.patch("/visits/:id", requireAuth, async (c) => {
+  const authUser = c.get("authUser");
+  const visitId = c.req.param("id");
+  // `status` llega sin tipar de confianza: se valida contra el enum más abajo.
+  const body = await c.req.json<{
+    status: string;
+    responseMessage?: string;
+    proposedDate?: string;
+    proposedTime?: string;
+  }>();
+
+  // `findOneAndUpdate` no ejecuta los validadores del esquema, así que el enum
+  // de estado se valida aquí explícitamente.
+  if (!VISIT_RESPONSE_STATUSES.includes(body.status as VisitResponseStatus)) {
+    return failure(
+      c,
+      400,
+      "VALIDATION_ERROR",
+      `status must be one of: ${VISIT_RESPONSE_STATUSES.join(", ")}`,
+    );
+  }
+
+  const visit = await Visit.findOne({ id: visitId }).lean();
+  if (!visit) {
+    return failure(c, 404, "NOT_FOUND", "Visit not found");
+  }
+  if (visit.ownerId !== authUser.id) {
+    return failure(c, 403, "FORBIDDEN", "Only the land owner can update visit status");
+  }
+
+  const updated = await Visit.findOneAndUpdate(
+    { id: visitId },
+    {
+      status: body.status,
+      responseMessage: body.responseMessage,
+      ...(body.proposedDate && { proposedDate: body.proposedDate }),
+      ...(body.proposedTime && { proposedTime: body.proposedTime }),
+    },
+    { returnDocument: "after" },
+  ).lean();
+
+  const statusLabels: Record<string, string> = {
+    confirmed: "confirmada",
+    rescheduled: "reprogramada",
+    rejected: "rechazada",
+  };
+
+  await Notification.create({
+    id: crypto.randomUUID(),
+    userId: visit.tenantId,
+    type: "visit_update",
+    title: `Visita ${statusLabels[body.status] || body.status}`,
+    body: `Tu solicitud de visita fue ${statusLabels[body.status] || body.status}.`,
+    read: false,
+  });
+
+  return success(c, updated);
+});

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -460,6 +460,37 @@ export const getRatingByUser = async (userId: string): Promise<RatingDto> => {
   return res?.data ?? { averageRating: 0, totalReviews: 0 };
 };
 
+// ─── Saved Searches (HU-99 / #325) ──────────────────────────────────────────
+
+export interface SavedSearchDto {
+  id: string;
+  userId: string;
+  name: string;
+  filters: Record<string, unknown>;
+  createdAt: string;
+}
+
+/** POST /api/v1/users/me/saved-searches — guardar un filtro con nombre. */
+export const createSavedSearch = async (input: {
+  name: string;
+  filters: Record<string, unknown>;
+}): Promise<SavedSearchDto | null> => {
+  const res = await request<SavedSearchDto>("POST", "/api/v1/users/me/saved-searches", input);
+  return res?.data ?? null;
+};
+
+/** GET /api/v1/users/me/saved-searches — listar mis búsquedas guardadas. */
+export const listSavedSearches = async (): Promise<SavedSearchDto[]> => {
+  const res = await request<SavedSearchDto[]>("GET", "/api/v1/users/me/saved-searches");
+  return res?.data ?? [];
+};
+
+/** DELETE /api/v1/users/me/saved-searches/:id — eliminar una búsqueda guardada. */
+export const deleteSavedSearch = async (id: string): Promise<boolean> => {
+  const res = await request<unknown>("DELETE", `/api/v1/users/me/saved-searches/${id}`);
+  return res?.ok ?? false;
+};
+
 export const api = {
   listLands,
   getMyLands,
@@ -484,4 +515,7 @@ export const api = {
   createReview,
   getReviewsByUser,
   getRatingByUser,
+  createSavedSearch,
+  listSavedSearches,
+  deleteSavedSearch,
 };


### PR DESCRIPTION
## Qué hace

Consolida el **backend** de las tres HU restantes sobre un `main` limpio, corrigiendo los problemas detectados al revisar los PRs #346, #347 y #348 (que estaban apilados entre sí y duplicaban el sistema de reseñas ya mergeado en #344).

- **HU-99** Búsquedas guardadas y alertas — `Closes #325`
- **HU-100** Agendar visita a un terreno — `Closes #326`
- **HU-101** Exportar contrato a PDF — `Closes #327`

## Correcciones aplicadas

| Problema | Corrección |
|---|---|
| `schemas.ts` llegaba con un **BOM** y mojibake (`l├│gico`, `d├¡as`…) que destrozaba los acentos de todo el fichero | Modelos `SavedSearch` y `Visit` añadidos sobre el `schemas.ts` limpio |
| El **email de alerta nunca se enviaba**: `User.findOne({ id })`, pero el usuario se identifica por `clerkUserId` | Corregido a `clerkUserId` |
| Las alertas se disparaban al crear el terreno en **`draft`** (invisible en el catálogo) y **nunca al publicarlo** | Se disparan en la transición a `active`; además se omite al propio dueño y cada aviso se aísla en `try/catch` |
| El `PATCH /visits/:id` no validaba el enum de estado (`findOneAndUpdate` no ejecuta validadores) | Validación explícita del estado |

## Pruebas

- **Backend: 331 pass / 0 fail** · typecheck limpio
- **MCP: 294 pass / 0 fail** · typecheck limpio (se tocó `schemas.ts`, compartido)
- **Web:** typecheck limpio · build OK
- Tests nuevos que cubren los fixes: la alerta **no** salta en borrador, **sí** al publicar, y **no** al propio dueño; más los 5 casos del export PDF (dueño, arrendatario, admin, no-parte → 403, inexistente → 404).

## Notas de seguimiento (no bloquean)

1. **Visitas y PDF son solo backend** — no tienen UI todavía.
2. `GET /notifications` lee del store **en memoria**, mientras las alertas (y las notificaciones del MCP, #328) se escriben en **Mongo**. Inconsistencia preexistente: conviene unificar el centro de notificaciones.

Sustituye a #346, #347 y #348.
