### PR TITLE
test(web): E2E de interactividad real y del modo SSR (#360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,10 @@ jobs:
         env:
           VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.VITE_CLERK_PUBLISHABLE_KEY }}
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
-      - run: bun run test:e2e -- --project=chromium
+      # `dev-ssr` corre las pruebas de interactividad contra `vite dev`, donde la
+      # app se renderiza en el servidor. Es el modo que nadie probaba y por donde
+      # se colaron #354 (la app no hidrataba) y el crash de Leaflet (#358).
+      - run: bun run test:e2e -- --project=chromium --project=dev-ssr
         env:
           VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.VITE_CLERK_PUBLISHABLE_KEY }}
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}

--- a/apps/backend-api/src/lib/payments-reconciliation-refunds.test.ts
+++ b/apps/backend-api/src/lib/payments-reconciliation-refunds.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+
+import { reconcile } from "./payments-reconciliation";
+
+/**
+ * Los reembolsos en la conciliación (#358).
+ *
+ * Antes solo contaba `status === "paid"`, así que un pago con reembolso parcial
+ * —dinero que sí entró— desaparecía de los totales y, además, hacía que su
+ * solicitud pagada se denunciara como «pagada sin ningún pago confirmado».
+ */
+
+const base = {
+  currency: "USD" as const,
+  platformFeeAmount: 50,
+  netAmount: 950,
+  amount: 1000,
+};
+
+describe("conciliación con reembolsos", () => {
+  it("cuenta un reembolso parcial como cobro y descuenta lo devuelto del neto", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "partially_refunded", ...base, refundedAmount: 200 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const usd = report.totals.find((t) => t.currency === "USD")!;
+    expect(usd.paidCount).toBe(1);
+    expect(usd.grossAmount).toBe(1000);
+    expect(usd.platformFeeAmount).toBe(50);
+    expect(usd.refundedAmount).toBe(200);
+    expect(usd.netAmount).toBe(750);
+  });
+
+  it("no denuncia como «solicitud pagada sin pago» una con reembolso parcial", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "partially_refunded", ...base, refundedAmount: 200 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    expect(report.discrepancies.filter((d) => d.type === "request_paid_without_paid_payment")).toEqual([]);
+  });
+
+  it("sí denuncia una solicitud que sigue «pagada» tras un reembolso total", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "refunded", ...base, refundedAmount: 1000 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const flagged = report.discrepancies.filter((d) => d.type === "request_paid_without_paid_payment");
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].rentalRequestId).toBe("rr_1");
+  });
+
+  it("un reembolso total deja el neto en cero pero conserva el movimiento en el bruto", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "refunded", ...base, refundedAmount: 1000 }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const usd = report.totals.find((t) => t.currency === "USD")!;
+    expect(usd.grossAmount).toBe(1000);
+    expect(usd.refundedAmount).toBe(1000);
+    // 950 de neto menos los 1000 devueltos: el cobro quedó revertido con creces
+    // (la comisión de plataforma no se reembolsa).
+    expect(usd.netAmount).toBe(-50);
+  });
+
+  it("declara un contador para cada estado de pago, incluidos los de reembolso", () => {
+    const report = reconcile([], [], []);
+    expect(report.paymentsByStatus).toHaveProperty("refunded", 0);
+    expect(report.paymentsByStatus).toHaveProperty("partially_refunded", 0);
+  });
+
+  it("un pago sin reembolsos deja el total devuelto en cero", () => {
+    const report = reconcile(
+      [{ id: "pay_1", rentalRequestId: "rr_1", status: "paid", ...base }],
+      [{ id: "rr_1", status: "paid" }],
+      [{ rentalRequestId: "rr_1" }],
+    );
+
+    const usd = report.totals.find((t) => t.currency === "USD")!;
+    expect(usd.refundedAmount).toBe(0);
+    expect(usd.netAmount).toBe(950);
+  });
+});

--- a/apps/backend-api/src/lib/payments-reconciliation.ts
+++ b/apps/backend-api/src/lib/payments-reconciliation.ts
@@ -25,6 +25,8 @@ export interface ReconciliationCurrencyTotalsDto {
   paidCount: number;
   grossAmount: number;
   platformFeeAmount: number;
+  /** Suma devuelta a los arrendatarios; ya está descontada del `netAmount`. */
+  refundedAmount: number;
   netAmount: number;
 }
 
