### PR TITLE
fix: catálogo caído en dev, etiquetas de contrato y reembolsos en la conciliación (#358)

### DIFF
--- a/apps/backend-api/src/lib/payments-reconciliation-refunds.test.ts
+++ b/apps/backend-api/src/lib/payments-reconciliation-refunds.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+
+import { reconcile } from "./payments-reconciliation";
+
+/**
+ * Los reembolsos en la conciliación (#358).
+ *
+ * Antes solo contaba `status === "paid"`, así que un pago con reembolso parcial
+ * —dinero que sí entró— desaparecía de los totales y, además, hacía que su
+ * solicitud pagada se denunciara como «pagada sin ningún pago confirmado».
+ */
+
+const base = {
+  currency: "USD" as const,
+  platformFeeAmount: 50,
+  netAmount: 950,
+  amount: 1000,
+};
+
+describe("conciliación con reembolsos", () => {
+  it("cuenta un reembolso parcial como cobro y descuenta lo devuelto del neto", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "partially_refunded", ...base, refundedAmount: 200 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const usd = report.totals.find((t) => t.currency === "USD")!;
+    expect(usd.paidCount).toBe(1);
+    expect(usd.grossAmount).toBe(1000);
+    expect(usd.platformFeeAmount).toBe(50);
+    expect(usd.refundedAmount).toBe(200);
+    expect(usd.netAmount).toBe(750);
+  });
+
+  it("no denuncia como «solicitud pagada sin pago» una con reembolso parcial", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "partially_refunded", ...base, refundedAmount: 200 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    expect(report.discrepancies.filter((d) => d.type === "request_paid_without_paid_payment")).toEqual([]);
+  });
+
+  it("sí denuncia una solicitud que sigue «pagada» tras un reembolso total", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "refunded", ...base, refundedAmount: 1000 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const flagged = report.discrepancies.filter((d) => d.type === "request_paid_without_paid_payment");
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].rentalRequestId).toBe("rr_1");
+  });
+
+  it("un reembolso total deja el neto en cero pero conserva el movimiento en el bruto", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "refunded", ...base, refundedAmount: 1000 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const usd = report.totals.find((t) => t.currency === "USD")!;
+    expect(usd.grossAmount).toBe(1000);
+    expect(usd.refundedAmount).toBe(1000);
+    // 950 de neto menos los 1000 devueltos: el cobro quedó revertido con creces
+    // (la comisión de plataforma no se reembolsa).
+    expect(usd.netAmount).toBe(-50);
+  });
+
+  it("declara un contador para cada estado de pago, incluidos los de reembolso", () => {
+    const report = reconcile([], [], []);
+    expect(report.paymentsByStatus).toHaveProperty("refunded", 0);
+    expect(report.paymentsByStatus).toHaveProperty("partially_refunded", 0);
+  });
+
+  it("un pago sin reembolsos deja el total devuelto en cero", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "paid", ...base }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const usd = report.totals.find((t) => t.currency === "USD")!;
+    expect(usd.refundedAmount).toBe(0);
+    expect(usd.netAmount).toBe(950);
+  });
+});

--- a/apps/backend-api/src/lib/payments-reconciliation.ts
+++ b/apps/backend-api/src/lib/payments-reconciliation.ts
@@ -25,6 +25,8 @@ export interface ReconciliationCurrencyTotalsDto {
   paidCount: number;
   grossAmount: number;
   platformFeeAmount: number;
+  /** Suma devuelta a los arrendatarios; ya está descontada del `netAmount`. */
+  refundedAmount: number;
   netAmount: number;
 }
 
@@ -50,7 +52,24 @@ const PAYMENT_STATUSES: PaymentStatus[] = [
   "paid",
   "failed",
   "cancelled",
+  "partially_refunded",
+  "refunded",
 ];
