### PR TITLE
feat(backend): seed de datos de demostración coherente y ligado a Clerk (#356)

### DIFF
--- a/apps/backend-api/README.md
+++ b/apps/backend-api/README.md
@@ -101,7 +101,32 @@ bun install
 bun run dev
 bun run build
 bun run test  # unit tests del store y routes
+bun run migrate
+bun run seed:demo  # datos de demostración (BORRA y repuebla)
 ```
+
+### Datos de demostración
+
+`bun run seed:demo` deja la base con un juego de datos **coherente** para
+recorrer la app: terrenos con fotos, solicitudes en los siete estados,
+contratos en los cuatro, pagos (incluidos reembolsos), chats con conversación,
+favoritos, reportes, reseñas, búsquedas guardadas, visitas y notificaciones.
+
+Todo cuelga de cuentas reales de Clerk, porque las rutas filtran por
+`authUser.id`, que *es* el id de Clerk: sin eso una sesión real no ve nada
+suyo. La cuenta principal aparece a la vez como **dueña** (los terrenos
+`land_me_*`) y como **arrendataria** (solicitudes sobre los de Alice), para
+que las dos caras del producto tengan datos en la misma sesión.
+
+Para sembrar contra otra cuenta, sin tocar el código:
+
+```bash
+SEED_MAIN_CLERK_ID=user_xxxxxxxx bun run seed:demo
+```
+
+El script aplica las migraciones pendientes antes de escribir y borra las
+colecciones de negocio (no `_migrations`). Se niega a correr con
+`NODE_ENV=production` salvo `--force`.
 
 ## Testing y CI
 

--- a/apps/backend-api/package.json
+++ b/apps/backend-api/package.json
@@ -9,6 +9,7 @@
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "migrate": "bun scripts/migrate.ts",
+    "seed:demo": "bun scripts/seed-demo.ts",
     "backup": "bun scripts/backup.ts",
     "test": "bun test"
   },

--- a/apps/backend-api/scripts/seed-demo.ts
+++ b/apps/backend-api/scripts/seed-demo.ts
@@ -1,0 +1,54 @@
+/**
+ * Puebla la base de desarrollo con el juego de datos de demostración (#356).
+ *
+ *   bun run seed:demo
+ *   SEED_MAIN_CLERK_ID=user_xxx bun run seed:demo   # sembrar contra otra cuenta
+ *
+ * BORRA las colecciones de negocio antes de escribir. Se niega a ejecutarse con
+ * NODE_ENV=production salvo que se pase --force, para que un despiste no vacíe
+ * una base real.
+ */
+import mongoose from "mongoose";
+
+import { connectMongoose } from "../src/db/mongoose";
+import { seedDemoDatabase } from "../src/db/seed-demo";
+import { migrateUp } from "../src/lib/migrator";
+
+const force = process.argv.includes("--force");
+
+if (process.env.NODE_ENV === "production" && !force) {
+  console.error("[seed-demo] Abortado: NODE_ENV=production. Usa --force si de verdad quieres borrar y repoblar.");
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  await connectMongoose();
+  console.log(`[seed-demo] Conectado a ${mongoose.connection.name}`);
+
+  // Los índices deben estar al día ANTES de escribir: si queda alguno obsoleto
+  // (como el `users.id_1` que retiró la migración 002) la inserción revienta.
+  const applied = await migrateUp(mongoose.connection.db!);
+  if (applied.length > 0) {
+    console.log(`[seed-demo] Migraciones aplicadas: ${applied.join(", ")}`);
+  }
+
+  const result = await seedDemoDatabase();
+
+  if (result.droppedGhostCollections.length > 0) {
+    console.log(`[seed-demo] Colecciones fantasma eliminadas: ${result.droppedGhostCollections.join(", ")}`);
+  }
+
+  console.log("[seed-demo] Documentos insertados:");
+  for (const [name, count] of Object.entries(result.counts)) {
+    console.log(`  ${name.padEnd(16)} ${count}`);
+  }
+
+  await mongoose.disconnect();
+  console.log("[seed-demo] Listo.");
+}
+
+main().catch(async (error) => {
+  console.error("[seed-demo] Falló:", error);
+  await mongoose.disconnect().catch(() => {});
+  process.exit(1);
+});

--- a/apps/backend-api/src/db/seed-demo.test.ts
+++ b/apps/backend-api/src/db/seed-demo.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildDemoData } from "./seed-demo";
+
+/**
+ * El valor del seed de demostración está en la **coherencia** del grafo: si un
+ * contrato apunta a un dueño que no es el del terreno, la app muestra datos que
+ * ningún flujo real podría producir y deja de servir para depurar pantallas
+ * vacías. Estas pruebas fijan esas invariantes sobre la estructura generada
+ * (`buildDemoData` es pura: no toca Mongo).
+ */
+
+const data = buildDemoData();
+
+const landById = new Map(data.lands.map((l) => [l.id as string, l]));
+const requestById = new Map(data.requests.map((r) => [r.id as string, r]));
+const contractById = new Map(data.contracts.map((c) => [c.id as string, c]));
+const userIds = new Set(data.users.map((u) => u.clerkUserId as string));
+
+describe("seed de demostración — integridad referencial", () => {
+  it("todos los terrenos pertenecen a un usuario sembrado", () => {
+    for (const land of data.lands) {
+      expect(userIds.has(land.ownerId as string)).toBe(true);
+    }
+  });
+
+  it("cada solicitud apunta a un terreno y a un solicitante existentes", () => {
+    for (const req of data.requests) {
+      expect(landById.has(req.landId as string)).toBe(true);
+      expect(userIds.has(req.tenantId as string)).toBe(true);
+    }
+  });
+
+  it("nadie se solicita su propio terreno", () => {
+    for (const req of data.requests) {
+      const land = landById.get(req.landId as string)!;
+      expect(req.tenantId).not.toBe(land.ownerId);
+    }
+  });
+
+  it("el dueño y el solicitante de cada contrato salen de su solicitud y su terreno", () => {
+    for (const contract of data.contracts) {
+      const req = requestById.get(contract.rentalRequestId as string);
+      expect(req).toBeDefined();
+      const land = landById.get(req!.landId as string)!;
+      expect(contract.ownerId).toBe(land.ownerId);
+      expect(contract.tenantId).toBe(req!.tenantId);
+    }
+  });
+
+  it("cada pago cuelga de una solicitud existente y, si tiene contrato, de uno real", () => {
+    for (const payment of data.payments) {
+      expect(requestById.has(payment.rentalRequestId as string)).toBe(true);
+      if (payment.contractId) {
+        const contract = contractById.get(payment.contractId as string)!;
+        expect(contract).toBeDefined();
+        // El pago y su contrato deben referirse a la misma solicitud.
+        expect(contract.rentalRequestId).toBe(payment.rentalRequestId);
+      }
+    }
+  });
+
+  it("los participantes de cada chat son el dueño del terreno y el solicitante", () => {
+    for (const chat of data.chats) {
+      const land = landById.get(chat.landId as string)!;
+      const req = requestById.get(chat.rentalRequestId as string)!;
+      const participants = chat.participants as { userId: string; role: string }[];
+      const owner = participants.find((p) => p.role === "owner")!;
+      const tenant = participants.find((p) => p.role === "tenant")!;
+      expect(owner.userId).toBe(land.ownerId as string);
+      expect(tenant.userId).toBe(req.tenantId as string);
+    }
+  });
+
+  it("cada mensaje pertenece a un chat y lo escribe uno de sus participantes", () => {
+    const chatById = new Map(data.chats.map((c) => [c.id as string, c]));
+    for (const msg of data.messages) {
+      const chat = chatById.get(msg.chatId as string);
+      expect(chat).toBeDefined();
+      const participantIds = (chat!.participants as { userId: string }[]).map((p) => p.userId);
+      expect(participantIds).toContain(msg.senderId as string);
+    }
+  });
+
+  it("las reseñas cuelgan de contratos reales, entre sus dos partes y sin autorreseñas", () => {
+    for (const review of data.reviews) {
+      const contract = contractById.get(review.contractId as string);
+      expect(contract).toBeDefined();
+      expect(review.senderId).not.toBe(review.receiverId);
+      const parties = [contract!.ownerId, contract!.tenantId];
+      expect(parties).toContain(review.senderId as string);
+      expect(parties).toContain(review.receiverId as string);
+      expect(review.rating as number).toBeGreaterThanOrEqual(1);
+      expect(review.rating as number).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("no hay dos reseñas del mismo autor sobre el mismo contrato (índice único)", () => {
+    const keys = data.reviews.map((r) => `${r.contractId}|${r.senderId}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("cada visita enlaza un terreno con su dueño real y un solicitante distinto", () => {
+    for (const visit of data.visits) {
+      const land = landById.get(visit.landId as string)!;
+      expect(land).toBeDefined();
+      expect(visit.ownerId).toBe(land.ownerId as string);
+      expect(visit.tenantId).not.toBe(visit.ownerId);
+    }
+  });
+
+  it("los favoritos son de terrenos ajenos y no se repiten (índice único)", () => {
+    for (const fav of data.favorites) {
+      const land = landById.get(fav.landId as string)!;
+      expect(land).toBeDefined();
+      expect(fav.userId).not.toBe(land.ownerId);
+    }
+    const keys = data.favorites.map((f) => `${f.userId}|${f.landId}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("los reportes apuntan a entidades existentes del tipo que declaran", () => {
+    const chatIds = new Set(data.chats.map((c) => c.id as string));
+    for (const report of data.reports) {
+      const target = report.targetId as string;
+      if (report.targetType === "land") expect(landById.has(target)).toBe(true);
+      if (report.targetType === "user") expect(userIds.has(target)).toBe(true);
+      if (report.targetType === "chat") expect(chatIds.has(target)).toBe(true);
+    }
+  });
+
+  it("los identificadores son únicos en cada colección", () => {
+    const withIds: [string, Record<string, unknown>[]][] = [
+      ["lands", data.lands], ["requests", data.requests], ["contracts", data.contracts],
+      ["payments", data.payments], ["chats", data.chats], ["messages", data.messages],
+      ["reports", data.reports], ["reviews", data.reviews], ["savedSearches", data.savedSearches],
+      ["visits", data.visits], ["notifications", data.notifications],
+      ["auditEvents", data.auditEvents], ["leads", data.leads],
+    ];
+    for (const [name, docs] of withIds) {
+      const ids = docs.map((d) => d.id as string);
+      expect(`${name}:${new Set(ids).size}`).toBe(`${name}:${ids.length}`);
+    }
+    const clerkIds = data.users.map((u) => u.clerkUserId as string);
+    expect(new Set(clerkIds).size).toBe(clerkIds.length);
+  });
+});
+
+describe("seed de demostración — cobertura de estados", () => {
+  const distinct = (docs: Record<string, unknown>[], field: string) =>
+    new Set(docs.map((d) => d[field] as string));
+
+  it("cubre los siete estados de solicitud", () => {
+    const statuses = distinct(data.requests, "status");
+    for (const s of ["draft", "pending_owner", "approved", "rejected", "cancelled", "pending_payment", "paid"]) {
+      expect([...statuses]).toContain(s);
+    }
+  });
+
+  it("cubre los cuatro estados de contrato", () => {
+    const statuses = distinct(data.contracts, "status");
+    for (const s of ["draft", "active", "completed", "cancelled"]) {
+      expect([...statuses]).toContain(s);
+    }
+  });
+
+  it("cubre los estados de pago relevantes, incluidos los reembolsos", () => {
+    const statuses = distinct(data.payments, "status");
+    for (const s of ["pending", "processing", "paid", "failed", "cancelled", "refunded", "partially_refunded"]) {
+      expect([...statuses]).toContain(s);
+    }
+  });
+
+  it("cubre los cuatro estados de visita", () => {
+    const statuses = distinct(data.visits, "status");
+    for (const s of ["pending", "confirmed", "rescheduled", "rejected"]) {
+      expect([...statuses]).toContain(s);
+    }
+  });
+
+  it("cubre los cuatro estados de reporte", () => {
+    const statuses = distinct(data.reports, "status");
+    for (const s of ["open", "reviewing", "resolved", "dismissed"]) {
+      expect([...statuses]).toContain(s);
+    }
+  });
+
+  it("cubre los tres estados de publicación de terreno", () => {
+    const statuses = distinct(data.lands, "status");
+    for (const s of ["draft", "active", "inactive"]) {
+      expect([...statuses]).toContain(s);
+    }
+  });
+
+  it("hay terrenos de alquiler, de venta y de ambas operaciones", () => {
+    const operations = distinct(data.lands, "operation");
+    for (const o of ["alquiler", "venta", "ambas"]) {
+      expect([...operations]).toContain(o);
+    }
+  });
+});
+
+describe("seed de demostración — la cuenta principal juega los dos papeles", () => {
+  const MAIN = process.env.SEED_MAIN_CLERK_ID || "user_3G7OsFKNNfMXJ85lEbqEwqZJvQi";
+
+  it("es dueña de varios terrenos publicados", () => {
+    const own = data.lands.filter((l) => l.ownerId === MAIN);
+    expect(own.length).toBeGreaterThanOrEqual(4);
+    expect(own.some((l) => l.status === "active")).toBe(true);
+  });
+
+  it("es solicitante en varias solicitudes y recibe otras tantas", () => {
+    const asTenant = data.requests.filter((r) => r.tenantId === MAIN);
+    const ownLandIds = new Set(data.lands.filter((l) => l.ownerId === MAIN).map((l) => l.id as string));
+    const asOwner = data.requests.filter((r) => ownLandIds.has(r.landId as string));
+    expect(asTenant.length).toBeGreaterThanOrEqual(3);
+    expect(asOwner.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("participa en contratos por ambos lados", () => {
+    expect(data.contracts.some((c) => c.tenantId === MAIN)).toBe(true);
+    expect(data.contracts.some((c) => c.ownerId === MAIN)).toBe(true);
+  });
+
+  it("tiene visitas propuestas y visitas recibidas", () => {
+    expect(data.visits.some((v) => v.tenantId === MAIN)).toBe(true);
+    expect(data.visits.some((v) => v.ownerId === MAIN)).toBe(true);
+  });
+
+  it("tiene favoritos, búsquedas guardadas y notificaciones sin leer", () => {
+    expect(data.favorites.filter((f) => f.userId === MAIN).length).toBeGreaterThan(0);
+    expect(data.savedSearches.filter((s) => s.userId === MAIN).length).toBeGreaterThan(0);
+    expect(data.notifications.filter((n) => n.userId === MAIN && n.read === false).length).toBeGreaterThan(0);
+  });
+
+  it("ha recibido reseñas, para que su perfil público muestre calificación", () => {
+    expect(data.reviews.filter((r) => r.receiverId === MAIN).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/backend-api/src/db/seed-demo.ts
+++ b/apps/backend-api/src/db/seed-demo.ts
@@ -1,0 +1,1068 @@
+/**
+ * Seed de demostración (#356): puebla la base con un grafo **coherente** de
+ * datos, ligado a cuentas reales de Clerk.
+ *
+ * Se diferencia del seed de arranque (`seed.ts`, que genera volumen aleatorio)
+ * en tres cosas:
+ *
+ * 1. **Actores reales.** Todo cuelga de los `clerkUserId` de las cuentas con
+ *    las que se prueba la app. Las rutas filtran por `authUser.id`, que *es* el
+ *    id de Clerk, así que sin esto una sesión real no ve nada suyo.
+ * 2. **Coherencia.** Los tratos se declaran de arriba abajo (terreno → solicitud
+ *    → contrato → pago → chat → reseña), de modo que el `ownerId` de un contrato
+ *    siempre es el dueño del terreno de su solicitud y un pago siempre cuelga de
+ *    una solicitud que llegó a cobrarse.
+ * 3. **Cobertura de estados.** Hay al menos un caso de cada estado de solicitud,
+ *    contrato, pago y visita, para poder recorrer todas las pantallas.
+ *
+ * La cuenta principal juega **de dueño y de arrendatario a la vez**, para que
+ * las dos caras del producto tengan datos en la misma sesión.
+ */
+import mongoose from "mongoose";
+
+import {
+  AuditEvent, Chat, ChatMessage, Contract, Favorite, Land, Lead, Notification,
+  Payment, RentalRequest, Report, Review, SavedSearch, User, Visit,
+} from "./schemas";
+import { makeLandPhoto } from "./seed-photo";
+import { photoUrl, storeLandPhoto } from "../lib/land-photos";
+
+// ─── Utilidades deterministas ────────────────────────────────────────────────
+
+/** PRNG con semilla (mulberry32): el mismo seed produce siempre los mismos datos. */
+function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rng = makeRng(20260721);
+const pick = <T>(arr: readonly T[]): T => arr[Math.floor(rng() * arr.length)];
+const between = (min: number, max: number): number => Math.floor(rng() * (max - min + 1)) + min;
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.now();
+const daysAgo = (n: number): Date => new Date(NOW - n * DAY);
+const daysAhead = (n: number): Date => new Date(NOW + n * DAY);
+/** Fecha en formato `YYYY-MM-DD`, que es como la guardan los campos de tipo texto. */
+const ymd = (d: Date): string => d.toISOString().slice(0, 10);
+
+// ─── Actores ─────────────────────────────────────────────────────────────────
+
+interface Actor {
+  clerkUserId: string;
+  email: string;
+  fullName: string;
+  role: "user" | "admin";
+  status?: "active" | "blocked";
+  verified?: boolean;
+  province?: string;
+  marketPreference?: "busco" | "ofrezco";
+}
+
+/**
+ * Cuentas reales del entorno de desarrollo de Clerk. El id de la cuenta
+ * principal se puede sustituir con `SEED_MAIN_CLERK_ID` para sembrar contra
+ * otra sesión sin tocar el código.
+ */
+const MAIN_CLERK_ID = process.env.SEED_MAIN_CLERK_ID || "user_3G7OsFKNNfMXJ85lEbqEwqZJvQi";
+
+const ME = MAIN_CLERK_ID;
+const ALICE = "user_3G9xea7HGkdJYgT9vUOxZGXloFh";
+const BOB = "user_3G9yI9HBzC4R9FCkdoK8ooKj8I8";
+const ADMIN = "user_3GHcoklFmax37t0GUdAPZoqBwJx";
+const ADMIN2 = "user_3CwqKl9BfXPsQ15JB60vxeCUTye";
+const ERIEL = "user_3CxedFfLXcE3YV0hU5vfFHGFwx3";
+const CESAR = "user_3CxePa7NncC8LqGFkkqJgQepPW2";
+
+const REAL_ACTORS: Actor[] = [
+  { clerkUserId: ME, email: "zhorychan@gmail.com", fullName: "Z H", role: "user", verified: true, province: "Panamá", marketPreference: "ofrezco" },
+  { clerkUserId: ALICE, email: "terra.alice+clerk_test@example.com", fullName: "Alice Tester", role: "user", verified: true, province: "Chiriquí", marketPreference: "ofrezco" },
+  { clerkUserId: BOB, email: "terra.bob+clerk_test@example.com", fullName: "Bob Tester", role: "user", province: "Coclé", marketPreference: "busco" },
+  { clerkUserId: ADMIN, email: "vero.buyer+clerk_test@example.com", fullName: "Vero Compradora", role: "admin", verified: true, province: "Panamá" },
+  { clerkUserId: ADMIN2, email: "c14mb10j@gmail.com", fullName: "César Bazán", role: "admin", verified: true, province: "Panamá" },
+  { clerkUserId: ERIEL, email: "eriel.tensu@utp.ac.pa", fullName: "Eriel Tensu", role: "user", province: "Herrera", marketPreference: "busco" },
+  { clerkUserId: CESAR, email: "cesar.bazan@utp.ac.pa", fullName: "Cesar Bazan", role: "user", province: "Veraguas", marketPreference: "ofrezco" },
+];
+
+/** Vecinos sintéticos: dan volumen al catálogo y al panel de admin. */
+const SYNTHETIC_NAMES = [
+  "Marisol Quintero", "Ramón Adames", "Yariela Castillo", "Efraín Batista",
+  "Digna Samudio", "Ovidio Pimentel", "Nidia Bonilla", "Aristides Vega",
+] as const;
+
+const SYNTHETIC_ACTORS: Actor[] = SYNTHETIC_NAMES.map((fullName, i) => ({
+  clerkUserId: `demo_user_${String(i + 1).padStart(2, "0")}`,
+  email: `${fullName.toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "").replace(/ /g, ".")}@terrashare.demo`,
+  fullName,
+  role: "user" as const,
+  // Uno bloqueado para poder probar el filtro de estado del panel de admin.
+  status: i === 7 ? ("blocked" as const) : ("active" as const),
+  verified: i % 3 === 0,
+  province: pick(["Bocas del Toro", "Chiriquí", "Coclé", "Colón", "Herrera", "Los Santos", "Panamá", "Veraguas"]),
+  marketPreference: i % 2 === 0 ? ("ofrezco" as const) : ("busco" as const),
+}));
+
+const ACTORS = [...REAL_ACTORS, ...SYNTHETIC_ACTORS];
+const SYNTHETIC_IDS = SYNTHETIC_ACTORS.filter((a) => a.status !== "blocked").map((a) => a.clerkUserId);
+
+// ─── Catálogo de terrenos ────────────────────────────────────────────────────
+
+const PROVINCES: Record<string, string[]> = {
+  "Bocas del Toro": ["Changuinola", "Almirante", "Isla Colón"],
+  "Chiriquí": ["David", "Boquete", "Bugaba", "Volcán"],
+  "Coclé": ["Penonomé", "Antón", "La Pintada", "Natá"],
+  "Colón": ["Colón", "Portobelo", "Chagres"],
+  "Darién": ["Yaviza", "La Palma", "Metetí"],
+  "Herrera": ["Chitré", "Ocú", "Pesé"],
+  "Los Santos": ["Las Tablas", "Pedasí", "Tonosí", "Guararé"],
+  "Panamá": ["Panamá Este", "Chepo", "San Miguelito"],
+  "Panamá Oeste": ["La Chorrera", "Capira", "Arraiján"],
+  "Veraguas": ["Santiago", "Soná", "Calobre"],
+};
+
+const WATER = [
+  "Pozo propio con bomba eléctrica", "Río permanente en el lindero norte",
+  "Quebrada natural todo el año", "Acueducto rural conectado",
+  "Nacimiento de agua dentro de la finca", "Pozo perforado a 45 m",
+];
+
+const ACCESS = [
+  "Carretera asfaltada hasta la entrada", "Camino de tierra transitable todo el año",
+  "Calle pavimentada a 300 m de la vía principal", "Camino balastrado en buen estado",
+  "Acceso directo por la vía Interamericana",
+];
+
+const FEATURES = [
+  "Riego instalado", "Suelo fértil clase II", "Cercas perimetrales completas",
+  "Acceso vehicular 4x4", "Electricidad trifásica disponible", "Galpón de almacenamiento",
+  "Pasto mejorado establecido", "Colinda con río", "Topografía suave", "Buen drenaje natural",
+  "Casa de campo habitable", "Corral de manejo",
+];
+
+type LandUse = "agricultura" | "ganaderia" | "forestal" | "acuicultura" | "mixto" | "otro";
+
+interface LandSpec {
+  id: string;
+  ownerId: string;
+  title: string;
+  description: string;
+  province: string;
+  district: string;
+  area: number;
+  pricePerMonth: number;
+  operation: "alquiler" | "venta" | "ambas";
+  salePrice?: number;
+  status: "draft" | "active" | "inactive";
+  allowedUses: LandUse[];
+  verified?: boolean;
+  photoCount: number;
+  createdDaysAgo: number;
+}
+
+/**
+ * Terrenos con guion: los de la cuenta principal y los de Alice sostienen los
+ * tratos explícitos de más abajo, así que su estado y operación son fijos.
+ */
+const SCRIPTED_LANDS: LandSpec[] = [
+  {
+    id: "land_me_01", ownerId: ME, title: "Finca La Esperanza", province: "Panamá", district: "Chepo",
+    description: "Finca de 45 hectáreas con pasto mejorado y corral de manejo. Acceso todo el año y quebrada permanente en el lindero. Ideal para ganadería de ceba o cultivo de raíces.",
+    area: 45, pricePerMonth: 1250, operation: "alquiler", status: "active",
+    allowedUses: ["ganaderia", "agricultura"], verified: true, photoCount: 3, createdDaysAgo: 120,
+  },
+  {
+    id: "land_me_02", ownerId: ME, title: "Parcela Río Claro", province: "Chiriquí", district: "Bugaba",
+    description: "Parcela agrícola de 12 hectáreas junto al río Claro, con riego instalado y suelo clase II. Se alquila o se vende; el dueño acepta visita previa.",
+    area: 12, pricePerMonth: 780, operation: "ambas", salePrice: 96000, status: "active",
+    allowedUses: ["agricultura", "mixto"], verified: true, photoCount: 3, createdDaysAgo: 210,
+  },
+  {
+    id: "land_me_03", ownerId: ME, title: "Lote Cerro Azul", province: "Panamá", district: "Panamá Este",
+    description: "Lote de 3 hectáreas en Cerro Azul, clima fresco y vista al valle. Solo venta. Tiene servidumbre inscrita y electricidad a pie de lote.",
+    area: 3, pricePerMonth: 0, operation: "venta", salePrice: 145000, status: "active",
+    allowedUses: ["otro"], photoCount: 2, createdDaysAgo: 60,
+  },
+  {
+    id: "land_me_04", ownerId: ME, title: "Terreno Las Garzas (borrador)", province: "Los Santos", district: "Tonosí",
+    description: "Borrador sin publicar: falta subir el plano y confirmar los linderos con el vecino del sur.",
+    area: 28, pricePerMonth: 540, operation: "alquiler", status: "draft",
+    allowedUses: ["ganaderia"], photoCount: 1, createdDaysAgo: 9,
+  },
+  {
+    id: "land_me_05", ownerId: ME, title: "Finca El Guayacán", province: "Veraguas", district: "Soná",
+    description: "Finca forestal de 80 hectáreas con teca de 8 años. Pausada temporalmente mientras se resuelve el permiso de aprovechamiento.",
+    area: 80, pricePerMonth: 1900, operation: "alquiler", status: "inactive",
+    allowedUses: ["forestal"], photoCount: 2, createdDaysAgo: 300,
+  },
+  {
+    id: "land_me_06", ownerId: ME, title: "Estanques de Puerto Caimito", province: "Panamá Oeste", district: "La Chorrera",
+    description: "Seis estanques acondicionados para acuicultura, con toma de agua y caseta de bombeo. Se alquila por temporada de cosecha.",
+    area: 9, pricePerMonth: 990, operation: "alquiler", status: "active",
+    allowedUses: ["acuicultura"], photoCount: 2, createdDaysAgo: 75,
+  },
+  {
+    id: "land_alice_01", ownerId: ALICE, title: "Hacienda Los Naranjos", province: "Chiriquí", district: "Boquete",
+    description: "Hacienda cafetalera de 22 hectáreas a 1.200 msnm, con beneficio húmedo y casa de trabajadores. Contrato mínimo de 12 meses.",
+    area: 22, pricePerMonth: 2100, operation: "alquiler", status: "active",
+    allowedUses: ["agricultura", "mixto"], verified: true, photoCount: 3, createdDaysAgo: 240,
+  },
+  {
+    id: "land_alice_02", ownerId: ALICE, title: "Potrero San Antonio", province: "Coclé", district: "Penonomé",
+    description: "Potrero de 35 hectáreas con pasto brachiaria establecido, dos abrevaderos y cerca eléctrica perimetral.",
+    area: 35, pricePerMonth: 1150, operation: "alquiler", status: "active",
+    allowedUses: ["ganaderia"], verified: true, photoCount: 3, createdDaysAgo: 400,
+  },
+  {
+    id: "land_alice_03", ownerId: ALICE, title: "Finca Alto Boquete", province: "Chiriquí", district: "Boquete",
+    description: "Terreno de 7 hectáreas para hortalizas de altura, con invernadero de 400 m² y sistema de goteo.",
+    area: 7, pricePerMonth: 1400, operation: "alquiler", status: "active",
+    allowedUses: ["agricultura"], photoCount: 2, createdDaysAgo: 90,
+  },
+  {
+    id: "land_alice_04", ownerId: ALICE, title: "Lote Volcán Sur", province: "Chiriquí", district: "Volcán",
+    description: "Lote de 5 hectáreas con bosque secundario y quebrada. El dueño prioriza proyectos de conservación.",
+    area: 5, pricePerMonth: 620, operation: "alquiler", status: "active",
+    allowedUses: ["forestal", "otro"], photoCount: 2, createdDaysAgo: 45,
+  },
+  {
+    id: "land_alice_05", ownerId: ALICE, title: "Finca Las Lajas", province: "Chiriquí", district: "David",
+    description: "Finca mixta de 60 hectáreas cerca de David, con acceso asfaltado y galpón de 600 m². Se vende o se alquila a largo plazo.",
+    area: 60, pricePerMonth: 2600, operation: "ambas", salePrice: 420000, status: "active",
+    allowedUses: ["mixto", "ganaderia"], verified: true, photoCount: 3, createdDaysAgo: 150,
+  },
+  {
+    id: "land_bob_01", ownerId: BOB, title: "Quinta El Higo", province: "Coclé", district: "Antón",
+    description: "Quinta de 4 hectáreas con frutales en producción y casa de dos recámaras. Ideal para agroturismo.",
+    area: 4, pricePerMonth: 700, operation: "alquiler", status: "active",
+    allowedUses: ["agricultura", "otro"], photoCount: 2, createdDaysAgo: 30,
+  },
+];
+
+const TITLE_PREFIXES = [
+  "Finca", "Parcela", "Hacienda", "Potrero", "Predio", "Lote", "Estancia", "Granja", "Quinta", "Campo",
+];
+const TITLE_SUFFIXES = [
+  "San Isidro", "La Palmera", "El Roble", "Santa Rita", "Los Cedros", "El Mirador",
+  "La Bonita", "Río Grande", "El Progreso", "Las Mercedes", "El Nance", "La Trinidad",
+  "Cañaveral", "El Tamarindo", "La Providencia", "Los Higuerones", "El Espino", "La Chorrerita",
+];
+
+/** Terrenos de relleno de los vecinos sintéticos, para que el catálogo respire. */
+function generateFillerLands(count: number): LandSpec[] {
+  const provinceNames = Object.keys(PROVINCES);
+  const lands: LandSpec[] = [];
+
+  for (let i = 0; i < count; i++) {
+    // Se recorren las provincias por turnos para que el filtro por provincia
+    // tenga resultados en todas, en vez de concentrarse por azar en dos o tres.
+    const province = provinceNames[i % provinceNames.length];
+    const district = pick(PROVINCES[province]);
+    const area = between(4, 260);
+    const roll = rng();
+    const operation = roll < 0.6 ? "alquiler" : roll < 0.85 ? "venta" : "ambas";
+    const uses = [pick(["agricultura", "ganaderia", "forestal", "acuicultura", "mixto"] as const)];
+    if (rng() < 0.35) {
+      const extra = pick(["agricultura", "ganaderia", "forestal", "mixto"] as const);
+      if (!uses.includes(extra)) uses.push(extra);
+    }
+
+    lands.push({
+      id: `land_demo_${String(i + 1).padStart(3, "0")}`,
+      ownerId: pick(SYNTHETIC_IDS),
+      title: `${pick(TITLE_PREFIXES)} ${pick(TITLE_SUFFIXES)}`,
+      description: `Terreno de ${area} hectáreas en ${district}, ${province}. ${pick(WATER)}. ${pick(ACCESS)}. Apto para ${uses.join(" y ")}.`,
+      province,
+      district,
+      area,
+      pricePerMonth: operation === "venta" ? 0 : between(280, 3200),
+      operation,
+      salePrice: operation === "venta" || operation === "ambas" ? area * between(1200, 4000) : undefined,
+      status: rng() < 0.88 ? "active" : pick(["draft", "inactive"] as const),
+      allowedUses: uses as LandUse[],
+      verified: rng() < 0.3,
+      photoCount: between(1, 3),
+      createdDaysAgo: between(1, 330),
+    });
+  }
+  return lands;
+}
+
+function pickFeatures(): string[] {
+  const pool = [...FEATURES];
+  const picked: string[] = [];
+  const n = between(3, 5);
+  for (let i = 0; i < n && pool.length > 0; i++) {
+    picked.push(pool.splice(Math.floor(rng() * pool.length), 1)[0]);
+  }
+  return picked;
+}
+
+// ─── Tratos con guion ────────────────────────────────────────────────────────
+
+type RequestStatus = "draft" | "pending_owner" | "approved" | "rejected" | "cancelled" | "pending_payment" | "paid";
+type ContractStatus = "draft" | "active" | "completed" | "cancelled";
+type PaymentStatus = "pending" | "processing" | "paid" | "failed" | "cancelled" | "refunded" | "partially_refunded";
+
+interface DealSpec {
+  key: string;
+  landId: string;
+  tenantId: string;
+  operation?: "alquiler" | "venta";
+  status: RequestStatus;
+  createdDaysAgo: number;
+  notes?: string;
+  offerAmount?: number;
+  months?: number;
+  /** Días desde hoy hasta el inicio del periodo; negativo = ya empezó. */
+  startsInDays?: number;
+  contract?: { status: ContractStatus; signed?: boolean };
+  payment?: { status: PaymentStatus; refundedAmount?: number };
+  /** Mensajes del chat: `me` = el solicitante, `them` = el dueño. */
+  chat?: { from: "tenant" | "owner"; text: string }[];
+  /** Reseñas cruzadas tras un contrato completado. */
+  reviews?: { from: "tenant" | "owner"; rating: number; comment: string }[];
+}
+
+/**
+ * Guion completo. Cubre los siete estados de solicitud, los cuatro de contrato
+ * y los siete de pago, repartidos entre las dos caras de la cuenta principal
+ * (dueña de `land_me_*`, solicitante en los de Alice).
+ */
+const DEALS: DealSpec[] = [
+  // ── La cuenta principal como ARRENDATARIA ──────────────────────────────────
+  {
+    key: "d01", landId: "land_alice_01", tenantId: ME, status: "paid", createdDaysAgo: 95,
+    months: 12, startsInDays: -60,
+    notes: "Quiero retomar la producción de café de altura. Tengo experiencia con beneficio húmedo.",
+    contract: { status: "active", signed: true },
+    payment: { status: "paid" },
+    chat: [
+      { from: "tenant", text: "Hola Alice, me interesa la hacienda. ¿El beneficio húmedo está operativo?" },
+      { from: "owner", text: "¡Hola! Sí, lo usamos la cosecha pasada. Le cambiamos la bomba en marzo." },
+      { from: "tenant", text: "Perfecto. ¿Podría visitarla un sábado por la mañana?" },
+      { from: "owner", text: "Claro, agenda la visita por la plataforma y te confirmo." },
+      { from: "tenant", text: "Listo, ya la agendé. Nos vemos el sábado." },
+      { from: "owner", text: "Confirmada. Te espero en la entrada principal a las 9." },
+    ],
+  },
+  {
+    key: "d02", landId: "land_alice_02", tenantId: ME, status: "paid", createdDaysAgo: 400,
+    months: 10, startsInDays: -360,
+    notes: "Engorde de 40 cabezas. Ya trabajé potreros de este tamaño en Coclé.",
+    contract: { status: "completed", signed: true },
+    payment: { status: "paid" },
+    chat: [
+      { from: "tenant", text: "Buenas, ¿el potrero aguanta 40 cabezas en verano?" },
+      { from: "owner", text: "Sí, con los dos abrevaderos no hemos tenido problema." },
+      { from: "tenant", text: "Cerramos entonces. Gracias por la disposición." },
+    ],
+    reviews: [
+      { from: "tenant", rating: 5, comment: "Alice fue clarísima con los linderos y el estado de las cercas. El potrero estaba tal cual lo describió. Repetiría sin dudarlo." },
+      { from: "owner", rating: 5, comment: "Cuidó el pasto y entregó el terreno mejor de lo que lo recibió. Pagos siempre puntuales." },
+    ],
+  },
+  {
+    key: "d03", landId: "land_alice_03", tenantId: ME, status: "pending_owner", createdDaysAgo: 3,
+    months: 8, startsInDays: 25,
+    notes: "Quiero producir tomate bajo invernadero. ¿El goteo cubre las 7 hectáreas o solo el invernadero?",
+    chat: [
+      { from: "tenant", text: "Hola, envié la solicitud. ¿El goteo cubre toda la finca?" },
+      { from: "owner", text: "Solo el invernadero por ahora, pero la tubería madre ya está puesta." },
+    ],
+  },
+  {
+    key: "d04", landId: "land_alice_04", tenantId: ME, status: "rejected", createdDaysAgo: 22,
+    months: 6, startsInDays: 10,
+    notes: "Proyecto de vivero forestal con especies nativas.",
+    chat: [
+      { from: "tenant", text: "¿Aceptaría un vivero forestal en la parte baja?" },
+      { from: "owner", text: "Lo siento, ya me comprometí con un proyecto de conservación. Gracias igual." },
+    ],
+  },
+  {
+    key: "d05", landId: "land_alice_05", tenantId: ME, operation: "venta", status: "pending_owner",
+    createdDaysAgo: 6, offerAmount: 385000,
+    notes: "Oferta en firme, pago de contado contra escritura. Financiamiento ya aprobado.",
+  },
+  {
+    key: "d06", landId: "land_bob_01", tenantId: ME, status: "cancelled", createdDaysAgo: 40,
+    months: 4, startsInDays: 15,
+    notes: "Cancelé porque encontré una finca más cerca de la ciudad.",
+    contract: { status: "cancelled" },
+    payment: { status: "cancelled" },
+  },
+  {
+    key: "d07", landId: "land_demo_004", tenantId: ME, status: "pending_payment", createdDaysAgo: 5,
+    months: 6, startsInDays: 20,
+    notes: "Solicitud aprobada, falta completar el pago del primer mes.",
+    contract: { status: "draft" },
+    payment: { status: "pending" },
+  },
+  {
+    key: "d08", landId: "land_demo_009", tenantId: ME, status: "draft", createdDaysAgo: 1,
+    months: 12, startsInDays: 30,
+    notes: "Borrador: falta confirmar el periodo con el socio.",
+  },
+
+  // ── La cuenta principal como DUEÑA ─────────────────────────────────────────
+  {
+    key: "d10", landId: "land_me_01", tenantId: BOB, status: "paid", createdDaysAgo: 70,
+    months: 12, startsInDays: -45,
+    notes: "Ganadería de ceba, 60 cabezas. Referencias disponibles.",
+    contract: { status: "active", signed: true },
+    payment: { status: "paid" },
+    chat: [
+      { from: "tenant", text: "Buenas tardes, ¿el corral de manejo incluye báscula?" },
+      { from: "owner", text: "Sí, báscula de 2.000 kg recién calibrada." },
+      { from: "tenant", text: "Excelente. Procedo con la solicitud." },
+      { from: "owner", text: "Perfecto, la apruebo hoy mismo." },
+      { from: "tenant", text: "Ya quedó el pago. Gracias por la agilidad." },
+    ],
+  },
+  {
+    key: "d11", landId: "land_me_01", tenantId: ERIEL, status: "pending_owner", createdDaysAgo: 2,
+    months: 9, startsInDays: 40,
+    notes: "Interesado en la parte alta para siembra de yuca. ¿Se puede subdividir el alquiler?",
+    chat: [
+      { from: "tenant", text: "¿Existe la posibilidad de alquilar solo 15 hectáreas?" },
+    ],
+  },
+  {
+    key: "d12", landId: "land_me_02", tenantId: BOB, status: "paid", createdDaysAgo: 380,
+    months: 9, startsInDays: -340,
+    notes: "Ciclo de sandía y melón para exportación.",
+    contract: { status: "completed", signed: true },
+    payment: { status: "partially_refunded", refundedAmount: 240 },
+    chat: [
+      { from: "tenant", text: "El riego funcionó perfecto toda la temporada." },
+      { from: "owner", text: "Me alegra. Avísame si quieres repetir el próximo ciclo." },
+    ],
+    reviews: [
+      { from: "tenant", rating: 5, comment: "Terreno impecable y dueño muy atento. El riego instalado nos ahorró semanas de trabajo." },
+      { from: "owner", rating: 4, comment: "Buen arrendatario, aunque la entrega se retrasó una semana por la cosecha." },
+    ],
+  },
+  {
+    key: "d13", landId: "land_me_02", tenantId: CESAR, operation: "venta", status: "approved",
+    createdDaysAgo: 12, offerAmount: 92000,
+    notes: "Oferta por debajo del precio de lista, pago 50% contado y 50% a 6 meses.",
+    chat: [
+      { from: "tenant", text: "¿Consideraría el 50/50 a seis meses?" },
+      { from: "owner", text: "Lo estoy evaluando con mi abogado, te confirmo esta semana." },
+    ],
+  },
+  {
+    key: "d14", landId: "land_me_06", tenantId: ERIEL, status: "pending_payment", createdDaysAgo: 8,
+    months: 5, startsInDays: 12,
+    notes: "Cultivo de tilapia, ciclo corto.",
+    contract: { status: "draft" },
+    payment: { status: "processing" },
+  },
+  {
+    key: "d15", landId: "land_me_06", tenantId: "demo_user_02", status: "rejected", createdDaysAgo: 30,
+    months: 3, startsInDays: 5,
+    notes: "Necesito los estanques solo tres meses.",
+  },
+  {
+    key: "d16", landId: "land_me_01", tenantId: "demo_user_03", status: "cancelled", createdDaysAgo: 55,
+    months: 6, startsInDays: 20,
+    notes: "Retiro la solicitud, cambié de zona.",
+    payment: { status: "failed" },
+  },
+  {
+    key: "d17", landId: "land_me_05", tenantId: "demo_user_01", status: "paid", createdDaysAgo: 260,
+    months: 8, startsInDays: -240,
+    notes: "Aprovechamiento forestal de teca.",
+    contract: { status: "completed", signed: true },
+    payment: { status: "refunded", refundedAmount: 1900 },
+    reviews: [
+      { from: "tenant", rating: 4, comment: "El permiso se atrasó y hubo que reembolsar, pero la comunicación fue honesta en todo momento." },
+    ],
+  },
+];
+
+// ─── Construcción del grafo ──────────────────────────────────────────────────
+
+interface Built {
+  users: Record<string, unknown>[];
+  lands: Record<string, unknown>[];
+  requests: Record<string, unknown>[];
+  contracts: Record<string, unknown>[];
+  payments: Record<string, unknown>[];
+  chats: Record<string, unknown>[];
+  messages: Record<string, unknown>[];
+  favorites: Record<string, unknown>[];
+  reports: Record<string, unknown>[];
+  reviews: Record<string, unknown>[];
+  savedSearches: Record<string, unknown>[];
+  visits: Record<string, unknown>[];
+  notifications: Record<string, unknown>[];
+  auditEvents: Record<string, unknown>[];
+  leads: Record<string, unknown>[];
+  /** Terrenos que necesitan foto, para subirlas a GridFS después de insertar. */
+  photoPlan: { landId: string; count: number; seed: number }[];
+}
+
+const PLATFORM_FEE_RATE = 0.05;
+
+export function buildDemoData(): Built {
+  const landSpecs = [...SCRIPTED_LANDS, ...generateFillerLands(24)];
+  const landById = new Map(landSpecs.map((l) => [l.id, l]));
+
+  const users = ACTORS.map((a, i) => ({
+    clerkUserId: a.clerkUserId,
+    email: a.email,
+    role: a.role,
+    status: a.status ?? "active",
+    profile: {
+      fullName: a.fullName,
+      phone: `+507 6${between(100, 999)}-${between(1000, 9999)}`,
+      province: a.province,
+      marketPreference: a.marketPreference,
+    },
+    verified: a.verified ?? false,
+    deletedAt: null,
+    createdAt: daysAgo(360 - i * 8),
+    updatedAt: daysAgo(between(1, 20)),
+  }));
+
+  const photoPlan: Built["photoPlan"] = [];
+  const lands = landSpecs.map((spec, i) => {
+    photoPlan.push({ landId: spec.id, count: spec.photoCount, seed: i + 1 });
+    return {
+      id: spec.id,
+      ownerId: spec.ownerId,
+      title: spec.title,
+      description: spec.description,
+      area: spec.area,
+      allowedUses: spec.allowedUses,
+      photos: [] as string[],
+      location: {
+        province: spec.province,
+        district: spec.district,
+        corregimiento: pick(PROVINCES[spec.province] ?? [spec.district]),
+        lat: 7.5 + rng() * 1.9,
+        lng: -82.5 + rng() * 4.5,
+      },
+      availability: { availableFrom: ymd(daysAgo(between(0, 30))) },
+      priceRule: { currency: "USD", pricePerMonth: spec.pricePerMonth },
+      status: spec.status,
+      operation: spec.operation,
+      salePrice: spec.salePrice,
+      water: pick(WATER),
+      access: pick(ACCESS),
+      features: pickFeatures(),
+      verified: spec.verified ?? false,
+      deletedAt: null,
+      createdAt: daysAgo(spec.createdDaysAgo),
+      updatedAt: daysAgo(Math.min(spec.createdDaysAgo, between(1, 25))),
+    };
+  });
+
+  const requests: Record<string, unknown>[] = [];
+  const contracts: Record<string, unknown>[] = [];
+  const payments: Record<string, unknown>[] = [];
+  const chats: Record<string, unknown>[] = [];
+  const messages: Record<string, unknown>[] = [];
+  const reviews: Record<string, unknown>[] = [];
+  const auditEvents: Record<string, unknown>[] = [];
+  const notifications: Record<string, unknown>[] = [];
+
+  let auditSeq = 0;
+  const audit = (
+    actorId: string,
+    entity: string,
+    action: string,
+    entityId: string,
+    createdAt: Date,
+    metadata?: Record<string, unknown>,
+  ) => {
+    auditSeq += 1;
+    auditEvents.push({
+      id: `audit_${String(auditSeq).padStart(5, "0")}`,
+      actorId,
+      actorRole: ACTORS.find((a) => a.clerkUserId === actorId)?.role ?? "user",
+      entity,
+      action,
+      entityId,
+      metadata: metadata ?? {},
+      createdAt,
+      updatedAt: createdAt,
+    });
+  };
+
+  let notifSeq = 0;
+  const notify = (userId: string, type: string, title: string, body: string, createdAt: Date, read = false) => {
+    notifSeq += 1;
+    notifications.push({
+      id: `notif_${String(notifSeq).padStart(4, "0")}`,
+      userId,
+      type,
+      title,
+      body,
+      read,
+      readAt: read ? createdAt.toISOString() : undefined,
+      createdAt,
+    });
+  };
+
+  for (const deal of DEALS) {
+    const land = landById.get(deal.landId);
+    if (!land) throw new Error(`Trato ${deal.key}: el terreno ${deal.landId} no existe`);
+    const ownerId = land.ownerId;
+    if (ownerId === deal.tenantId) throw new Error(`Trato ${deal.key}: el dueño no puede ser el solicitante`);
+
+    const createdAt = daysAgo(deal.createdDaysAgo);
+    const updatedAt = daysAgo(Math.max(0, deal.createdDaysAgo - between(1, 3)));
+    const operation = deal.operation ?? "alquiler";
+    const requestId = `rr_${deal.key}`;
+
+    const startsAt = daysAhead(deal.startsInDays ?? 30);
+    const endsAt = new Date(startsAt.getTime() + (deal.months ?? 12) * 30 * DAY);
+
+    requests.push({
+      id: requestId,
+      landId: deal.landId,
+      tenantId: deal.tenantId,
+      operation,
+      ...(operation === "alquiler"
+        ? {
+            period: { startDate: ymd(startsAt), endDate: ymd(endsAt) },
+            intendedUse: land.allowedUses[0],
+          }
+        : { offerAmount: deal.offerAmount }),
+      notes: deal.notes,
+      status: deal.status,
+      createdAt,
+      updatedAt,
+    });
+    audit(deal.tenantId, "rental_request", "created", requestId, createdAt);
+    if (deal.status === "approved" || deal.status === "paid" || deal.status === "pending_payment") {
+      audit(ownerId, "rental_request", "approved", requestId, updatedAt);
+    }
+    if (deal.status === "rejected") {
+      audit(ownerId, "rental_request", "rejected", requestId, updatedAt);
+      notify(deal.tenantId, "request_rejected", "Solicitud rechazada",
+        `El dueño de "${land.title}" no pudo aceptar tu solicitud.`, updatedAt, deal.createdDaysAgo > 25);
+    }
+    if (deal.status === "pending_owner") {
+      notify(ownerId, "request_received", "Nueva solicitud recibida",
+        `Recibiste una solicitud para "${land.title}".`, createdAt);
+    }
+
+    // ── Contrato ──
+    let contractId: string | undefined;
+    if (deal.contract) {
+      contractId = `contract_${deal.key}`;
+      const signedAt = deal.contract.signed ? ymd(new Date(createdAt.getTime() + 2 * DAY)) : undefined;
+      contracts.push({
+        id: contractId,
+        rentalRequestId: requestId,
+        ownerId,
+        tenantId: deal.tenantId,
+        terms: {
+          summary: operation === "venta"
+            ? `Compraventa de "${land.title}" por USD ${deal.offerAmount?.toLocaleString("es-PA")}.`
+            : `Arrendamiento de "${land.title}" por ${deal.months ?? 12} meses a USD ${land.pricePerMonth}/mes, uso ${land.allowedUses[0]}.`,
+          signedAt,
+          startsAt: ymd(startsAt),
+          endsAt: ymd(endsAt),
+        },
+        status: deal.contract.status,
+        createdAt: new Date(createdAt.getTime() + DAY),
+        updatedAt,
+      });
+      audit(ownerId, "contract", "created", contractId, new Date(createdAt.getTime() + DAY));
+      if (signedAt) audit(deal.tenantId, "contract", "signed", contractId, new Date(createdAt.getTime() + 2 * DAY));
+      if (deal.contract.status === "completed") {
+        audit(ownerId, "contract", "completed", contractId, updatedAt);
+        notify(deal.tenantId, "contract_completed", "Contrato completado",
+          `El contrato de "${land.title}" se marcó como completado. Ya puedes dejar una reseña.`, updatedAt, true);
+      }
+      if (deal.contract.status === "cancelled") {
+        audit(deal.tenantId, "contract", "cancelled", contractId, updatedAt);
+      }
+    }
+
+    // ── Pago ──
+    if (deal.payment) {
+      const amount = operation === "venta"
+        ? (deal.offerAmount ?? 0)
+        : land.pricePerMonth;
+      const platformFeeAmount = Math.round(amount * PLATFORM_FEE_RATE * 100) / 100;
+      const refundedAmount = deal.payment.refundedAmount ?? 0;
+      const paidAt = new Date(createdAt.getTime() + 3 * DAY);
+      payments.push({
+        id: `pay_${deal.key}`,
+        rentalRequestId: requestId,
+        contractId,
+        amount,
+        currency: "USD",
+        platformFeeAmount,
+        netAmount: Math.round((amount - platformFeeAmount) * 100) / 100,
+        settlementCurrency: "USD",
+        status: deal.payment.status,
+        refundedAmount,
+        refunds: refundedAmount > 0
+          ? [{
+              id: `re_${deal.key}`,
+              amount: refundedAmount,
+              reason: deal.payment.status === "refunded"
+                ? "Contrato anulado por permiso denegado"
+                : "Ajuste parcial acordado con el arrendatario",
+              stripeRefundId: `re_demo_${deal.key}`,
+              createdAt: new Date(paidAt.getTime() + 20 * DAY),
+            }]
+          : [],
+        stripeSessionId: `cs_demo_${deal.key}`,
+        stripePaymentIntentId: `pi_demo_${deal.key}`,
+        checkoutUrl: `https://checkout.stripe.com/c/pay/cs_demo_${deal.key}`,
+        createdAt: paidAt,
+        updatedAt: refundedAmount > 0 ? new Date(paidAt.getTime() + 20 * DAY) : paidAt,
+      });
+      if (deal.payment.status === "paid" || deal.payment.status === "partially_refunded" || deal.payment.status === "refunded") {
+        audit(deal.tenantId, "payment", "paid", `pay_${deal.key}`, paidAt, { amount, currency: "USD" });
+        notify(ownerId, "payment_received", "Pago recibido",
+          `Se acreditó un pago de USD ${amount.toLocaleString("es-PA")} por "${land.title}".`, paidAt, true);
+      }
+      if (refundedAmount > 0) {
+        audit(ADMIN, "payment", "refunded", `pay_${deal.key}`, new Date(paidAt.getTime() + 20 * DAY), { refundedAmount });
+      }
+    }
+
+    // ── Chat ──
+    if (deal.chat && deal.chat.length > 0) {
+      const chatId = `chat_${deal.key}`;
+      const chatCreatedAt = new Date(createdAt.getTime() - DAY);
+      chats.push({
+        id: chatId,
+        landId: deal.landId,
+        rentalRequestId: requestId,
+        participants: [
+          { userId: ownerId, role: "owner" },
+          { userId: deal.tenantId, role: "tenant" },
+        ],
+        status: "active",
+        createdAt: chatCreatedAt,
+        updatedAt: new Date(chatCreatedAt.getTime() + deal.chat.length * 3600_000),
+      });
+      deal.chat.forEach((m, i) => {
+        messages.push({
+          id: `msg_${deal.key}_${String(i + 1).padStart(2, "0")}`,
+          chatId,
+          senderId: m.from === "owner" ? ownerId : deal.tenantId,
+          text: m.text,
+          viaAssistant: false,
+          createdAt: new Date(chatCreatedAt.getTime() + (i + 1) * 3600_000),
+        });
+      });
+      // El último mensaje del interlocutor genera una notificación sin leer.
+      const last = deal.chat[deal.chat.length - 1];
+      if (last.from === "tenant") {
+        notify(ownerId, "chat_message", "Mensaje nuevo",
+          `Tienes un mensaje sobre "${land.title}".`, new Date(chatCreatedAt.getTime() + deal.chat.length * 3600_000),
+          deal.createdDaysAgo > 20);
+      }
+    }
+
+    // ── Reseñas ──
+    if (deal.reviews && contractId) {
+      for (const r of deal.reviews) {
+        const senderId = r.from === "owner" ? ownerId : deal.tenantId;
+        const receiverId = r.from === "owner" ? deal.tenantId : ownerId;
+        const at = new Date(NOW - (deal.createdDaysAgo - (deal.months ?? 12) * 30 + 5) * DAY);
+        reviews.push({
+          id: `review_${deal.key}_${r.from}`,
+          contractId,
+          senderId,
+          receiverId,
+          rating: r.rating,
+          comment: r.comment,
+          createdAt: at > new Date(NOW) ? daysAgo(5) : at,
+          updatedAt: at > new Date(NOW) ? daysAgo(5) : at,
+        });
+        notify(receiverId, "review_received", "Nueva reseña",
+          `Recibiste una reseña de ${r.rating} estrellas.`, daysAgo(5), true);
+      }
+    }
+  }
+
+  // ── Favoritos: la cuenta principal guarda terrenos ajenos ──────────────────
+  const favoriteLandIds = ["land_alice_01", "land_alice_03", "land_alice_05", "land_bob_01", "land_demo_002", "land_demo_007"];
+  const favorites = favoriteLandIds.map((landId, i) => ({
+    userId: ME,
+    landId,
+    createdAt: daysAgo(3 + i * 4),
+    updatedAt: daysAgo(3 + i * 4),
+  }));
+  // Y otros usuarios guardan los de la cuenta principal (así el dueño ve interés).
+  favorites.push(
+    { userId: BOB, landId: "land_me_01", createdAt: daysAgo(12), updatedAt: daysAgo(12) },
+    { userId: ERIEL, landId: "land_me_01", createdAt: daysAgo(6), updatedAt: daysAgo(6) },
+    { userId: CESAR, landId: "land_me_02", createdAt: daysAgo(9), updatedAt: daysAgo(9) },
+    { userId: BOB, landId: "land_me_03", createdAt: daysAgo(2), updatedAt: daysAgo(2) },
+  );
+
+  // ── Búsquedas guardadas de la cuenta principal ─────────────────────────────
+  const savedSearches = [
+    {
+      id: "search_001", userId: ME, name: "Ganadería en Coclé hasta $1.500",
+      filters: { province: "Coclé", use: "ganaderia", maxPrice: 1500, operation: "alquiler" },
+      createdAt: daysAgo(28), updatedAt: daysAgo(28),
+    },
+    {
+      id: "search_002", userId: ME, name: "Café en Boquete",
+      filters: { province: "Chiriquí", district: "Boquete", use: "agricultura" },
+      createdAt: daysAgo(14), updatedAt: daysAgo(14),
+    },
+    {
+      id: "search_003", userId: ME, name: "Lotes en venta bajo $150.000",
+      filters: { operation: "venta", maxSalePrice: 150000 },
+      createdAt: daysAgo(4), updatedAt: daysAgo(4),
+    },
+    {
+      id: "search_004", userId: BOB, name: "Acuicultura cerca de la capital",
+      filters: { province: "Panamá Oeste", use: "acuicultura" },
+      createdAt: daysAgo(11), updatedAt: daysAgo(11),
+    },
+  ];
+  notify(ME, "saved_search_match", "Nuevo terreno para «Café en Boquete»",
+    "Se publicó «Finca Alto Boquete», que coincide con tu búsqueda guardada.", daysAgo(2));
+
+  // ── Visitas: los cuatro estados, en las dos caras ──────────────────────────
+  const visits = [
+    // La cuenta principal como solicitante.
+    {
+      id: "visit_001", landId: "land_alice_01", tenantId: ME, ownerId: ALICE,
+      proposedDate: ymd(daysAhead(4)), proposedTime: "09:00",
+      message: "Quisiera ver el beneficio húmedo y las cercas del lindero norte.",
+      status: "confirmed", responseMessage: "Confirmada. Te espero en la entrada principal.",
+      createdAt: daysAgo(6), updatedAt: daysAgo(5),
+    },
+    {
+      id: "visit_002", landId: "land_alice_03", tenantId: ME, ownerId: ALICE,
+      proposedDate: ymd(daysAhead(9)), proposedTime: "14:30",
+      message: "Me interesa revisar el invernadero y el sistema de goteo.",
+      status: "pending", createdAt: daysAgo(2), updatedAt: daysAgo(2),
+    },
+    {
+      id: "visit_003", landId: "land_alice_04", tenantId: ME, ownerId: ALICE,
+      proposedDate: ymd(daysAhead(12)), proposedTime: "10:00",
+      message: "¿Podríamos vernos el fin de semana?",
+      status: "rescheduled", responseMessage: "El sábado no puedo; te propongo el domingo a las 10.",
+      createdAt: daysAgo(8), updatedAt: daysAgo(7),
+    },
+    {
+      id: "visit_004", landId: "land_demo_004", tenantId: ME, ownerId: landById.get("land_demo_004")!.ownerId,
+      proposedDate: ymd(daysAhead(3)), proposedTime: "16:00",
+      message: "Visita rápida para ver el acceso.",
+      status: "rejected", responseMessage: "Esta semana estoy fuera del país, disculpa.",
+      createdAt: daysAgo(10), updatedAt: daysAgo(9),
+    },
+    // La cuenta principal como dueña que recibe solicitudes de visita.
+    {
+      id: "visit_005", landId: "land_me_01", tenantId: BOB, ownerId: ME,
+      proposedDate: ymd(daysAhead(5)), proposedTime: "08:30",
+      message: "Quiero revisar el corral de manejo antes de traer el ganado.",
+      status: "pending", createdAt: daysAgo(1), updatedAt: daysAgo(1),
+    },
+    {
+      id: "visit_006", landId: "land_me_02", tenantId: ERIEL, ownerId: ME,
+      proposedDate: ymd(daysAhead(7)), proposedTime: "11:00",
+      message: "Interesado en ver el riego instalado.",
+      status: "confirmed", responseMessage: "Perfecto, nos vemos en la entrada del río.",
+      createdAt: daysAgo(4), updatedAt: daysAgo(3),
+    },
+    {
+      id: "visit_007", landId: "land_me_03", tenantId: CESAR, ownerId: ME,
+      proposedDate: ymd(daysAhead(2)), proposedTime: "15:00",
+      message: "¿Se puede ver el lote esta semana?",
+      status: "rescheduled", responseMessage: "Te propongo el jueves a la misma hora.",
+      createdAt: daysAgo(5), updatedAt: daysAgo(4),
+    },
+    {
+      id: "visit_008", landId: "land_me_06", tenantId: "demo_user_02", ownerId: ME,
+      proposedDate: ymd(daysAhead(1)), proposedTime: "07:00",
+      message: "Visita para evaluar los estanques.",
+      status: "rejected", responseMessage: "Los estanques están en mantenimiento hasta fin de mes.",
+      createdAt: daysAgo(14), updatedAt: daysAgo(13),
+    },
+  ];
+  notify(ME, "visit_request", "Nueva solicitud de visita",
+    `Bob Tester quiere visitar "Finca La Esperanza" el ${ymd(daysAhead(5))} a las 08:30.`, daysAgo(1));
+  notify(ME, "visit_update", "Visita confirmada",
+    `Alice Tester confirmó tu visita a "Hacienda Los Naranjos".`, daysAgo(5), true);
+
+  // ── Reportes para moderación ──────────────────────────────────────────────
+  const reports = [
+    {
+      id: "report_001", targetType: "land", targetId: "land_demo_011", reason: "informacion_falsa",
+      description: "Las fotos no corresponden al terreno; el área declarada no coincide con el plano público.",
+      reporterId: ME, status: "open",
+      createdAt: daysAgo(2), updatedAt: daysAgo(2),
+    },
+    {
+      id: "report_002", targetType: "land", targetId: "land_demo_017", reason: "fraude",
+      description: "El anunciante pide un adelanto por transferencia fuera de la plataforma.",
+      reporterId: BOB, status: "open",
+      createdAt: daysAgo(4), updatedAt: daysAgo(4),
+    },
+    {
+      id: "report_003", targetType: "user", targetId: "demo_user_08", reason: "spam",
+      description: "Envía el mismo mensaje promocional a todos los chats.",
+      reporterId: ERIEL, status: "reviewing",
+      createdAt: daysAgo(9), updatedAt: daysAgo(6),
+    },
+    {
+      id: "report_004", targetType: "land", targetId: "land_me_06", reason: "otro",
+      description: "El precio parece muy bajo para la zona, ¿se puede verificar?",
+      reporterId: CESAR, status: "dismissed",
+      resolutionNote: "Revisado: el precio es correcto, corresponde a alquiler por temporada.",
+      resolvedBy: ADMIN,
+      createdAt: daysAgo(20), updatedAt: daysAgo(18),
+    },
+    {
+      id: "report_005", targetType: "chat", targetId: "chat_d04", reason: "contenido_inapropiado",
+      description: "Lenguaje ofensivo en la conversación.",
+      reporterId: ME, status: "resolved",
+      resolutionNote: "Se contactó al usuario y se le dio una advertencia formal.",
+      resolvedBy: ADMIN2,
+      createdAt: daysAgo(30), updatedAt: daysAgo(27),
+    },
+    {
+      id: "report_006", targetType: "land", targetId: "land_demo_003", reason: "spam",
+      description: "Terreno duplicado, ya está publicado por otro usuario.",
+      reporterId: "demo_user_04", status: "open",
+      createdAt: daysAgo(1), updatedAt: daysAgo(1),
+    },
+  ];
+  audit(ADMIN, "report", "status_changed", "report_004", daysAgo(18), { to: "dismissed" });
+  audit(ADMIN2, "report", "status_changed", "report_005", daysAgo(27), { to: "resolved" });
+
+  // ── Leads de la landing ───────────────────────────────────────────────────
+  const leads = Array.from({ length: 40 }, (_, i) => ({
+    id: `lead_${String(i + 1).padStart(4, "0")}`,
+    email: `interesado${i + 1}@correo.demo`,
+    source: pick(["landing", "landing", "app-web", "admin-dashboard"] as const),
+    createdAt: daysAgo(between(0, 90)),
+    updatedAt: daysAgo(between(0, 90)),
+  }));
+
+  // Sesiones de la cuenta principal en la auditoría, para que el panel tenga
+  // eventos recientes de tipo `auth`.
+  for (let i = 0; i < 8; i++) {
+    audit(ME, "auth", "created", ME, daysAgo(i * 3 + 1), { event: "login" });
+  }
+
+  return {
+    users, lands, requests, contracts, payments, chats, messages, favorites,
+    reports, reviews, savedSearches, visits, notifications, auditEvents, leads,
+    photoPlan,
+  };
+}
+
+// ─── Escritura ───────────────────────────────────────────────────────────────
+
+/**
+ * Colecciones fantasma en camelCase que quedaron de la etapa del driver nativo
+ * (antes de #135). Mongoose lee de las minúsculas, así que estos documentos son
+ * invisibles para la app y solo confunden al inspeccionar la base.
+ */
+const GHOST_COLLECTIONS = ["rentalRequests", "chatMessages", "auditEvents", "webhookEvents", "idempotencyKeys", "backupRecords", "savedSearches"];
+
+async function dropGhostCollections(): Promise<string[]> {
+  const db = mongoose.connection.db;
+  if (!db) return [];
+  const existing = (await db.listCollections().toArray()).map((c) => c.name);
+  const dropped: string[] = [];
+  for (const name of GHOST_COLLECTIONS) {
+    if (existing.includes(name)) {
+      await db.collection(name).drop();
+      dropped.push(name);
+    }
+  }
+  return dropped;
+}
+
+/** Sube las fotos sintéticas a GridFS y enlaza sus URLs en cada terreno. */
+async function seedPhotos(plan: Built["photoPlan"]): Promise<number> {
+  let total = 0;
+  for (const item of plan) {
+    const urls: string[] = [];
+    for (let i = 0; i < item.count; i++) {
+      const fileId = await storeLandPhoto({
+        landId: item.landId,
+        buffer: makeLandPhoto(item.seed * 10 + i),
+        contentType: "image/png",
+        filename: `${item.landId}-${i + 1}.png`,
+      });
+      urls.push(photoUrl(item.landId, fileId));
+      total++;
+    }
+    await Land.collection.updateOne({ id: item.landId }, { $set: { photos: urls } });
+  }
+  return total;
+}
+
+export interface SeedDemoResult {
+  counts: Record<string, number>;
+  droppedGhostCollections: string[];
+  photos: number;
+}
+
+/**
+ * Borra y repuebla las colecciones de datos de negocio. No toca `_migrations`
+ * (el registro de migraciones aplicadas) para no forzar su reejecución.
+ */
+export async function seedDemoDatabase(): Promise<SeedDemoResult> {
+  if (mongoose.connection.readyState !== 1) {
+    throw new Error("[seed-demo] No hay conexión a MongoDB");
+  }
+
+  const data = buildDemoData();
+  const droppedGhostCollections = await dropGhostCollections();
+
+  // GridFS se limpia a mano: las fotos viejas apuntan a terrenos que ya no existen.
+  const db = mongoose.connection.db!;
+  const existing = (await db.listCollections().toArray()).map((c) => c.name);
+  for (const name of ["landPhotos.files", "landPhotos.chunks"]) {
+    if (existing.includes(name)) await db.collection(name).deleteMany({});
+  }
+
+  // `Model.collection` escribe con el driver nativo: conserva la forma exacta de
+  // los documentos semilla, evita el casteo de Mongoose y usa el nombre de
+  // colección real del modelo (el desajuste que originó las fantasma, #135).
+  const collections: { name: string; model: mongoose.Model<never>; docs: Record<string, unknown>[] }[] = [
+    { name: "users", model: User as never, docs: data.users },
+    { name: "lands", model: Land as never, docs: data.lands },
+    { name: "rentalrequests", model: RentalRequest as never, docs: data.requests },
+    { name: "contracts", model: Contract as never, docs: data.contracts },
+    { name: "payments", model: Payment as never, docs: data.payments },
+    { name: "chats", model: Chat as never, docs: data.chats },
+    { name: "chatmessages", model: ChatMessage as never, docs: data.messages },
+    { name: "favorites", model: Favorite as never, docs: data.favorites },
+    { name: "reports", model: Report as never, docs: data.reports },
+    { name: "reviews", model: Review as never, docs: data.reviews },
+    { name: "savedsearches", model: SavedSearch as never, docs: data.savedSearches },
+    { name: "visits", model: Visit as never, docs: data.visits },
+    { name: "notifications", model: Notification as never, docs: data.notifications },
+    { name: "auditevents", model: AuditEvent as never, docs: data.auditEvents },
+    { name: "leads", model: Lead as never, docs: data.leads },
+  ];
+
+  const counts: Record<string, number> = {};
+  for (const { name, model, docs } of collections) {
+    await model.collection.deleteMany({});
+    if (docs.length > 0) await model.collection.insertMany(docs as never);
+    counts[name] = docs.length;
+  }
+
+  counts.photos = await seedPhotos(data.photoPlan);
+
+  return { counts, droppedGhostCollections, photos: counts.photos };
+}