@@ -50,7 +52,24 @@ const PAYMENT_STATUSES: PaymentStatus[] = [
   "paid",
   "failed",
   "cancelled",
+  "partially_refunded",
+  "refunded",
 ];
+
+/**
+ * Estados en los que el dinero **sí entró**. Un reembolso parcial sigue siendo
+ * un cobro (se devolvió una parte, no el cobro entero), y uno total también
+ * ocurrió aunque después se revirtiera: dejarlos fuera de los totales escondía
+ * movimientos reales del informe, que es justo lo que una conciliación existe
+ * para no perder. La devolución se resta aparte, en `refundedAmount`.
+ */
+const COLLECTED_STATUSES: PaymentStatus[] = ["paid", "partially_refunded", "refunded"];
+
+/**
+ * Estados en los que el cobro **sigue en pie** hoy. Un reembolso total deja la
+ * solicitud sin cobro vigente, así que no cuenta aquí.
+ */
+const STILL_COLLECTED_STATUSES: PaymentStatus[] = ["paid", "partially_refunded"];
 
 interface ReconPayment {
   id: string;
@@ -60,6 +79,7 @@ interface ReconPayment {
   currency: BusinessCurrency;
   platformFeeAmount?: number;
   netAmount?: number;
+  refundedAmount?: number;
 }
 
 interface ReconRequest {
@@ -83,7 +103,9 @@ export function reconcile(
   const requestById = new Map(requests.map((r) => [r.id, r]));
   const contractByRequest = new Set(contracts.map((c) => c.rentalRequestId));
   const paidPaymentRequestIds = new Set(
-    payments.filter((p) => p.status === "paid").map((p) => p.rentalRequestId),
+    payments
+      .filter((p) => STILL_COLLECTED_STATUSES.includes(p.status))
+      .map((p) => p.rentalRequestId),
   );
 
   const paymentsByStatus = Object.fromEntries(
@@ -96,7 +118,7 @@ export function reconcile(
   for (const p of payments) {
     paymentsByStatus[p.status] = (paymentsByStatus[p.status] ?? 0) + 1;
 
-    if (p.status !== "paid") continue;
+    if (!COLLECTED_STATUSES.includes(p.status)) continue;
 
     const totals =
       totalsByCurrency.get(p.currency) ??
@@ -105,12 +127,16 @@ export function reconcile(
         paidCount: 0,
         grossAmount: 0,
         platformFeeAmount: 0,
+        refundedAmount: 0,
         netAmount: 0,
       } satisfies ReconciliationCurrencyTotalsDto);
+    const refunded = p.refundedAmount ?? 0;
     totals.paidCount += 1;
     totals.grossAmount = round2(totals.grossAmount + p.amount);
     totals.platformFeeAmount = round2(totals.platformFeeAmount + (p.platformFeeAmount ?? 0));
-    totals.netAmount = round2(totals.netAmount + (p.netAmount ?? p.amount));
+    totals.refundedAmount = round2(totals.refundedAmount + refunded);
+    // El neto es lo que queda del cobro tras la comisión y las devoluciones.
+    totals.netAmount = round2(totals.netAmount + (p.netAmount ?? p.amount) - refunded);
     totalsByCurrency.set(p.currency, totals);
 
     const request = requestById.get(p.rentalRequestId);
@@ -164,7 +190,7 @@ export function reconcile(
 
 export async function buildReconciliationReport(): Promise<ReconciliationReportDto> {
   const [payments, requests, contracts] = await Promise.all([
-    Payment.find().select("id rentalRequestId status amount currency platformFeeAmount netAmount").lean(),
+    Payment.find().select("id rentalRequestId status amount currency platformFeeAmount netAmount refundedAmount").lean(),
     RentalRequest.find().select("id status").lean(),
     Contract.find().select("rentalRequestId").lean(),
   ]);

--- a/apps/web/playwright.config.js
+++ b/apps/web/playwright.config.js
@@ -18,20 +18,45 @@ export default defineConfig({
     baseURL: "http://localhost:5173",
     trace: "on-first-retry"
   },
-  // El E2E prueba el build de producción (client-only, servido estáticamente),
-  // no `bun run dev`: en dev, TanStack Start hace SSR e incompatibiliza con el
-  // client entry usado en producción. Así se prueba el mismo artefacto que se
-  // despliega. El build tarda, por eso el timeout más alto.
-  webServer: {
-    command: "bun run preview:static",
-    url: "http://localhost:5173",
-    reuseExistingServer: !process.env.CI,
-    timeout: 180000
-  },
+  // Se levantan los DOS modos en que arranca la app, porque el montaje difiere
+  // y cada uno tiene fallos propios:
+  //
+  // - 5173: build de producción (SPA client-only servida estáticamente). Es el
+  //   artefacto que se despliega y contra el que corre la suite principal.
+  // - 5174: `bun run dev`, donde TanStack Start hace SSR del documento entero.
+  //
+  // Probar solo producción dejaba ciego todo lo específico del SSR: así pasaron
+  // desapercibidos #354 (la app nunca hidrataba en dev) y el crash de Leaflet
+  // que tumbaba el catálogo (#358).
+  webServer: [
+    {
+      command: "bun run preview:static",
+      url: "http://localhost:5173",
+      reuseExistingServer: !process.env.CI,
+      // El build tarda, por eso el timeout más alto.
+      timeout: 180000
+    },
+    {
+      command: "bunx vite dev --port 5174 --strictPort",
+      url: "http://localhost:5174",
+      reuseExistingServer: !process.env.CI,
+      timeout: 180000
+    }
+  ],
   projects: [
     {
       name: "chromium",
+      // Las `.ssr.spec.js` son del proyecto `dev-ssr`: apuntan al otro servidor.
+      testIgnore: /\.ssr\.spec\.js$/,
       use: { ...devices["Desktop Chrome"] }
+    },
+    {
+      // Mismas pruebas de interactividad, contra el servidor de desarrollo:
+      // aquí el documento llega renderizado por el servidor, así que si la
+      // hidratación no engancha, el marcado se ve pero nada responde.
+      name: "dev-ssr",
+      testMatch: /\.ssr\.spec\.js$/,
+      use: { ...devices["Desktop Chrome"], baseURL: "http://localhost:5174" }
     },
     {
       name: "firefox",

--- a/apps/web/src/components/LazyPanamaMap.tsx
+++ b/apps/web/src/components/LazyPanamaMap.tsx
@@ -1,0 +1,43 @@
+import { Suspense, lazy, useEffect, useState, type ComponentProps } from "react";
+
+import type PanamaMapComponent from "./PanamaMap";
+
+/**
+ * Carga `PanamaMap` **solo en el navegador**.
+ *
+ * Leaflet toca `window` en cuanto se evalúa su módulo, así que importarlo desde
+ * un componente que el servidor renderiza rompe el SSR con `window is not
+ * defined`. En dev (`bun run dev`, donde TanStack Start sí hace SSR) eso dejaba
+ * el catálogo entero en una página de error.
+ *
+ * `lazy()` no evalúa el módulo hasta que se renderiza, y el interruptor
+ * `mounted` garantiza que ese primer render ocurra ya en el cliente: durante el
+ * SSR y la hidratación inicial se pinta el hueco, y el mapa entra después.
+ */
+const PanamaMap = lazy(() => import("./PanamaMap"));
+
+type PanamaMapProps = ComponentProps<typeof PanamaMapComponent>;
+
+/**
+ * Hueco con el mismo tamaño que el mapa (la columna ya estira
+ * `.panama-map-container` al 100%), para no provocar salto de maqueta.
+ */
+function MapPlaceholder() {
+  return <div className="panama-map-container" aria-hidden="true" />;
+}
+
+export default function LazyPanamaMap(props: PanamaMapProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return <MapPlaceholder />;
+
+  return (
+    <Suspense fallback={<MapPlaceholder />}>
+      <PanamaMap {...props} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/short-id.ts
+++ b/apps/web/src/lib/short-id.ts
@@ -1,0 +1,18 @@
+/**
+ * Etiqueta corta y legible para un identificador de entidad.
+ *
+ * Los ids del backend llevan prefijo de tipo (`contract_<uuid>`,
+ * `rr_<uuid>`, `pay_<uuid>`), así que recortar los primeros caracteres a secas
+ * devolvía el prefijo y nada más: **todos** los contratos se titulaban
+ * «Contrato #contract» y eran indistinguibles entre sí.
+ *
+ * Se descarta el prefijo y se recorta lo que identifica de verdad.
+ */
+export function shortId(id: string | undefined | null, length = 8): string {
+  if (!id) return "—";
+  const separator = id.indexOf("_");
+  const meaningful = separator >= 0 ? id.slice(separator + 1) : id;
+  // Si tras quitar el prefijo no queda nada (un id que *es* solo el prefijo),
+  // se devuelve el original antes que una cadena vacía.
+  return (meaningful || id).slice(0, length);
+}

--- a/apps/web/src/pages/AdminReconciliationPage.tsx
+++ b/apps/web/src/pages/AdminReconciliationPage.tsx
@@ -17,6 +17,8 @@ const STATUS_LABELS: Record<string, string> = {
   paid: "Pagados",
   failed: "Fallidos",
   cancelled: "Cancelados",
+  partially_refunded: "Reembolso parcial",
+  refunded: "Reembolsados",
 };
 
 function formatMoney(amount: number, currency: string): string {
@@ -72,7 +74,7 @@ export default function AdminReconciliationPage() {
             </div>
             <div className="adm-stat">
               <div className="adm-stat__value">{totalPaid}</div>
-              <div className="adm-stat__label">Pagos pagados</div>
+              <div className="adm-stat__label">Pagos cobrados</div>
             </div>
             {report.totals.map((t) => (
               <div className="adm-stat" key={`stat-${t.currency}`}>
@@ -84,22 +86,24 @@ export default function AdminReconciliationPage() {
 
           <h2 className="adm-title" style={{ fontSize: 20, marginTop: 8 }}>Totales por moneda</h2>
           <div className="adm-table" style={{ marginBottom: 26 }}>
-            <div className="adm-trow adm-trow--head" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr" }}>
+            <div className="adm-trow adm-trow--head" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr 1fr" }}>
               <span>Moneda</span>
               <span>Pagos</span>
               <span>Bruto</span>
               <span>Comisión</span>
+              <span>Reembolsado</span>
               <span>Neto</span>
             </div>
             {report.totals.length === 0 ? (
-              <div className="adm-empty">Aún no hay pagos pagados.</div>
+              <div className="adm-empty">Aún no hay pagos cobrados.</div>
             ) : (
               report.totals.map((t) => (
-                <div key={t.currency} className="adm-trow" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr" }}>
+                <div key={t.currency} className="adm-trow" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr 1fr 1fr" }}>
                   <span className="adm-cell--strong">{t.currency}</span>
                   <span>{t.paidCount}</span>
                   <span>{formatMoney(t.grossAmount, t.currency)}</span>
                   <span className="adm-cell--muted">{formatMoney(t.platformFeeAmount, t.currency)}</span>
+                  <span className="adm-cell--muted">{formatMoney(t.refundedAmount ?? 0, t.currency)}</span>
                   <span className="adm-cell--strong">{formatMoney(t.netAmount, t.currency)}</span>
                 </div>
               ))

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -15,7 +15,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import { listLands, photoSrc } from "../services/api";
-import PanamaMap from "../components/PanamaMap";
+import PanamaMap from "../components/LazyPanamaMap";
 import EmptyState from "../components/EmptyState";
 import { useFavorites } from "../hooks/useFavorites";
 import { useCompareLands } from "../hooks/useCompareLands";

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { useParams } from "@tanstack/react-router";
 import { useAuth, useUser } from "@clerk/clerk-react";
 import { Star, Download } from "lucide-react";
@@ -96,7 +97,7 @@ export default function ContractDetailPage() {
     <div>
       <div className="section-header">
         <h1>Detalle de contrato</h1>
-        <p>Contrato #{contractId?.slice(0, 8)}</p>
+        <p>Contrato #{shortId(contractId)}</p>
       </div>
 
       {loading && (
@@ -114,7 +115,7 @@ export default function ContractDetailPage() {
       {contract && status && (
         <div className="glass-panel" style={{ marginTop: "1.5rem" }}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start", marginBottom: "1rem" }}>
-            <h3 style={{ margin: 0 }}>Contrato #{contract.id?.slice(0, 8)}</h3>
+            <h3 style={{ margin: 0 }}>Contrato #{shortId(contract.id)}</h3>
             <span style={{
               padding: "0.25rem 0.75rem",
               borderRadius: "999px",
@@ -127,7 +128,7 @@ export default function ContractDetailPage() {
             </span>
           </div>
           <div style={{ fontSize: "0.9rem", opacity: 0.75, display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-            <p style={{ margin: 0 }}><strong>Solicitud:</strong> {contract.rentalRequestId?.slice(0, 8) || "—"}</p>
+            <p style={{ margin: 0 }}><strong>Solicitud:</strong> {shortId(contract.rentalRequestId)}</p>
             <p style={{ margin: 0 }}><strong>Período:</strong> {contract.terms?.startsAt || "—"} → {contract.terms?.endsAt || "—"}</p>
             <p style={{ margin: 0 }}><strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString() : "—"}</p>
           </div>

--- a/apps/web/src/pages/ContractsPage.tsx
+++ b/apps/web/src/pages/ContractsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { useAuth, useUser } from "@clerk/clerk-react";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
@@ -80,9 +81,9 @@ export default function ContractsPage() {
               <div key={contract.id} className="glass-panel">
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start", marginBottom: "1rem" }}>
                   <div>
-                    <h3 style={{ margin: 0 }}>Contrato #{contract.id.slice(0, 8)}</h3>
+                    <h3 style={{ margin: 0 }}>Contrato #{shortId(contract.id)}</h3>
                     <p style={{ margin: "0.25rem 0", opacity: 0.6, fontSize: "0.85rem" }}>
-                      Solicitud: {contract.rentalRequestId?.slice(0, 8)}
+                      Solicitud: {shortId(contract.rentalRequestId)}
                     </p>
                   </div>
                   <span style={{

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useUser } from "@clerk/clerk-react";
 import type { ChatDto, LandDto, RentalRequestDto, RentalRequestStatus } from "@terrashare/shared";
@@ -179,7 +180,7 @@ function BuscoHome({ name }: { name: string }) {
                   ) : status.foot === "wait" ? (
                     <div className="hm-req__note">Esperando respuesta del propietario</div>
                   ) : (
-                    <div className="hm-req__note">Solicitud #{req.id.slice(0, 8)}</div>
+                    <div className="hm-req__note">Solicitud #{shortId(req.id)}</div>
                   )}
                 </div>
               );

--- a/apps/web/src/pages/PaymentPage.tsx
+++ b/apps/web/src/pages/PaymentPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { shortId } from "../lib/short-id";
 import type { FormEvent } from "react";
 import { useParams, Link } from "@tanstack/react-router";
 import { loadStripe } from "@stripe/stripe-js";
@@ -216,7 +217,7 @@ export default function PaymentPage() {
             <div style={{ flex: 1, minWidth: 0 }}>
               <div className="dl-head__title">{isSale ? "Trato de compra" : "Trato de alquiler"}</div>
               <div className="dl-head__meta">
-                {isSale ? "Oferta" : "Solicitud"} #{requestId?.slice(0, 8)}
+                {isSale ? "Oferta" : "Solicitud"} #{shortId(requestId)}
               </div>
             </div>
             <span className="dl-head__status">Aprobada · falta pago</span>

--- a/apps/web/src/pages/PaymentsPage.tsx
+++ b/apps/web/src/pages/PaymentsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { shortId } from "../lib/short-id";
 import { Link } from "@tanstack/react-router";
 import { useUser } from "@clerk/clerk-react";
 import type { PaymentDto } from "@terrashare/shared";
@@ -128,7 +129,7 @@ export default function PaymentsPage() {
               <div key={p.id} className="pay-row">
                 <span className="pay-cell--date">{isPending ? "Pendiente" : formatDate(p.createdAt)}</span>
                 <span className="pay-cell--land">
-                  {p.landTitle || `Solicitud #${p.rentalRequestId?.slice(0, 8) ?? "—"}`}
+                  {p.landTitle || `Solicitud #${shortId(p.rentalRequestId)}`}
                 </span>
                 <span>${(p.amount ?? 0).toLocaleString("es-PA")}</span>
                 <span>

--- a/apps/web/tests/e2e/hydration.interactive.spec.js
+++ b/apps/web/tests/e2e/hydration.interactive.spec.js
@@ -1,0 +1,40 @@
+import { test } from "@playwright/test";
+
+import {
+  expectClientSideBackNavigation,
+  expectClientSideNavigation,
+  expectThemeChoicePersists,
+  expectThemeToggleResponds,
+} from "./support/interactivity.js";
+
+/**
+ * Interactividad real del cliente sobre el build de producción (#360).
+ *
+ * El resto de la suite comprueba HTML ya renderizado: texto, enlaces,
+ * redirecciones. Estas pruebas exigen que el JavaScript del cliente esté vivo:
+ * cada una necesita que un manejador de React responda a un clic. Si la app no
+ * hidrata, fallan.
+ *
+ * El mismo juego corre contra el servidor de desarrollo en `hydration.ssr.spec.js`.
+ */
+test.describe("interactividad del cliente — build de producción (#360)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("el botón de tema responde al clic y cambia data-theme", async ({ page }) => {
+    await expectThemeToggleResponds(page);
+  });
+
+  test("la elección de tema se guarda en localStorage", async ({ page }) => {
+    await expectThemeChoicePersists(page);
+  });
+
+  test("el clic en «Explorar catálogo» navega por el router, sin recargar el documento", async ({ page }) => {
+    await expectClientSideNavigation(page);
+  });
+
+  test("volver atrás lo maneja el router y deja la landing utilizable", async ({ page }) => {
+    await expectClientSideBackNavigation(page);
+  });
+});

--- a/apps/web/tests/e2e/hydration.ssr.spec.js
+++ b/apps/web/tests/e2e/hydration.ssr.spec.js
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  expectClientSideBackNavigation,
+  expectClientSideNavigation,
+  expectThemeChoicePersists,
+  expectThemeToggleResponds,
+  waitForClient,
+} from "./support/interactivity.js";
+
+/**
+ * Interactividad y salud del SSR en el servidor de desarrollo (#360).
+ *
+ * Corre en el proyecto `dev-ssr`, contra `bun run dev` (puerto 5174), donde
+ * TanStack Start renderiza el documento completo en el servidor. Es un modo de
+ * arranque distinto al de producción y hasta ahora no lo probaba nadie, que es
+ * justo por donde se colaron dos fallos graves:
+ *
+ * - **#354**: el cliente montaba sobre un `#root` que en SSR no existe, así que
+ *   la app nunca hidrataba. El HTML se veía perfecto —y por eso los smoke tests
+ *   pasaban— pero nada era clicable y era imposible iniciar sesión.
+ * - **#358**: `CatalogPage` importaba Leaflet, que toca `window` al evaluarse,
+ *   y tumbaba el render del servidor. En producción (SPA client-only) el módulo
+ *   nunca se evalúa en el servidor, así que allí no se notaba.
+ *
+ * Aquí, si la hidratación no engancha, el marcado se ve igual pero nada
+ * responde: exactamente el escenario que hay que detectar.
+ */
+test.describe("interactividad del cliente — servidor de desarrollo con SSR (#360)", () => {
+  test("el botón de tema responde al clic y cambia data-theme", async ({ page }) => {
+    await page.goto("/");
+    await waitForClient(page);
+    await expectThemeToggleResponds(page);
+  });
+
+  test("la elección de tema se guarda en localStorage", async ({ page }) => {
+    await page.goto("/");
+    await waitForClient(page);
+    await expectThemeChoicePersists(page);
+  });
+
+  test("el clic en «Explorar catálogo» navega por el router, sin recargar el documento", async ({ page }) => {
+    await page.goto("/");
+    await waitForClient(page);
+    await expectClientSideNavigation(page);
+  });
+
+  test("volver atrás lo maneja el router y deja la landing utilizable", async ({ page }) => {
+    await page.goto("/");
+    await waitForClient(page);
+    await expectClientSideBackNavigation(page);
+  });
+});
+
+test.describe("render del servidor sin errores (#360)", () => {
+  // Rutas que el servidor debe poder renderizar. `/catalog` está aquí porque un
+  // import que toca `window` en el módulo (Leaflet) la tumbaba entera.
+  for (const path of ["/", "/catalog", "/login", "/register"]) {
+    test(`${path} se renderiza en el servidor sin reventar`, async ({ page }) => {
+      const response = await page.goto(path);
+
+      expect(response, `sin respuesta para ${path}`).not.toBeNull();
+      expect(response.status(), `${path} respondió ${response.status()}`).toBeLessThan(400);
+
+      // Una excepción en el render del servidor deja la página sin nada útil:
+      // se comprueba que llegó documento con contenido real.
+      const body = await page.locator("body").innerText();
+      expect(body.length, `${path} llegó vacía: probablemente falló el render del servidor`).toBeGreaterThan(0);
+      expect(body).not.toContain("window is not defined");
+    });
+  }
+});

--- a/apps/web/tests/e2e/support/interactivity.js
+++ b/apps/web/tests/e2e/support/interactivity.js
@@ -1,0 +1,121 @@
+import { expect } from "@playwright/test";
+
+/**
+ * Comprobaciones de interactividad reutilizables (#360).
+ *
+ * Se comparten entre los dos modos de arranque de la app —el build estático de
+ * producción y el servidor de desarrollo con SSR— porque el fallo que interesa
+ * cazar (el cliente de React no engancha) se manifiesta igual en ambos, pero
+ * solo uno de los dos lo estaba probando.
+ */
+
+/**
+ * Marca el objeto `window` actual. Sobrevive a la navegación del router de
+ * React (que no recarga el documento) y desaparece en una recarga completa; así
+ * distinguimos una navegación del cliente de un enlace HTML normal.
+ */
+const MARK = "__terrashareHydrationProbe";
+
+/**
+ * Margen para que el cliente arranque. En producción el bundle está construido
+ * y engancha casi al instante; con el servidor de desarrollo, Vite transforma y
+ * sirve los módulos bajo demanda, así que la primera hidratación puede pasar de
+ * los 5 s por defecto de `expect`. El margen holgado evita un test intermitente
+ * sin debilitar la comprobación: si el cliente está muerto, no responde nunca.
+ */
+const HYDRATION_TIMEOUT = 20000;
+
+/**
+ * Espera a que la app quede lista para interactuar. Sin esto, en dev se podría
+ * hacer clic antes de que React enganche y el fallo parecería una regresión.
+ */
+export async function waitForClient(page) {
+  await page.waitForLoadState("networkidle");
+}
+
+export async function markWindow(page) {
+  await page.evaluate((key) => {
+    window[key] = true;
+  }, MARK);
+}
+
+export async function windowStillMarked(page) {
+  return page.evaluate((key) => window[key] === true, MARK);
+}
+
+const themeToggle = (page) =>
+  page.getByRole("button", { name: /Cambiar a modo (claro|oscuro)/ });
+
+const readTheme = (page) =>
+  page.evaluate(() => document.documentElement.getAttribute("data-theme"));
+
+/**
+ * El botón de tema responde al clic. El atributo `data-theme` lo escribe un
+ * manejador de React: sin hidratación no cambia nunca, por muy visible que esté
+ * el botón en el HTML.
+ */
+export async function expectThemeToggleResponds(page) {
+  const toggle = themeToggle(page);
+  await expect(toggle).toBeVisible();
+
+  const before = await readTheme(page);
+  await toggle.click();
+
+  await expect
+    .poll(() => readTheme(page), {
+      message: "data-theme no cambió: el cliente de React no responde a los clics",
+      timeout: HYDRATION_TIMEOUT,
+    })
+    .not.toBe(before);
+
+  expect(["light", "dark"]).toContain(await readTheme(page));
+}
+
+/** Persistir la elección es trabajo del cliente; el servidor no toca localStorage. */
+export async function expectThemeChoicePersists(page) {
+  await themeToggle(page).click();
+
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("ts-theme")), {
+      message: "no se guardó la preferencia de tema",
+      timeout: HYDRATION_TIMEOUT,
+    })
+    .toMatch(/^(light|dark)$/);
+}
+
+/**
+ * Un clic en el CTA principal navega **por el router**, sin recargar el
+ * documento. La marca en `window` es la prueba: si el navegador hubiera seguido
+ * el href a pelo —que es lo que pasa cuando no hay hidratación— se perdería.
+ */
+export async function expectClientSideNavigation(page) {
+  await markWindow(page);
+
+  await page.getByRole("link", { name: /Explorar catálogo/ }).first().click();
+
+  // El catálogo está tras login: sin sesión, la landing manda a registro.
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: HYDRATION_TIMEOUT }).not.toBe("/");
+  expect(new URL(page.url()).pathname).toMatch(/^\/(catalog|login|register)/);
+
+  expect(
+    await windowStillMarked(page),
+    "el documento se recargó: la navegación no la resolvió el router del cliente",
+  ).toBe(true);
+}
+
+/** El retroceso también lo maneja el router, y la landing sigue viva después. */
+export async function expectClientSideBackNavigation(page) {
+  await page.getByRole("link", { name: /Explorar catálogo/ }).first().click();
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: HYDRATION_TIMEOUT }).not.toBe("/");
+
+  await markWindow(page);
+  await page.goBack();
+
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: HYDRATION_TIMEOUT }).toBe("/");
+  expect(
+    await windowStillMarked(page),
+    "el retroceso recargó el documento en vez de resolverlo el router",
+  ).toBe(true);
+
+  await expectThemeToggleResponds(page);
+}

--- a/packages/shared/src/dto/payments.ts
+++ b/packages/shared/src/dto/payments.ts
@@ -86,6 +86,8 @@ export interface ReconciliationCurrencyTotalsDto {
   paidCount: number;
   grossAmount: number;
   platformFeeAmount: number;
+  /** Suma devuelta a los arrendatarios; ya está descontada del `netAmount`. */
+  refundedAmount: number;
   netAmount: number;
 }
 


### PR DESCRIPTION
> Apilado sobre #359 (necesita el arreglo del catálogo para que la comprobación de SSR pase). Retargetear a `main` cuando #359 se mergee.

## Problema

Los E2E comprobaban HTML ya renderizado —texto, enlaces, redirecciones— y **solo contra el build de producción** (`preview:static`, SPA client-only). Dos huecos:

1. Ninguna prueba hacía clic en algo y comprobaba que la app *reaccionara*.
2. Nadie tocaba el modo con que arranca `bun run dev`, donde TanStack Start hace SSR del documento completo — un montaje distinto, con fallos propios.

Por el segundo pasaron dos fallos graves con el CI en verde: **#354** (la app nunca hidrataba en desarrollo: el HTML se veía perfecto, pero nada era clicable y era imposible iniciar sesión) y el **crash de Leaflet** que tumbaba `/catalog` (#358).

## Qué se añade

**Pruebas que exigen un cliente vivo** (`tests/e2e/support/interactivity.js`, compartidas por los dos modos):

- El botón de tema responde al clic y cambia `data-theme` — lo escribe un manejador de React, así que sin hidratación no cambia por muy visible que esté el botón.
- La elección se persiste en `localStorage` — trabajo del cliente; el servidor no lo toca.
- Un clic en el CTA navega **por el router, sin recargar el documento**. Se comprueba marcando `window`: la marca sobrevive a la navegación del cliente y se pierde en una recarga completa, que es justo lo que hace un enlace sin hidratar. Sin esto, la prueba pasaría igual con la app muerta, porque el navegador seguiría el `href` a pelo.
- Ídem al volver atrás, y la landing sigue respondiendo después.

**Proyecto `dev-ssr`**: el mismo juego contra `vite dev` (puerto 5174), más una comprobación de que `/`, `/catalog`, `/login` y `/register` se renderizan en el servidor sin reventar. `playwright.config.js` levanta ahora los dos servidores; `chromium` ignora las `.ssr.spec.js` y el CI corre ambos proyectos.

## Verificación: fallan con los bugs, pasan sin ellos

Reintroduje los dos fallos a propósito y volví a correr `--project=dev-ssr`:

| Escenario | Resultado |
|---|---|
| Montaje de #354 (siempre sobre `#root`) | **4 fallos** — los 4 de interactividad, con «data-theme no cambió: el cliente de React no responde a los clics» |
| Import directo de Leaflet | **+1 fallo** — «/catalog se renderiza en el servidor sin reventar» |
| Con ambos arreglos | **8 pass** |

Suite completa con los dos proyectos: **49 passed**.

Closes #360
