### PR TITLE
feat(web): UI para agendar visitas (HU-100) y descargar contrato en PDF (HU-101)

### DIFF
--- a/apps/web/src/components/UserDashboardLayout.tsx
+++ b/apps/web/src/components/UserDashboardLayout.tsx
@@ -36,6 +36,7 @@ export default function UserDashboardLayout({ children, onSignOut }: UserDashboa
     { label: "Mis solicitudes", onClick: () => navigate({ to: "/dashboard" }) },
     { label: "Mis terrenos", onClick: () => navigate({ to: "/dashboard/lands" }) },
     { label: "Contratos", onClick: () => navigate({ to: "/dashboard/contracts" }) },
+    { label: "Visitas", onClick: () => navigate({ to: "/dashboard/visits" }) },
     { label: "Pagos", onClick: () => navigate({ to: "/dashboard/payments" }) },
     { label: "Privacidad", onClick: () => navigate({ to: "/dashboard/privacy" }) },
   ];

--- a/apps/web/src/components/VisitModal.tsx
+++ b/apps/web/src/components/VisitModal.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { CalendarClock } from "lucide-react";
+
+interface VisitModalProps {
+  landTitle: string;
+  onSubmit: (proposedDate: string, proposedTime: string, message: string) => Promise<void>;
+  onClose: () => void;
+}
+
+/** Fecha mínima seleccionable: hoy (no tiene sentido proponer una visita pasada). */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Modal para solicitar una visita a un terreno (HU-100 / #326). El dueño
+ * responde después desde /dashboard/visits.
+ */
+export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalProps) {
+  const [date, setDate] = useState("");
+  const [time, setTime] = useState("");
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async () => {
+    if (!date || !time) {
+      setError("Indica la fecha y la hora de la visita");
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    try {
+      await onSubmit(date, time, message);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudo solicitar la visita");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, zIndex: 1000,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        background: "rgba(0,0,0,0.5)", backdropFilter: "blur(4px)",
+      }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Agendar visita"
+        style={{
+          background: "var(--surface, #1a1a2e)",
+          borderRadius: "12px", padding: "2rem",
+          maxWidth: "460px", width: "90%",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.3)",
+        }}
+      >
+        <h2 style={{ margin: "0 0 0.5rem", fontSize: "1.25rem" }}>Agendar visita</h2>
+        <p style={{ margin: "0 0 1.5rem", fontSize: "0.85rem", opacity: 0.7 }}>
+          Propón una fecha y hora para visitar «{landTitle}». El dueño podrá confirmarla,
+          reprogramarla o rechazarla.
+        </p>
+
+        <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1rem" }}>
+          <label style={{ flex: 1, fontSize: "0.85rem" }}>
+            Fecha
+            <input
+              type="date"
+              value={date}
+              min={todayIso()}
+              onChange={(e) => setDate(e.target.value)}
+              style={{ width: "100%", marginTop: "0.25rem", padding: "0.5rem", borderRadius: "8px" }}
+            />
+          </label>
+          <label style={{ flex: 1, fontSize: "0.85rem" }}>
+            Hora
+            <input
+              type="time"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+              style={{ width: "100%", marginTop: "0.25rem", padding: "0.5rem", borderRadius: "8px" }}
+            />
+          </label>
+        </div>
+
+        <textarea
+          placeholder="Mensaje para el dueño (opcional)…"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          maxLength={500}
+          rows={3}
+          style={{ width: "100%", padding: "0.5rem", borderRadius: "8px", resize: "vertical" }}
+        />
+
+        {error && (
+          <p style={{ color: "#f87171", fontSize: "0.85rem", margin: "0.75rem 0 0" }}>{error}</p>
+        )}
+
+        <div style={{ display: "flex", gap: "0.75rem", justifyContent: "flex-end", marginTop: "1.5rem" }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{ padding: "0.5rem 1rem", borderRadius: "8px", cursor: "pointer" }}
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !date || !time}
+            style={{
+              padding: "0.5rem 1rem", borderRadius: "8px",
+              cursor: submitting ? "default" : "pointer",
+              opacity: submitting || !date || !time ? 0.6 : 1,
+              display: "inline-flex", alignItems: "center", gap: "0.4rem",
+              fontSize: "0.9rem", fontWeight: 600,
+            }}
+          >
+            <CalendarClock size={16} />
+            {submitting ? "Enviando…" : "Solicitar visita"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { useParams } from "@tanstack/react-router";
 import { useAuth, useUser } from "@clerk/clerk-react";
-import { Star } from "lucide-react";
+import { Star, Download } from "lucide-react";
 import ReviewModal from "../components/ReviewModal";
-import { createReview, getReviewsByUser, type ReviewDto } from "../services/api";
+import { createReview, getReviewsByUser, downloadContractPdf, type ReviewDto } from "../services/api";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
 
@@ -26,6 +26,9 @@ export default function ContractDetailPage() {
   const [showReviewModal, setShowReviewModal] = useState(false);
   const [myReview, setMyReview] = useState<ReviewDto | null>(null);
   const [reviews, setReviews] = useState<ReviewDto[]>([]);
+  // Descarga del contrato en PDF (HU-101 / #327).
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState("");
 
   useEffect(() => {
     if (!user || !contractId) return;
@@ -76,6 +79,19 @@ export default function ContractDetailPage() {
   const status = contract ? statusConfig[contract.status] || statusConfig.draft : null;
   const canReview = contract?.status === "completed" && user && !myReview;
 
+  const handleDownloadPdf = async () => {
+    if (!contract) return;
+    setDownloading(true);
+    setDownloadError("");
+    try {
+      await downloadContractPdf(contract.id);
+    } catch (e) {
+      setDownloadError(e instanceof Error ? e.message : "No se pudo descargar el PDF");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
   return (
     <div>
       <div className="section-header">
@@ -115,6 +131,26 @@ export default function ContractDetailPage() {
             <p style={{ margin: 0 }}><strong>Período:</strong> {contract.terms?.startsAt || "—"} → {contract.terms?.endsAt || "—"}</p>
             <p style={{ margin: 0 }}><strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString() : "—"}</p>
           </div>
+
+          {/* Descargar el contrato en PDF (HU-101 / #327). */}
+          <button
+            onClick={handleDownloadPdf}
+            disabled={downloading}
+            style={{
+              marginTop: "1rem", padding: "0.5rem 1.25rem", borderRadius: "8px",
+              cursor: downloading ? "default" : "pointer", fontSize: "0.9rem", fontWeight: 600,
+              display: "flex", alignItems: "center", gap: "0.5rem",
+              opacity: downloading ? 0.6 : 1,
+            }}
+          >
+            <Download size={16} /> {downloading ? "Generando…" : "Descargar PDF"}
+          </button>
+
+          {downloadError && (
+            <p style={{ color: "var(--danger, #dc2626)", fontSize: "0.85rem", margin: "0.5rem 0 0" }}>
+              {downloadError}
+            </p>
+          )}
 
           {canReview && (
             <button

--- a/apps/web/src/pages/LandDetailPage.tsx
+++ b/apps/web/src/pages/LandDetailPage.tsx
@@ -19,8 +19,10 @@ import {
   User,
   Flag,
   Star,
+  CalendarClock,
 } from "lucide-react";
-import { createChat, getLandById, createReport, getOwnerPublicProfile, photoSrc, getRatingByUser } from "../services/api";
+import { createChat, getLandById, createReport, getOwnerPublicProfile, photoSrc, getRatingByUser, createVisit } from "../services/api";
+import VisitModal from "../components/VisitModal";
 import type { ReportReason } from "../services/api";
 import { useFavorites } from "../hooks/useFavorites";
 import "./detail.css";
@@ -92,6 +94,9 @@ export default function LandDetailPage() {
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [owner, setOwner] = useState<PublicOwnerProfileDto | null>(null);
   const [ownerRating, setOwnerRating] = useState<{ averageRating: number; totalReviews: number } | null>(null);
+  // Agendar visita (HU-100 / #326).
+  const [visitOpen, setVisitOpen] = useState(false);
+  const [visitFeedback, setVisitFeedback] = useState("");
 
   // Favoritos (#147): solo consultamos el backend si hay sesión.
   const { isFavorite, toggle: toggleFavorite } = useFavorites({ enabled: Boolean(isSignedIn) });
@@ -269,6 +274,18 @@ export default function LandDetailPage() {
           >
             <Share2 size={17} />
           </button>
+          {/* Agendar visita (HU-100): solo tiene sentido si no soy el dueño. */}
+          {isSignedIn && user?.id !== land.ownerId && (
+            <button
+              type="button"
+              className="det-nav__action"
+              title="Agendar visita"
+              aria-label="Agendar visita"
+              onClick={() => { setVisitFeedback(""); setVisitOpen(true); }}
+            >
+              <CalendarClock size={17} /> Visitar
+            </button>
+          )}
           <button
             type="button"
             className="det-nav__action"
@@ -280,6 +297,23 @@ export default function LandDetailPage() {
           </button>
         </div>
       </nav>
+
+      {visitFeedback && (
+        <p className="det-visit-feedback" role="status" style={{ padding: "0 1rem" }}>
+          {visitFeedback}
+        </p>
+      )}
+
+      {visitOpen && (
+        <VisitModal
+          landTitle={land.title}
+          onClose={() => setVisitOpen(false)}
+          onSubmit={async (proposedDate, proposedTime, message) => {
+            await createVisit(land.id, { proposedDate, proposedTime, message: message || undefined });
+            setVisitFeedback("Solicitud de visita enviada. Puedes seguirla en «Mis Visitas».");
+          }}
+        />
+      )}
 
       {reportOpen && (
         <div className="det-report" role="dialog" aria-modal="true" aria-label="Reportar terreno">

--- a/apps/web/src/pages/VisitsPage.tsx
+++ b/apps/web/src/pages/VisitsPage.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useState } from "react";
+import { useUser } from "@clerk/clerk-react";
+import { CalendarClock, Check, X, RefreshCw } from "lucide-react";
+
+import { listMyVisits, respondToVisit, type VisitDto, type VisitStatus } from "../services/api";
+
+const statusConfig: Record<VisitStatus, { label: string; color: string; bg: string }> = {
+  pending: { label: "Pendiente", color: "#997a00", bg: "rgba(200, 170, 0, 0.15)" },
+  confirmed: { label: "Confirmada", color: "var(--success, #059669)", bg: "rgba(11, 95, 55, 0.12)" },
+  rescheduled: { label: "Reprogramada", color: "var(--river-500)", bg: "rgba(13, 111, 147, 0.12)" },
+  rejected: { label: "Rechazada", color: "var(--danger, #dc2626)", bg: "rgba(180, 40, 40, 0.12)" },
+};
+
+/**
+ * Visitas del usuario (HU-100 / #326). Muestra tanto las que solicité como las
+ * de mis terrenos; en estas últimas puedo confirmar, reprogramar o rechazar.
+ */
+export default function VisitsPage() {
+  const { user } = useUser();
+  const [visits, setVisits] = useState<VisitDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setVisits(await listMyVisits());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudieron cargar las visitas");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    void load();
+  }, [user, load]);
+
+  const respond = async (visit: VisitDto, status: Exclude<VisitStatus, "pending">) => {
+    setBusyId(visit.id);
+    setError("");
+    try {
+      let proposedDate: string | undefined;
+      let proposedTime: string | undefined;
+
+      if (status === "rescheduled") {
+        const date = window.prompt("Nueva fecha (AAAA-MM-DD):", visit.proposedDate);
+        if (!date) return;
+        const time = window.prompt("Nueva hora (HH:MM):", visit.proposedTime);
+        if (!time) return;
+        proposedDate = date;
+        proposedTime = time;
+      }
+
+      const updated = await respondToVisit(visit.id, { status, proposedDate, proposedTime });
+      if (updated) {
+        setVisits((prev) => prev.map((v) => (v.id === updated.id ? updated : v)));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudo actualizar la visita");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const header = (
+    <div className="section-header">
+      <h1>Mis Visitas</h1>
+      <p>Visitas que solicitaste y solicitudes sobre tus terrenos</p>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div>
+        {header}
+        <div className="glass-panel" style={{ marginTop: "1.5rem", textAlign: "center", padding: "3rem" }}>
+          Cargando visitas...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {header}
+
+      {error && (
+        <div className="glass-panel" style={{ marginTop: "1rem", padding: "1rem", color: "var(--danger, #dc2626)" }}>
+          {error}
+        </div>
+      )}
+
+      {visits.length === 0 ? (
+        <div className="glass-panel" style={{ marginTop: "1.5rem", textAlign: "center", padding: "3rem" }}>
+          <CalendarClock size={32} style={{ opacity: 0.5 }} />
+          <p style={{ marginTop: "0.75rem" }}>Todavía no tienes visitas.</p>
+          <p style={{ fontSize: "0.85rem", opacity: 0.7 }}>
+            Puedes solicitar una desde la ficha de cualquier terreno.
+          </p>
+        </div>
+      ) : (
+        <div style={{ marginTop: "1.5rem", display: "grid", gap: "1rem" }}>
+          {visits.map((visit) => {
+            const isOwner = user?.id === visit.ownerId;
+            const cfg = statusConfig[visit.status];
+            return (
+              <div key={visit.id} className="glass-panel" style={{ padding: "1.25rem" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", flexWrap: "wrap" }}>
+                  <div>
+                    <p style={{ margin: 0, fontWeight: 600 }}>
+                      {visit.proposedDate} · {visit.proposedTime}
+                    </p>
+                    <p style={{ margin: "0.25rem 0 0", fontSize: "0.85rem", opacity: 0.75 }}>
+                      {isOwner ? "Solicitud sobre tu terreno" : "Visita que solicitaste"}
+                    </p>
+                    {visit.message && (
+                      <p style={{ margin: "0.5rem 0 0", fontSize: "0.9rem" }}>«{visit.message}»</p>
+                    )}
+                    {visit.responseMessage && (
+                      <p style={{ margin: "0.5rem 0 0", fontSize: "0.85rem", opacity: 0.75 }}>
+                        Respuesta: {visit.responseMessage}
+                      </p>
+                    )}
+                  </div>
+                  <span
+                    style={{
+                      alignSelf: "flex-start", padding: "0.25rem 0.75rem", borderRadius: "999px",
+                      fontSize: "0.8rem", fontWeight: 600, color: cfg.color, background: cfg.bg,
+                    }}
+                  >
+                    {cfg.label}
+                  </span>
+                </div>
+
+                {isOwner && visit.status === "pending" && (
+                  <div style={{ display: "flex", gap: "0.5rem", marginTop: "1rem", flexWrap: "wrap" }}>
+                    <button
+                      type="button"
+                      disabled={busyId === visit.id}
+                      onClick={() => respond(visit, "confirmed")}
+                      style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem", padding: "0.4rem 0.9rem", borderRadius: "8px", cursor: "pointer" }}
+                    >
+                      <Check size={15} /> Confirmar
+                    </button>
+                    <button
+                      type="button"
+                      disabled={busyId === visit.id}
+                      onClick={() => respond(visit, "rescheduled")}
+                      style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem", padding: "0.4rem 0.9rem", borderRadius: "8px", cursor: "pointer" }}
+                    >
+                      <RefreshCw size={15} /> Reprogramar
+                    </button>
+                    <button
+                      type="button"
+                      disabled={busyId === visit.id}
+                      onClick={() => respond(visit, "rejected")}
+                      style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem", padding: "0.4rem 0.9rem", borderRadius: "8px", cursor: "pointer" }}
+                    >
+                      <X size={15} /> Rechazar
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/dashboard.visits.tsx
+++ b/apps/web/src/routes/dashboard.visits.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "../components/route-guards";
+import UserDashboardLayout from "../components/UserDashboardLayout";
+import VisitsPage from "../pages/VisitsPage";
+
+export const Route = createFileRoute("/dashboard/visits")({
+  component: () => (
+    <ProtectedRoute><UserDashboardLayout><VisitsPage /></UserDashboardLayout></ProtectedRoute>
+  ),
+});

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -491,6 +491,82 @@ export const deleteSavedSearch = async (id: string): Promise<boolean> => {
   return res?.ok ?? false;
 };
 
+// ─── Visitas (HU-100 / #326) ────────────────────────────────────────────────
+
+export type VisitStatus = "pending" | "confirmed" | "rescheduled" | "rejected";
+
+export interface VisitDto {
+  id: string;
+  landId: string;
+  tenantId: string;
+  ownerId: string;
+  proposedDate: string;
+  proposedTime: string;
+  message?: string;
+  status: VisitStatus;
+  responseMessage?: string;
+  createdAt: string;
+}
+
+/** POST /api/v1/lands/:landId/visits — solicitar una visita a un terreno. */
+export const createVisit = async (
+  landId: string,
+  input: { proposedDate: string; proposedTime: string; message?: string },
+): Promise<VisitDto | null> => {
+  const res = await request<VisitDto>("POST", `/api/v1/lands/${landId}/visits`, input);
+  return res?.data ?? null;
+};
+
+/** GET /api/v1/users/me/visits — visitas donde participo (como dueño o interesado). */
+export const listMyVisits = async (): Promise<VisitDto[]> => {
+  const res = await request<VisitDto[]>("GET", "/api/v1/users/me/visits");
+  return res?.data ?? [];
+};
+
+/** PATCH /api/v1/visits/:id — el dueño confirma, reprograma o rechaza. */
+export const respondToVisit = async (
+  visitId: string,
+  input: {
+    status: Exclude<VisitStatus, "pending">;
+    responseMessage?: string;
+    proposedDate?: string;
+    proposedTime?: string;
+  },
+): Promise<VisitDto | null> => {
+  const res = await request<VisitDto>("PATCH", `/api/v1/visits/${visitId}`, input);
+  return res?.data ?? null;
+};
+
+// ─── Contrato en PDF (HU-101 / #327) ────────────────────────────────────────
+
+/**
+ * GET /api/v1/contracts/:id/pdf — descarga el contrato. El endpoint exige
+ * autenticación y devuelve binario, así que no pasa por `request` (que asume
+ * JSON): se pide el blob con las mismas cabeceras y se dispara la descarga.
+ */
+export const downloadContractPdf = async (contractId: string): Promise<void> => {
+  const headers = await buildHeaders();
+  delete headers["Content-Type"];
+
+  const res = await fetch(`${BASE_URL}/api/v1/contracts/${contractId}/pdf`, { headers });
+  if (!res.ok) {
+    throw new Error("No se pudo descargar el contrato");
+  }
+
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `contrato-${contractId}.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};
+
 export const api = {
   listLands,
   getMyLands,
@@ -518,4 +594,8 @@ export const api = {
   createSavedSearch,
   listSavedSearches,
   deleteSavedSearch,
+  createVisit,
+  listMyVisits,
+  respondToVisit,
+  downloadContractPdf,
 };


### PR DESCRIPTION
## Qué hace

HU-100 (visitas) y HU-101 (PDF) se mergearon en #349 **solo con backend**. Este PR añade la interfaz que faltaba para que sean usables.

## HU-100 — Agendar visita
- **`VisitModal`**: propone fecha, hora y mensaje desde la ficha del terreno. El botón «Visitar» solo aparece si hay sesión y no eres el dueño.
- **`/dashboard/visits`**: lista las visitas que solicité y las de mis terrenos. Como dueño puedo **confirmar**, **reprogramar** (pide nueva fecha/hora) o **rechazar**; el estado se muestra con su color.
- Enlace **«Visitas»** en la navegación del dashboard.

## HU-101 — Exportar contrato a PDF
- Botón **«Descargar PDF»** en el detalle del contrato. El endpoint exige auth y devuelve binario, así que la descarga va por `blob` reutilizando las cabeceras de sesión (no pasa por el helper `request`, que asume JSON).

## Cliente de API
`createVisit`, `listMyVisits`, `respondToVisit`, `downloadContractPdf`.

## Pruebas

**Verificado contra el backend en marcha** (flujo real, no solo unitario):

| Caso | Resultado |
|---|---|
| Arrendatario solicita visita | 201, visita creada |
| Dueño intenta visitar su propio terreno | **403** |
| Estado inválido (`"hackeado"`) | **400** — confirma el fix del enum de #349 |
| Tercero intenta responder | **403** |
| Dueño confirma | `status: "confirmed"` |
| Descarga PDF (dueño) | 200, `application/pdf`, cabecera `%PDF-` |
| Descarga PDF (no-parte / inexistente) | **403** / **404** |

Además: **web typecheck limpio**, **build OK**, ruta `/dashboard/visits` registrada en el árbol generado y **sin errores de consola**.

> Nota: las páginas del dashboard están tras `ProtectedRoute` (Clerk), así que la verificación visual con sesión real queda para una revisión manual; lo verificable sin sesión (build, rutas, consola, API E2E) está cubierto.

Closes #350.
