### PR TITLE
fix(backend): unificar el centro de notificaciones (memoria vs Mongo)

### DIFF
--- a/apps/backend-api/src/routes/notifications.test.ts
+++ b/apps/backend-api/src/routes/notifications.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 
 import { requestJson } from "../lib/http-test-utils";
+import { Notification } from "../db/schemas";
 
 describe("notifications routes", () => {
   it("responds 200 with an empty list when the user has no notifications", async () => {
@@ -18,5 +19,89 @@ describe("notifications routes", () => {
     const { response } = await requestJson("/api/v1/notifications");
 
     expect(response.status).toBe(401);
+  });
+});
+
+/**
+ * Las notificaciones reales se persisten en Mongo (alertas de búsquedas
+ * guardadas y acciones sensibles del MCP). Antes estas rutas leían del store en
+ * memoria y esas notificaciones nunca llegaban al usuario.
+ *
+ * Se siembran en `beforeEach` (escritura) y los tests solo leen por HTTP.
+ */
+describe("notifications persistidas en Mongo (#350)", () => {
+  const owner = "notif_user_01";
+  const other = "notif_user_02";
+
+  beforeEach(async () => {
+    await Notification.create({
+      id: "ntf_test_01",
+      userId: owner,
+      type: "saved_search_match",
+      title: "Nuevo terreno coincide con tu busqueda",
+      body: "Un terreno nuevo encaja con tus filtros.",
+      read: false,
+    });
+  });
+
+  it("lista las notificaciones creadas en Mongo", async () => {
+    const { response, payload } = await requestJson("/api/v1/notifications", {
+      headers: { "x-dev-user-id": owner },
+    });
+
+    expect(response.status).toBe(200);
+    expect(payload.data).toHaveLength(1);
+    expect(payload.data[0].id).toBe("ntf_test_01");
+    expect(payload.data[0].type).toBe("saved_search_match");
+    // No debe filtrar los campos internos de Mongo.
+    expect(payload.data[0]._id).toBeUndefined();
+  });
+
+  it("no muestra las notificaciones de otro usuario", async () => {
+    const { payload } = await requestJson("/api/v1/notifications", {
+      headers: { "x-dev-user-id": other },
+    });
+    expect(payload.data).toHaveLength(0);
+  });
+
+  it("devuelve el detalle de una notificación propia", async () => {
+    const { response, payload } = await requestJson("/api/v1/notifications/ntf_test_01", {
+      headers: { "x-dev-user-id": owner },
+    });
+    expect(response.status).toBe(200);
+    expect(payload.data.title).toContain("Nuevo terreno");
+  });
+
+  it("bloquea el detalle de una notificación ajena", async () => {
+    const { response } = await requestJson("/api/v1/notifications/ntf_test_01", {
+      headers: { "x-dev-user-id": other },
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("marca una notificación como leída", async () => {
+    const { response, payload } = await requestJson("/api/v1/notifications/ntf_test_01/read", {
+      method: "PATCH",
+      headers: { "x-dev-user-id": owner },
+    });
+
+    expect(response.status).toBe(200);
+    expect(payload.data.read).toBe(true);
+    expect(payload.data.readAt).toBeTruthy();
+  });
+
+  it("no deja marcar como leída una notificación ajena", async () => {
+    const { response } = await requestJson("/api/v1/notifications/ntf_test_01/read", {
+      method: "PATCH",
+      headers: { "x-dev-user-id": other },
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("devuelve 404 si la notificación no existe", async () => {
+    const { response } = await requestJson("/api/v1/notifications/ntf_inexistente", {
+      headers: { "x-dev-user-id": owner },
+    });
+    expect(response.status).toBe(404);
   });
 });

--- a/apps/backend-api/src/routes/notifications.ts
+++ b/apps/backend-api/src/routes/notifications.ts
@@ -3,58 +3,74 @@ import { Hono } from "hono";
 import { failure, success } from "../lib/api-response";
 import { canReadNotification } from "../lib/auth-helpers";
 import { requireAuth } from "../middleware/require-auth";
-import { getStore } from "../store/in-memory-db";
+import { Notification } from "../db/schemas";
 import type { AppEnv } from "../types";
 
 export const notificationRoutes = new Hono<AppEnv>();
 
-// TODO(#136): notifications currently live only in the in-memory store and no
-// flow creates them yet, so this returns an empty list until a later feature
-// generates notifications (e.g. on rental-request status changes). Do not seed
-// fake data here.
-notificationRoutes.get("/notifications", requireAuth, (c) => {
+/**
+ * Centro de notificaciones. Lee y escribe sobre el modelo `Notification` de
+ * Mongo, que es donde las generan realmente los flujos del producto: alertas de
+ * búsquedas guardadas (HU-99) y las acciones sensibles del servidor MCP (#328).
+ *
+ * Antes estas rutas leían del store en memoria, que nadie alimentaba, así que
+ * todas esas notificaciones quedaban invisibles para el usuario.
+ */
+
+/** Quita los campos internos de Mongo de un documento `lean`. */
+function clean<T>(doc: Record<string, unknown> | null | undefined): T | undefined {
+  if (!doc) return undefined;
+  const { _id, __v, ...rest } = doc;
+  return rest as T;
+}
+
+notificationRoutes.get("/notifications", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
 
-  const items = Array.from(store.notifications.values())
-    .filter((n) => n.userId === authUser.id)
-    .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+  const docs = (await Notification.find({ userId: authUser.id })
+    .sort({ createdAt: -1 })
+    .lean()) as unknown as Record<string, unknown>[];
 
-  return success(c, items);
+  return success(c, docs.map((d) => clean(d)));
 });
 
-notificationRoutes.get("/notifications/:notificationId", requireAuth, (c) => {
+notificationRoutes.get("/notifications/:notificationId", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const notification = store.notifications.get(c.req.param("notificationId"));
 
-  if (!notification) {
+  const doc = (await Notification.findOne({ id: c.req.param("notificationId") })
+    .lean()) as Record<string, unknown> | null;
+  if (!doc) {
     return failure(c, 404, "NOT_FOUND", "Notification not found");
   }
 
-  if (!canReadNotification(authUser, notification)) {
+  if (!canReadNotification(authUser, doc as unknown as { userId: string })) {
     return failure(c, 403, "FORBIDDEN", "Not allowed to access this notification");
   }
 
-  return success(c, notification);
+  return success(c, clean(doc));
 });
 
-notificationRoutes.patch("/notifications/:notificationId/read", requireAuth, (c) => {
+notificationRoutes.patch("/notifications/:notificationId/read", requireAuth, async (c) => {
   const authUser = c.get("authUser");
-  const store = getStore();
-  const notification = store.notifications.get(c.req.param("notificationId"));
+  const notificationId = c.req.param("notificationId");
 
-  if (!notification) {
+  const doc = (await Notification.findOne({ id: notificationId })
+    .lean()) as Record<string, unknown> | null;
+  if (!doc) {
     return failure(c, 404, "NOT_FOUND", "Notification not found");
   }
 
-  if (!canReadNotification(authUser, notification)) {
+  if (!canReadNotification(authUser, doc as unknown as { userId: string })) {
     return failure(c, 403, "FORBIDDEN", "Not allowed to access this notification");
   }
 
-  notification.read = true;
-  notification.readAt = new Date().toISOString();
-  store.notifications.set(notification.id, notification);
+  await Notification.updateOne(
+    { id: notificationId },
+    { $set: { read: true, readAt: new Date().toISOString() } },
+  );
 
-  return success(c, notification);
+  const updated = (await Notification.findOne({ id: notificationId })
+    .lean()) as Record<string, unknown> | null;
+
+  return success(c, clean(updated));
 });

--- a/apps/backend-api/src/routes/saved-searches.test.ts
+++ b/apps/backend-api/src/routes/saved-searches.test.ts
@@ -101,12 +101,16 @@ describe("saved-search alerts (#325)", () => {
   }
 
   /**
-   * Las alertas se persisten en el modelo `Notification` de Mongo. Nota: hoy
-   * `GET /notifications` lee del store en memoria, así que se consulta el modelo
-   * directamente (ver follow-up de unificación del centro de notificaciones).
+   * Cuenta las alertas tal y como las ve el usuario: a través del centro de
+   * notificaciones (`GET /notifications`), que desde #350 lee de Mongo. Así se
+   * verifica el camino completo: la alerta se genera y llega al usuario.
    */
   async function notifCount(userId: string = seeker): Promise<number> {
-    return Notification.countDocuments({ userId, type: "saved_search_match" });
+    const res = await requestJson("/api/v1/notifications", {
+      headers: { "x-dev-user-id": userId },
+    });
+    const items = (res.payload?.data ?? []) as { type: string }[];
+    return items.filter((n) => n.type === "saved_search_match").length;
   }
 
   it("no alerta mientras el terreno sigue en borrador, y alerta al publicarlo", async () => {

--- a/apps/backend-api/src/test-preload.ts
+++ b/apps/backend-api/src/test-preload.ts
@@ -24,6 +24,9 @@ function fixtures(): Record<string, Record<string, unknown>[]> {
     chats: [...store.chats.values()],
     chatmessages: [...store.chatMessages.values()].flat(),
     auditevents: [...store.auditEvents.values()],
+    // Incluida aunque el store no la siembre: así la colección se vacía entre
+    // tests y las notificaciones que crea un test no se filtran al siguiente.
+    notifications: [...store.notifications.values()],
   } as unknown as Record<string, Record<string, unknown>[]>;
 }
 


### PR DESCRIPTION
## Qué hace

El centro de notificaciones estaba **partido en dos**, y el efecto real era que **el usuario no veía ninguna notificación**:

- Las rutas (`GET /notifications`, detalle, marcar-leída) leían del **store en memoria**, que ningún flujo alimenta — había hasta un `TODO(#136)` admitiéndolo.
- Las notificaciones reales se escriben en **Mongo**: alertas de búsquedas guardadas (HU-99) y las acciones sensibles del MCP (#328 — reembolso, bloqueo de cuenta, moderación, firma, retiro de terreno).

Este PR las unifica en Mongo, que es la fuente que ya usan las tools del MCP.

## Cambios

- **`routes/notifications.ts`** → listar, detalle y marcar-leída sobre el modelo `Notification`. Se mantiene `canReadNotification` y se limpian los campos internos (`_id`, `__v`).
- **`test-preload.ts`** → la colección `notifications` entra en las fixtures para vaciarse entre tests. Antes no se limpiaba nunca y las notificaciones de un test se filtraban al siguiente.

## Pruebas

- **7 tests nuevos**: listar, no ver las de otro usuario, detalle, detalle ajeno → **403**, marcar leída, marcar ajena → **403**, inexistente → **404**.
- El test de alertas de búsquedas guardadas ahora verifica **por la API REST** en vez de consultar el modelo: comprueba el camino completo (la alerta se genera → el usuario la ve).
- **Backend 338 pass · MCP 294 pass · web typecheck y build OK.**

Closes #352.
