### PR TITLE
fix(web): la app nunca hidrataba — createRoot sobre un #root inexistente

### DIFF
--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -1,18 +1,34 @@
 import { StrictMode, startTransition } from "react";
-import { hydrateRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { RouterProvider } from "@tanstack/react-router";
 import { StartClient } from "@tanstack/react-start/client";
+import { getRouter } from "./router";
 
-// Entrada del cliente de TanStack Start.
+// La app arranca en dos modos distintos y el montaje NO es el mismo en ambos:
 //
-// El servidor emite el documento completo desde `__root.tsx` (<html>…<body>), así
-// que la hidratación va sobre `document`: no existe ningún contenedor `#root`.
-// Antes se montaba con `createRoot(document.getElementById("root"))`, que era
-// `null`, y la app NUNCA hidrataba — sin hidratación no corre nada del cliente
-// (ni Clerk ni los manejadores de eventos), aunque el HTML del servidor se viera.
+// - Producción: se despliega como SPA client-only. `scripts/serve-static.mjs`
+//   (y el Dockerfile) generan un `index.html` con `<div id="root">`, así que se
+//   monta ahí con `createRoot`. Es también lo que prueban los E2E.
 //
-// `StartClient` reconstruye el router con los datos de hidratación que envía el
-// servidor; crear uno aparte con `getRouter()` se saltaba ese protocolo.
+// - Desarrollo (`bun run dev`): TanStack Start hace SSR y `__root.tsx` emite el
+//   documento completo (<html>…<body>). Ahí NO existe `#root`, y montar sobre
+//   él dejaba `createRoot(null)` → "Target container is not a DOM element". La
+//   app nunca hidrataba: el HTML se veía, pero nada del cliente corría (ni
+//   Clerk ni los manejadores de eventos), así que era imposible iniciar sesión.
+//   Para ese caso se hidrata el documento con `StartClient`, que reconstruye el
+//   router con los datos de hidratación del servidor.
 startTransition(() => {
+  const container = document.getElementById("root");
+
+  if (container) {
+    createRoot(container).render(
+      <StrictMode>
+        <RouterProvider router={getRouter()} />
+      </StrictMode>,
+    );
+    return;
+  }
+
   hydrateRoot(
     document,
     <StrictMode>

--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -1,13 +1,22 @@
 import { StrictMode, startTransition } from "react";
-import { createRoot } from "react-dom/client";
-import { RouterProvider } from "@tanstack/react-router";
-import { getRouter } from "./router";
+import { hydrateRoot } from "react-dom/client";
+import { StartClient } from "@tanstack/react-start/client";
 
+// Entrada del cliente de TanStack Start.
+//
+// El servidor emite el documento completo desde `__root.tsx` (<html>…<body>), así
+// que la hidratación va sobre `document`: no existe ningún contenedor `#root`.
+// Antes se montaba con `createRoot(document.getElementById("root"))`, que era
+// `null`, y la app NUNCA hidrataba — sin hidratación no corre nada del cliente
+// (ni Clerk ni los manejadores de eventos), aunque el HTML del servidor se viera.
+//
+// `StartClient` reconstruye el router con los datos de hidratación que envía el
+// servidor; crear uno aparte con `getRouter()` se saltaba ese protocolo.
 startTransition(() => {
-  const router = getRouter();
-  createRoot(document.getElementById("root")!).render(
+  hydrateRoot(
+    document,
     <StrictMode>
-      <RouterProvider router={router} />
+      <StartClient />
     </StrictMode>,
   );
 });

--- a/apps/web/src/routes/dashboard.contracts.index.tsx
+++ b/apps/web/src/routes/dashboard.contracts.index.tsx
@@ -3,7 +3,7 @@ import { ProtectedRoute } from "../components/route-guards";
 import UserDashboardLayout from "../components/UserDashboardLayout";
 import ContractsPage from "../pages/ContractsPage";
 
-export const Route = createFileRoute("/dashboard/contracts")({
+export const Route = createFileRoute("/dashboard/contracts/")({
   component: () => (
     <ProtectedRoute><UserDashboardLayout><ContractsPage /></UserDashboardLayout></ProtectedRoute>
   ),


### PR DESCRIPTION
## Qué pasaba

**En desarrollo (`bun run dev`) la app no era interactiva.** El HTML del servidor se veía bien, pero React **nunca hidrataba**: ningún clic ni formulario funcionaba y **era imposible iniciar sesión**.

`client.tsx` montaba siempre así:

```ts
createRoot(document.getElementById("root")!)
```

En dev, TanStack Start hace SSR y `__root.tsx` emite el documento completo (`<html>…<body>`): **ahí no hay ningún `#root`**, así que `getElementById` devolvía `null` y React moría con `Target container is not a DOM element`. Como nada del cliente corría, **Clerk no se inicializaba** y toda ruta protegida quedaba en «Cargando…» para siempre.

> **Producción NO estaba rota.** Se despliega como SPA client-only: `scripts/serve-static.mjs` y el Dockerfile generan un `index.html` con `<div id="root">`, donde `createRoot(#root)` es lo correcto — y es justo lo que ejercitan los E2E (`preview:static`). Mi primer intento hidrataba el documento siempre, lo cual **rompía producción** (32 E2E en rojo); este PR ya lleva la corrección.

## Solución

Detectar el contenedor y montar según el modo:

- Hay `#root` → **SPA de producción**: `createRoot`.
- No hay → **dev con SSR**: `hydrateRoot(document, <StartClient/>)`, que reconstruye el router con los datos de hidratación del servidor.

También: **`dashboard.contracts.tsx` → `dashboard.contracts.index.tsx`**. Como ruta *padre* sin `<Outlet/>` se tragaba a `dashboard.contracts.$id`, dejando **el detalle de contrato inalcanzable**. (`dashboard.admin.reports` ya lo hacía bien con `.index`.)

## Por qué no se detectó antes

Los E2E prueban el build de producción, que funcionaba. Nadie prueba el modo dev automáticamente, y los smoke tests solo verifican contenido renderizado en servidor — ninguno comprueba interactividad real.

## Verificación

**Producción (E2E local, `preview:static`):** 12/12 en 22 s.

**Dev, en Chrome con sesión de Clerk real:**

| Comprobación | Resultado |
|---|---|
| Login con Clerk | ✅ el widget por fin es interactivo |
| `/dashboard/visits` | ✅ vacío y con listado |
| «Visitar» + modal | ✅ valida fecha/hora; oculto para el dueño |
| Alta de visita end-to-end | ✅ «Pendiente» → «Confirmada» con respuesta del dueño |
| Detalle de contrato | ✅ ahora alcanzable |
| «Descargar PDF» | ✅ 200, `application/pdf`, `%PDF-` |
| Notificaciones | ✅ muestra «Visita confirmada» (antes siempre vacío) |

Typecheck y build del web en verde.

Closes #354.