--- a/apps/backend-api/src/db/seed-photo.ts
+++ b/apps/backend-api/src/db/seed-photo.ts
@@ -1,0 +1,132 @@
+/**
+ * Generador de fotos sintéticas para el seed de demostración (#356).
+ *
+ * Los terrenos sin foto dejan el catálogo lleno de marcadores de posición, que
+ * es justo lo que hace difícil distinguir "pantalla vacía por falta de datos"
+ * de "pantalla vacía por bug". En vez de depender de imágenes externas (que
+ * añadirían red y una licencia que gestionar), pintamos un PNG procedural: un
+ * paisaje plano de cielo + horizonte + parcela, con el tono derivado de una
+ * semilla para que cada terreno se vea distinto y siempre igual entre corridas.
+ */
+import { deflateSync } from "node:zlib";
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const typeAndData = Buffer.concat([Buffer.from(type, "ascii"), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(typeAndData), 0);
+  return Buffer.concat([length, typeAndData, crc]);
+}
+
+type Rgb = [number, number, number];
+
+/** Codifica un PNG RGB de 8 bits sin entrelazar (filtro 0 en cada scanline). */
+function encodePng(width: number, height: number, pixel: (x: number, y: number) => Rgb): Buffer {
+  const stride = width * 3;
+  const raw = Buffer.alloc(height * (stride + 1));
+  for (let y = 0; y < height; y++) {
+    const rowStart = y * (stride + 1);
+    raw[rowStart] = 0; // filtro "None"
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = pixel(x, y);
+      const i = rowStart + 1 + x * 3;
+      raw[i] = r;
+      raw[i + 1] = g;
+      raw[i + 2] = b;
+    }
+  }
+
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // profundidad de bits
+  ihdr[9] = 2; // color type: truecolor RGB
+  ihdr[10] = 0; // compresión deflate
+  ihdr[11] = 0; // filtro adaptativo
+  ihdr[12] = 0; // sin entrelazado
+
+  return Buffer.concat([
+    PNG_SIGNATURE,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(raw, { level: 9 })),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+function mix(a: Rgb, b: Rgb, t: number): Rgb {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+/** Ruido determinista en [0,1) a partir de coordenadas y semilla. */
+function noise(x: number, y: number, seed: number): number {
+  const n = Math.sin(x * 12.9898 + y * 78.233 + seed * 43.758) * 43758.5453;
+  return n - Math.floor(n);
+}
+
+const WIDTH = 640;
+const HEIGHT = 400;
+
+/**
+ * Devuelve un PNG de paisaje para un terreno. `seed` fija el tono (cielo y
+ * verde de la parcela) y el relieve, así que el mismo terreno tiene siempre la
+ * misma foto y dos terrenos distintos se distinguen a simple vista.
+ */
+export function makeLandPhoto(seed: number): Buffer {
+  const skyTop: Rgb = [120 + ((seed * 7) % 40), 170 + ((seed * 11) % 30), 215];
+  const skyBottom: Rgb = [214, 232, 238];
+  const fieldNear: Rgb = [46 + ((seed * 13) % 30), 96 + ((seed * 17) % 45), 38];
+  const fieldFar: Rgb = [126 + ((seed * 5) % 40), 158 + ((seed * 3) % 30), 82];
+  const hills: Rgb = [72, 108, 76];
+
+  const horizon = Math.round(HEIGHT * (0.42 + ((seed % 7) / 100)));
+  // Perfil de colinas: dos senos desfasados por la semilla, sin aleatoriedad.
+  const hillAt = (x: number) =>
+    horizon
+    - Math.round(18 * Math.sin((x / WIDTH) * Math.PI * 2 + seed))
+    - Math.round(10 * Math.sin((x / WIDTH) * Math.PI * 5 + seed * 2));
+
+  return encodePng(WIDTH, HEIGHT, (x, y) => {
+    if (y < hillAt(x)) {
+      return mix(skyTop, skyBottom, y / horizon);
+    }
+    if (y < horizon + 12) {
+      return hills;
+    }
+    // Campo en perspectiva: más oscuro y más texturado según se acerca.
+    const depth = (y - horizon) / (HEIGHT - horizon);
+    const base = mix(fieldFar, fieldNear, depth);
+    const grain = (noise(Math.floor(x / 3), Math.floor(y / 3), seed) - 0.5) * 26 * depth;
+    return [
+      Math.max(0, Math.min(255, Math.round(base[0] + grain))),
+      Math.max(0, Math.min(255, Math.round(base[1] + grain))),
+      Math.max(0, Math.min(255, Math.round(base[2] + grain))),
+    ];
+  });
+}

--- a/apps/backend-api/src/migrations/002-drop-stale-user-id-index.ts
+++ b/apps/backend-api/src/migrations/002-drop-stale-user-id-index.ts
@@ -1,0 +1,33 @@
+import type { Migration } from "./types";
+import { User } from "../db/schemas";
+
+/**
+ * Elimina el índice único obsoleto `users.id_1` (#356).
+ *
+ * `UserSchema` no tiene campo `id` — la identidad del usuario es `clerkUserId`.
+ * El índice quedó de la etapa del driver nativo, cuando los usuarios semilla
+ * llevaban un `id` propio, y sobrevive en cualquier base creada antes de #135
+ * porque Mongoose crea índices pero nunca borra los que sobran.
+ *
+ * Mientras existe, rompe el alta de usuarios reales: `ensureUserInMongo` inserta
+ * sin `id`, Mongo indexa el campo ausente como `null`, y el **segundo** usuario
+ * de Clerk que inicie sesión choca con E11000 contra el primero. El error se
+ * traga el `catch` de `ensureUserInMongo`, así que el síntoma visible es que el
+ * panel de admin solo muestra un usuario real, sin ningún error en los logs.
+ */
+export const migration: Migration = {
+  id: "002",
+  name: "drop-stale-user-id-index",
+  async up(db) {
+    await db
+      .collection(User.collection.name)
+      .dropIndex("id_1")
+      .catch(() => {
+        // En bases nuevas el índice nunca existió: la migración no tiene efecto.
+      });
+  },
+  async down() {
+    // No se recrea a propósito: el índice era un error y volver a ponerlo
+    // reintroduciría el fallo de alta de usuarios.
+  },
+};

--- a/apps/backend-api/src/migrations/index.ts
+++ b/apps/backend-api/src/migrations/index.ts
@@ -1,8 +1,9 @@
 import type { Migration } from "./types";
 import { migration as m001UniqueIndexes } from "./001-unique-indexes";
+import { migration as m002DropStaleUserIdIndex } from "./002-drop-stale-user-id-index";
 
 /**
  * Registro ordenado de migraciones (#173). Añade nuevas migraciones al final,
  * con un `id` estrictamente mayor. El migrador las aplica en este orden.
  */
-export const migrations: Migration[] = [m001UniqueIndexes];
+export const migrations: Migration[] = [m001UniqueIndexes, m002DropStaleUserIdIndex];


### PR DESCRIPTION
## Qué resuelve

Había pantallas vacías sin poder saber si era falta de datos o un bug de llamada. El seed de arranque (`src/db/seed.ts`) no servía para eso: genera volumen aleatorio sobre usuarios sintéticos `user_001..020`, y las rutas filtran por `authUser.id` — que **es** el id de Clerk — así que una sesión real no ve nada suyo. Además las relaciones se sorteaban: el `ownerId` de un contrato no tenía por qué ser el dueño del terreno de su solicitud.

## Qué hace

`bun run seed:demo` (nuevo `src/db/seed-demo.ts`):

- **Actores reales de Clerk.** La cuenta principal juega de **dueña** (`land_me_*`) y de **arrendataria** (solicitudes sobre los terrenos de Alice) a la vez, con Bob de contraparte y dos cuentas admin. Se puede apuntar a otra sesión con `SEED_MAIN_CLERK_ID=user_xxx`.
- **Coherencia por construcción.** Los tratos se declaran de arriba abajo (terreno → solicitud → contrato → pago → chat → reseña) y las claves se derivan, no se sortean.
- **Cobertura de estados.** Los 7 de solicitud, los 4 de contrato, los 7 de pago (incluidos `refunded` y `partially_refunded`), los 4 de visita y los 4 de reporte.
- **Todas las entidades**, incluidas las que faltaban: favoritos, reseñas, búsquedas guardadas, visitas y notificaciones.
- **Fotos reales.** `src/db/seed-photo.ts` genera PNG procedurales (un paisaje cuyo tono sale de una semilla) y los sube a GridFS, así el catálogo no es un muro de marcadores de posición. Sin dependencias nuevas ni imágenes externas.
- **Determinista**: PRNG con semilla, misma salida en cada corrida.

## Dos hallazgos preexistentes, arreglados aquí

1. **`users.id_1`: índice único obsoleto que rompe el alta de usuarios reales.** `UserSchema` no tiene campo `id` — la identidad es `clerkUserId` — pero el índice sobrevivía de la etapa del driver nativo. Mongo indexa el campo ausente como `null`, así que el **segundo** usuario de Clerk que iniciara sesión chocaba con E11000 contra el primero. El `catch` de `ensureUserInMongo` se tragaba el error: el síntoma era un panel de admin con un solo usuario real y ni una línea en los logs. Lo retira la migración **002**, y el script de seed aplica migraciones antes de escribir.
2. **Colecciones fantasma en camelCase.** `rentalRequests` (100 docs), `chatMessages` (200) y `auditEvents` (500) quedaron de antes de #135. Mongoose lee de las minúsculas, así que esos documentos eran invisibles para la app y solo engañaban al contar. El seed las elimina.

## Verificación

- `bun test`: **364 pass / 0 fail** (338 antes; +26 del nuevo `seed-demo.test.ts`, que fija las invariantes del grafo: integridad referencial, nadie se solicita su propio terreno, participantes del chat = dueño + solicitante, sin autorreseñas, ids únicos, cobertura de estados).
- `bun run typecheck`: limpio.
- Contra el backend en marcha, con la cuenta principal: `/lands/me` 6, `/rental-requests` 16 (8 como dueña + 8 como solicitante), `/contracts` 8, `/payments` 9, `/chats` 8, `/users/me/favorites` 6, `/users/me/visits` 8, `/users/me/saved-searches` 3, `/notifications` 14, y el perfil público devuelve calificación 4,7 sobre 3 reseñas.

Closes #356