+
+/**
+ * Estados en los que el dinero **sí entró**. Un reembolso parcial sigue siendo
+ * un cobro (se devolvió una parte, no el cobro entero), y uno total también
+ * ocurrió aunque después se revirtiera: dejarlos fuera de los totales escondía
+ * movimientos reales del informe, que es justo lo que una conciliación existe
+ * para no perder. La devolución se resta aparte, en `refundedAmount`.
+ */
+const COLLECTED_STATUSES: PaymentStatus[] = ["paid", "partially_refunded", "refunded"];
+
+/**
+ * Estados en los que el cobro **sigue en pie** hoy. Un reembolso total deja la
+ * solicitud sin cobro vigente, así que no cuenta aquí.
+ */
+const STILL_COLLECTED_STATUSES: PaymentStatus[] = ["paid", "partially_refunded"];
 
 interface ReconPayment {
   id: string;
@@ -60,6 +79,7 @@ interface ReconPayment {
   currency: BusinessCurrency;
   platformFeeAmount?: number;
   netAmount?: number;
+  refundedAmount?: number;
 }
 
 interface ReconRequest {
@@ -83,7 +103,9 @@ export function reconcile(
   const requestById = new Map(requests.map((r) => [r.id, r]));
   const contractByRequest = new Set(contracts.map((c) => c.rentalRequestId));
   const paidPaymentRequestIds = new Set(
-    payments.filter((p) => p.status === "paid").map((p) => p.rentalRequestId),
+    payments
+      .filter((p) => STILL_COLLECTED_STATUSES.includes(p.status))
+      .map((p) => p.rentalRequestId),
   );
 
   const paymentsByStatus = Object.fromEntries(
@@ -96,7 +118,7 @@ export function reconcile(
   for (const p of payments) {
     paymentsByStatus[p.status] = (paymentsByStatus[p.status] ?? 0) + 1;
 
-    if (p.status !== "paid") continue;
+    if (!COLLECTED_STATUSES.includes(p.status)) continue;
 
     const totals =
       totalsByCurrency.get(p.currency) ??
@@ -105,12 +127,16 @@ export function reconcile(
         paidCount: 0,
         grossAmount: 0,
         platformFeeAmount: 0,
+        refundedAmount: 0,
         netAmount: 0,
       } satisfies ReconciliationCurrencyTotalsDto);
+    const refunded = p.refundedAmount ?? 0;
     totals.paidCount += 1;
     totals.grossAmount = round2(totals.grossAmount + p.amount);
     totals.platformFeeAmount = round2(totals.platformFeeAmount + (p.platformFeeAmount ?? 0));
-    totals.netAmount = round2(totals.netAmount + (p.netAmount ?? p.amount));
+    totals.refundedAmount = round2(totals.refundedAmount + refunded);
+    // El neto es lo que queda del cobro tras la comisión y las devoluciones.
+    totals.netAmount = round2(totals.netAmount + (p.netAmount ?? p.amount) - refunded);
     totalsByCurrency.set(p.currency, totals);
 
     const request = requestById.get(p.rentalRequestId);
@@ -164,7 +190,7 @@ export function reconcile(
 
 export async function buildReconciliationReport(): Promise<ReconciliationReportDto> {
   const [payments, requests, contracts] = await Promise.all([
-    Payment.find().select("id rentalRequestId status amount currency platformFeeAmount netAmount").lean(),
+    Payment.find().select("id rentalRequestId status amount currency platformFeeAmount netAmount refundedAmount").lean(),
     RentalRequest.find().select("id status").lean(),
     Contract.find().select("rentalRequestId").lean(),
   ]);

--- a/apps/web/src/components/LazyPanamaMap.tsx
+++ b/apps/web/src/components/LazyPanamaMap.tsx
@@ -1,0 +1,43 @@
+import { Suspense, lazy, useEffect, useState, type ComponentProps } from "react";
+
+import type PanamaMapComponent from "./PanamaMap";
+
+/**
+ * Carga `PanamaMap` **solo en el navegador**.
+ *
+ * Leaflet toca `window` en cuanto se evalúa su módulo, así que importarlo desde
+ * un componente que el servidor renderiza rompe el SSR con `window is not
+ * defined`. En dev (`bun run dev`, donde TanStack Start sí hace SSR) eso dejaba
+ * el catálogo entero en una página de error.
+ *
+ * `lazy()` no evalúa el módulo hasta que se renderiza, y el interruptor
+ * `mounted` garantiza que ese primer render ocurra ya en el cliente: durante el
+ * SSR y la hidratación inicial se pinta el hueco, y el mapa entra después.
+ */
+const PanamaMap = lazy(() => import("./PanamaMap"));
+
+type PanamaMapProps = ComponentProps<typeof PanamaMapComponent>;
+
+/**
+ * Hueco con el mismo tamaño que el mapa (la columna ya estira
+ * `.panama-map-container` al 100%), para no provocar salto de maqueta.
+ */
+function MapPlaceholder() {
+  return <div className="panama-map-container" aria-hidden="true" />;
+}
+
+export default function LazyPanamaMap(props: PanamaMapProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return <MapPlaceholder />;
+
+  return (
+    <Suspense fallback={<MapPlaceholder />}>
+      <PanamaMap {...props} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/short-id.ts
+++ b/apps/web/src/lib/short-id.ts
@@ -1,0 +1,18 @@
+/**
+ * Etiqueta corta y legible para un identificador de entidad.
+ *
+ * Los ids del backend llevan prefijo de tipo (`contract_<uuid>`,
+ * `rr_<uuid>`, `pay_<uuid>`), así que recortar los primeros caracteres a secas
+ * devolvía el prefijo y nada más: **todos** los contratos se titulaban
+ * «Contrato #contract» y eran indistinguibles entre sí.
+ *
+ * Se descarta el prefijo y se recorta lo que identifica de verdad.
+ */
+export function shortId(id: string | undefined | null, length = 8): string {
+  if (!id) return "—";
+  const separator = id.indexOf("_");
+  const meaningful = separator >= 0 ? id.slice(separator + 1) : id;
+  // Si tras quitar el prefijo no queda nada (un id que *es* solo el prefijo),
+  // se devuelve el original antes que una cadena vacía.
+  return (meaningful || id).slice(0, length);
+}

--- a/apps/web/src/pages/AdminReconciliationPage.tsx
+++ b/apps/web/src/pages/AdminReconciliationPage.tsx
@@ -17,6 +17,8 @@ const STATUS_LABELS: Record<string, string> = {
   paid: "Pagados",
   failed: "Fallidos",
   cancelled: "Cancelados",
+  partially_refunded: "Reembolso parcial",
+  refunded: "Reembolsados",
 };
 
 function formatMoney(amount: number, currency: string): string {
@@ -72,7 +74,7 @@ export default function AdminReconciliationPage() {
             </div>
             <div className="adm-stat">
               <div className="adm-stat__value">{totalPaid}</div>
-              <div className="adm-stat__label">Pagos pagados</div>
+              <div className="adm-stat__label">Pagos cobrados</div>
             </div>
             {report.totals.map((t) => (
               <div className="adm-stat" key={`stat-${t.currency}`}>
@@ -84,22 +86,24 @@ export default function AdminReconciliationPage() {
 
           <h2 className="adm-title" style={{ fontSize: 20, marginTop: 8 }}>Totales por moneda</h2>
           <div className="adm-table" style={{ marginBottom: 26 }}>
-            <div className="adm-trow adm-trow--head" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr" }}>
+            <div className="adm-trow adm-trow--head" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr 1fr" }}>
               <span>Moneda</span>
               <span>Pagos</span>
               <span>Bruto</span>
               <span>Comisión</span>
+              <span>Reembolsado</span>
               <span>Neto</span>
             </div>
             {report.totals.length === 0 ? (
-              <div className="adm-empty">Aún no hay pagos pagados.</div>
+              <div className="adm-empty">Aún no hay pagos cobrados.</div>
             ) : (
               report.totals.map((t) => (
-                <div key={t.currency} className="adm-trow" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr" }}>
+                <div key={t.currency} className="adm-trow" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr 1fr" }}>
                   <span className="adm-cell--strong">{t.currency}</span>
                   <span>{t.paidCount}</span>
                   <span>{formatMoney(t.grossAmount, t.currency)}</span>
                   <span className="adm-cell--muted">{formatMoney(t.platformFeeAmount, t.currency)}</span>
+                  <span className="adm-cell--muted">{formatMoney(t.refundedAmount ?? 0, t.currency)}</span>
                   <span className="adm-cell--strong">{formatMoney(t.netAmount, t.currency)}</span>
                 </div>
               ))

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -15,7 +15,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import { listLands, photoSrc } from "../services/api";
-import PanamaMap from "../components/PanamaMap";
+import PanamaMap from "../components/LazyPanamaMap";
 import EmptyState from "../components/EmptyState";
 import { useFavorites } from "../hooks/useFavorites";
 import { useCompareLands } from "../hooks/useCompareLands";

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { useParams } from "@tanstack/react-router";
 import { useAuth, useUser } from "@clerk/clerk-react";
 import { Star, Download } from "lucide-react";
@@ -96,7 +97,7 @@ export default function ContractDetailPage() {
     <div>
       <div className="section-header">
         <h1>Detalle de contrato</h1>
-        <p>Contrato #{contractId?.slice(0, 8)}</p>
+        <p>Contrato #{shortId(contractId)}</p>
       </div>
 
       {loading && (
@@ -114,7 +115,7 @@ export default function ContractDetailPage() {
       {contract && status && (
         <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start", marginBottom: "1rem" }}>
-            <h3 style={{ margin: 0 }}>Contrato #{contract.id?.slice(0, 8)}</h3>
+            <h3 style={{ margin: 0 }}>Contrato #{shortId(contract.id)}</h3>
             <span style={{
               padding: "0.25rem 0.75rem",
               borderRadius: "999px",
@@ -127,7 +128,7 @@ export default function ContractDetailPage() {
             </span>
           </div>
           <div style={{ fontSize: "0.9rem", opacity: 0.75, display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-            <p style={{ margin: 0 }}><strong>Solicitud:</strong> {contract.rentalRequestId?.slice(0, 8) || "—"}</p>
+            <p style={{ margin: 0 }}><strong>Solicitud:</strong> {shortId(contract.rentalRequestId)}</p>
             <p style={{ margin: 0 }}><strong>Período:</strong> {contract.terms?.startsAt || "—"} → {contract.terms?.endsAt || "—"}</p>
             <p style={{ margin: 0 }}><strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString() : "—"}</p>
           </div>

--- a/apps/web/src/pages/ContractsPage.tsx
+++ b/apps/web/src/pages/ContractsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { useAuth, useUser } from "@clerk/clerk-react";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
@@ -80,9 +81,9 @@ export default function ContractsPage() {
               <div key={contract.id} className="glass-panel">
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start", marginBottom: "1rem" }}>
                   <div>
-                    <h3 style={{ margin: 0 }}>Contrato #{contract.id.slice(0, 8)}</h3>
+                    <h3 style={{ margin: 0 }}>Contrato #{shortId(contract.id)}</h3>
                     <p style={{ margin: "0.25rem 0", opacity: 0.6, fontSize: "0.85rem" }}>
-                      Solicitud: {contract.rentalRequestId?.slice(0, 8)}
+                      Solicitud: {shortId(contract.rentalRequestId)}
                     </p>
                   </div>
                   <span style={{

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useUser } from "@clerk/clerk-react";
 import type { ChatDto, LandDto, RentalRequestDto, RentalRequestStatus } from "@terrashare/shared";
@@ -179,7 +180,7 @@ function BuscoHome({ name }: { name: string }) {
                   ) : status.foot === "wait" ? (
                     <div className="hm-req__note">Esperando respuesta del propietario</div>
                   ) : (
-                    <div className="hm-req__note">Solicitud #{req.id.slice(0, 8)}</div>
+                    <div className="hm-req__note">Solicitud #{shortId(req.id)}</div>
                   )}
                 </div>
               );

--- a/apps/web/src/pages/PaymentPage.tsx
+++ b/apps/web/src/pages/PaymentPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { shortId } from "../lib/short-id";
 import type { FormEvent } from "react";
 import { useParams, Link } from "@tanstack/react-router";
 import { loadStripe } from "@stripe/stripe-js";
@@ -216,7 +217,7 @@ export default function PaymentPage() {
             <div style={{ flex: 1, minWidth: 0 }}>
               <div className="dl-head__title">{isSale ? "Trato de compra" : "Trato de alquiler"}</div>
               <div className="dl-head__meta">
-                {isSale ? "Oferta" : "Solicitud"} #{requestId?.slice(0, 8)}
+                {isSale ? "Oferta" : "Solicitud"} #{shortId(requestId)}
               </div>
             </div>
             <span className="dl-head__status">Aprobada · falta pago</span>

--- a/apps/web/src/pages/PaymentsPage.tsx
+++ b/apps/web/src/pages/PaymentsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { Link } from "@tanstack/react-router";
 import { useUser } from "@clerk/clerk-react";
 import type { PaymentDto } from "@terrashare/shared";
@@ -128,7 +129,7 @@ export default function PaymentsPage() {
               <div key={p.id} className="pay-row">
                 <span className="pay-cell--date">{isPending ? "Pendiente" : formatDate(p.createdAt)}</span>
                 <span className="pay-cell--land">
-                  {p.landTitle || `Solicitud #${p.rentalRequestId?.slice(0, 8) ?? "—"}`}
+                  {p.landTitle || `Solicitud #${shortId(p.rentalRequestId)}`}
                 </span>
                 <span>${(p.amount ?? 0).toLocaleString("es-PA")}</span>
                 <span>

--- a/packages/shared/src/dto/payments.ts
+++ b/packages/shared/src/dto/payments.ts
@@ -86,6 +86,8 @@ export interface ReconciliationCurrencyTotalsDto {
   paidCount: number;
   grossAmount: number;
   platformFeeAmount: number;
+  /** Suma devuelta a los arrendatarios; ya está descontada del `netAmount`. */
+  refundedAmount: number;
   netAmount: number;
 }
 


### PR DESCRIPTION
Tres defectos **preexistentes** que salieron al recorrer las pantallas con los datos sembrados en #356.

## 1. `/catalog` estaba caído en desarrollo

`CatalogPage` importa `PanamaMap` → Leaflet, y Leaflet toca `window` en cuanto se evalúa su módulo, así que el SSR de TanStack Start reventaba y la pantalla principal del producto devolvía una página de error en `bun run dev`:

```
Error in renderToPipeableStream: ReferenceError: window is not defined
    at leaflet/src/core/Util.js:217 → src/components/PanamaMap.tsx:2 → src/pages/CatalogPage.tsx:18
```

Nuevo `LazyPanamaMap`: `lazy()` no evalúa el módulo hasta renderizarlo, y un interruptor `mounted` garantiza que ese primer render ocurra ya en el cliente. El hueco reserva el tamaño del mapa para no provocar salto de maqueta.

**Por qué el CI no lo veía:** los E2E corren contra `preview:static`, que es una SPA client-only. Sin SSR, el módulo nunca se evalúa en el servidor. Es el mismo punto ciego de #355.

## 2. Todos los contratos se titulaban «Contrato #contract»

`contract.id.slice(0, 8)` sobre `contract_<uuid>` devuelve el prefijo y nada más, así que las tarjetas eran indistinguibles. Nuevo `shortId()` en `src/lib/short-id.ts`: descarta el prefijo de tipo y recorta lo que identifica de verdad. Aplicado también a `rr_` y `pay_` en `ContractDetailPage`, `HomePage`, `PaymentPage` y `PaymentsPage`.

Antes: `Contrato #contract` ×8 · Ahora: `Contrato #d01`, `#d02`, `#d06`…

## 3. La conciliación ignoraba los pagos con reembolso

`reconcile()` solo tomaba `status === "paid"` como cobrado:

- un **reembolso parcial** —dinero que sí entró— desaparecía de los totales por moneda, justo lo que un informe de conciliación existe para no perder;
- su solicitud se denunciaba como «Solicitud pagada sin ningún pago confirmado»: discrepancia falsa;
- `PAYMENT_STATUSES` no declaraba `refunded` ni `partially_refunded`, así que la UI los imprimía en crudo;
- lo devuelto no se restaba en ninguna parte y el neto quedaba inflado.

Ahora se distingue **cobrado alguna vez** (entra en los totales) de **cobro vigente hoy** (evita la discrepancia falsa; un reembolso total sí sigue marcándose, que es correcto), y las devoluciones tienen columna propia y se descuentan del neto.

## Verificación

- `bun test` backend: **344 pass / 0 fail** (338 antes + 6 del nuevo `payments-reconciliation-refunds.test.ts`).
- `bun run typecheck` backend y web: limpios. `bun run build` web: OK.
- En el navegador, con los datos sembrados:
  - `/catalog` carga, lista 20 terrenos y el mapa pinta los marcadores.
  - Contratos: `#d01`, `#d02`, `#d06`, `#d07`, `#d10`, `#d12`, `#d14`, `#d17`.
  - Conciliación: de 2 discrepancias a **1** (desaparece la falsa de `rr_d12`; sigue la legítima de `rr_d17`, cuyo pago se reembolsó entero); 5 pagos cobrados, bruto USD 7.180, comisión USD 359, reembolsado USD 2.140, neto USD 4.681; y los contadores ya dicen «Reembolso parcial» y «Reembolsados».

Closes #358
