### PR TITLE
feat(admin): panel de seguridad para la 2FA + arreglos de contraste del tema oscuro (#362, #363)

### DIFF
--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -12,6 +12,7 @@ import { requireAuth } from "./middleware/require-auth";
 import { authRoutes } from "./routes/auth";
 import { healthRoutes } from "./routes/health";
 import { adminRoutes } from "./routes/admin";
+import { adminSecurityRoutes } from "./routes/admin-security";
 import { landRoutes } from "./routes/lands";
 import { favoriteRoutes } from "./routes/favorites";
 import { leadRoutes } from "./routes/leads";
@@ -71,6 +72,7 @@ export function createApp() {
   app.route("/api/v1", healthRoutes);
   app.route("/api/v1", authRoutes);
   app.route("/api/v1", adminRoutes);
+  app.route("/api/v1", adminSecurityRoutes);
   app.route("/api/v1", backupRoutes);
   app.route("/api/v1", landRoutes);
   app.route("/api/v1", favoriteRoutes);

--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -514,6 +514,25 @@ const NotificationSchema = new Schema<INotification>({
 
 export const Notification = mongoose.models.Notification || mongoose.model<INotification>("Notification", NotificationSchema);
 
+/**
+ * Ajuste de la aplicación editable en caliente (#362). Sustituye a las
+ * variables de entorno para lo que un administrador debe poder cambiar sin
+ * reiniciar el servicio, como la exigencia de 2FA.
+ */
+export interface IAppSetting extends Document {
+  key: string;
+  value: unknown;
+  updatedAt: Date;
+}
+
+const AppSettingSchema = new Schema<IAppSetting>({
+  key: { type: String, required: true, unique: true },
+  value: { type: Schema.Types.Mixed },
+}, { timestamps: true });
+
+export const AppSetting = mongoose.models.AppSetting
+  || mongoose.model<IAppSetting>("AppSetting", AppSettingSchema);
+
 /** Búsqueda guardada de un usuario; alimenta las alertas de nuevos terrenos (HU-99 #325). */
 export interface ISavedSearch extends Document {
   id: string;

--- a/apps/backend-api/src/lib/security-settings.ts
+++ b/apps/backend-api/src/lib/security-settings.ts
@@ -1,0 +1,80 @@
+/**
+ * Ajustes de seguridad que se pueden cambiar en caliente (#362).
+ *
+ * Hasta ahora la exigencia de 2FA a los administradores solo se controlaba con
+ * la variable `REQUIRE_ADMIN_MFA`, así que para cambiarla había que tocar el
+ * entorno y reiniciar, y ninguna pantalla decía si estaba activa. El resultado
+ * práctico era un 403 `MFA_REQUIRED` sin explicación y sin forma de quitarlo.
+ *
+ * Ahora el valor vive en Mongo y la variable de entorno queda como valor por
+ * defecto para cuando nadie lo ha tocado todavía.
+ */
+import { AppSetting } from "../db/schemas";
+import { env } from "../config/env";
+
+export const REQUIRE_ADMIN_MFA_KEY = "security.requireAdminMfa";
+
+/** De dónde sale el valor que está en vigor. */
+export type SettingSource = "stored" | "environment";
+
+export interface AdminMfaSetting {
+  requireAdminMfa: boolean;
+  source: SettingSource;
+  /** Valor por defecto del entorno, para poder explicarlo en la interfaz. */
+  environmentDefault: boolean;
+}
+
+/**
+ * Caché breve: `requireAdmin` corre en cada petición a `/admin/*` y no merece
+ * una lectura a Mongo por cada una. 10 s hace que un cambio desde el panel se
+ * note casi al momento sin castigar el camino caliente.
+ */
+const CACHE_TTL_MS = 10_000;
+let cached: { value: AdminMfaSetting; at: number } | null = null;
+
+/** Vacía la caché. Se llama al guardar, y desde los tests. */
+export function invalidateSecuritySettingsCache(): void {
+  cached = null;
+}
+
+async function readStoredValue(): Promise<boolean | null> {
+  try {
+    const doc = await AppSetting.findOne({ key: REQUIRE_ADMIN_MFA_KEY }).lean();
+    if (!doc) return null;
+    return (doc as { value?: unknown }).value === true;
+  } catch {
+    // Si Mongo no responde, se cae al valor del entorno en vez de romper la
+    // autorización: es preferible un fallo de configuración a un 500.
+    return null;
+  }
+}
+
+/** Ajuste en vigor, con su procedencia. */
+export async function getAdminMfaSetting(): Promise<AdminMfaSetting> {
+  const now = Date.now();
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.value;
+
+  const stored = await readStoredValue();
+  const value: AdminMfaSetting = stored === null
+    ? { requireAdminMfa: env.requireAdminMfa, source: "environment", environmentDefault: env.requireAdminMfa }
+    : { requireAdminMfa: stored, source: "stored", environmentDefault: env.requireAdminMfa };
+
+  cached = { value, at: now };
+  return value;
+}
+
+/** Atajo para el middleware: solo el booleano en vigor. */
+export async function isAdminMfaRequired(): Promise<boolean> {
+  return (await getAdminMfaSetting()).requireAdminMfa;
+}
+
+/** Guarda el ajuste y devuelve el estado resultante. */
+export async function setAdminMfaRequired(required: boolean): Promise<AdminMfaSetting> {
+  await AppSetting.updateOne(
+    { key: REQUIRE_ADMIN_MFA_KEY },
+    { $set: { key: REQUIRE_ADMIN_MFA_KEY, value: required } },
+    { upsert: true },
+  );
+  invalidateSecuritySettingsCache();
+  return getAdminMfaSetting();
+}

--- a/apps/backend-api/src/middleware/require-auth.ts
+++ b/apps/backend-api/src/middleware/require-auth.ts
@@ -6,6 +6,7 @@ import { failure } from "../lib/api-response";
 import type { AuthContextUser } from "../types";
 import { resolveClerkAuthUser } from "../lib/clerk-user";
 import { getStore } from "../store/in-memory-db";
+import { isAdminMfaRequired } from "../lib/security-settings";
 import { User } from "../db/schemas";
 import type { AppEnv } from "../types";
 
@@ -140,6 +141,23 @@ export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   }
 };
 
+/**
+ * Solo comprueba el rol, **sin** la exigencia de 2FA.
+ *
+ * Es la salida de emergencia del panel de seguridad (#362): si la exigencia
+ * está activa y el admin no tiene 2FA en su cuenta, todas las rutas `/admin/*`
+ * le responden 403 — incluida la que serviría para desactivarla. Sin esta
+ * excepción, encender el interruptor sin 2FA configurado deja la cuenta fuera
+ * de su propio panel y solo se puede arreglar tocando la base a mano.
+ */
+export const requireAdminRoleOnly: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const authUser = c.get("authUser");
+  if (!authUser || authUser.role !== "admin") {
+    return failure(c, 403, "FORBIDDEN", "Admin role required");
+  }
+  await next();
+};
+
 export const requireAdmin: MiddlewareHandler<AppEnv> = async (c, next) => {
   const authUser = c.get("authUser");
   if (!authUser || authUser.role !== "admin") {
@@ -148,7 +166,9 @@ export const requireAdmin: MiddlewareHandler<AppEnv> = async (c, next) => {
 
   const hasDevHeader = Boolean(c.req.header("x-dev-user-id") || c.req.header("x-dev-role"));
   const isDevBypass = hasDevHeader && env.allowDevAuthBypass;
-  if (env.requireAdminMfa && !isDevBypass && authUser.mfaVerified !== true) {
+  // El ajuste guardado manda sobre `REQUIRE_ADMIN_MFA`, para poder cambiarlo
+  // desde el panel sin reiniciar el servicio.
+  if (!isDevBypass && (await isAdminMfaRequired()) && authUser.mfaVerified !== true) {
     return failure(c, 403, "MFA_REQUIRED", "Admin must have MFA enabled");
   }
 

--- a/apps/backend-api/src/routes/admin-security.test.ts
+++ b/apps/backend-api/src/routes/admin-security.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { createApp } from "../app";
+import { AppSetting } from "../db/schemas";
+import { invalidateSecuritySettingsCache, REQUIRE_ADMIN_MFA_KEY } from "../lib/security-settings";
+
+/**
+ * Panel de seguridad: exigencia de 2FA a los administradores (#362).
+ *
+ * Lo que estas pruebas fijan es sobre todo la **salida de emergencia**: la
+ * pantalla que apaga la exigencia no puede quedar detrás de la propia
+ * exigencia, o encenderla sin 2FA configurada encierra a la cuenta fuera de su
+ * panel sin forma de volver atrás.
+ *
+ * Gotcha de bun:test + mongodb-memory-server: escribir en el cuerpo del test y
+ * leer después puede colgarse, así que lo que se escribe se siembra en
+ * `beforeEach` y el cuerpo solo lee (salvo las pruebas del PATCH, que son una
+ * sola escritura y su respuesta).
+ */
+
+const app = createApp();
+
+const adminHeaders = { "x-dev-user-id": "admin_sec_test", "x-dev-role": "admin" };
+const userHeaders = { "x-dev-user-id": "user_sec_test", "x-dev-role": "user" };
+
+const get = (path: string, headers: Record<string, string>) =>
+  app.request(path, { headers });
+
+const patch = (path: string, headers: Record<string, string>, body: unknown) =>
+  app.request(path, {
+    method: "PATCH",
+    headers: { ...headers, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("GET /admin/security-settings", () => {
+  it("devuelve el ajuste en vigor y si quien pregunta tiene 2FA", async () => {
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(typeof body.data.requireAdminMfa).toBe("boolean");
+    expect(["stored", "environment"]).toContain(body.data.source);
+    expect(typeof body.data.environmentDefault).toBe("boolean");
+    expect(typeof body.data.callerMfaEnabled).toBe("boolean");
+  });
+
+  it("fuera de producción la 2FA no se exige por defecto", async () => {
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    const body = await res.json();
+
+    expect(body.data.requireAdminMfa).toBe(false);
+    // Sin nada guardado, el valor sale del entorno.
+    expect(body.data.source).toBe("environment");
+  });
+
+  it("un usuario sin rol admin no puede verlo", async () => {
+    const res = await get("/api/v1/admin/security-settings", userHeaders);
+    expect(res.status).toBe(403);
+  });
+
+  it("sin autenticar responde 401", async () => {
+    const res = await app.request("/api/v1/admin/security-settings");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("PATCH /admin/security-settings", () => {
+  it("guarda la exigencia y la respuesta pasa a declararse como guardada", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, { requireAdminMfa: true });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.requireAdminMfa).toBe(true);
+    expect(body.data.source).toBe("stored");
+  });
+
+  it("rechaza un valor que no sea booleano", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, { requireAdminMfa: "sí" });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("rechaza un cuerpo sin el campo", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("un usuario sin rol admin no puede cambiarlo", async () => {
+    const res = await patch("/api/v1/admin/security-settings", userHeaders, { requireAdminMfa: true });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("la exigencia activa no encierra al admin fuera del panel", () => {
+  beforeEach(async () => {
+    // 2FA exigida y guardada, que es el escenario que dejaba fuera a la cuenta.
+    await AppSetting.updateOne(
+      { key: REQUIRE_ADMIN_MFA_KEY },
+      { $set: { key: REQUIRE_ADMIN_MFA_KEY, value: true } },
+      { upsert: true },
+    );
+    invalidateSecuritySettingsCache();
+  });
+
+  it("el ajuste guardado queda en vigor y se declara como tal", async () => {
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    const body = await res.json();
+
+    expect(body.data.requireAdminMfa).toBe(true);
+    expect(body.data.source).toBe("stored");
+  });
+
+  it("con la exigencia activa, la pantalla de seguridad sigue accesible", async () => {
+    // Es la salida de emergencia: si esto respondiera 403, no habría manera de
+    // apagar la exigencia desde la interfaz.
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    expect(res.status).toBe(200);
+  });
+
+  it("con la exigencia activa, se puede volver a apagar", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, { requireAdminMfa: false });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.requireAdminMfa).toBe(false);
+  });
+});

--- a/apps/backend-api/src/routes/admin-security.ts
+++ b/apps/backend-api/src/routes/admin-security.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+
+import { failure, success } from "../lib/api-response";
+import { requireAuth, requireAdminRoleOnly } from "../middleware/require-auth";
+import { getAdminMfaSetting, setAdminMfaRequired } from "../lib/security-settings";
+import { createAuditEvent as createAudit } from "../store/audit";
+import type { AppEnv } from "../types";
+
+export const adminSecurityRoutes = new Hono<AppEnv>();
+
+/**
+ * Panel de seguridad (#362).
+ *
+ * Estas dos rutas usan `requireAdminRoleOnly` **a propósito**: son la salida de
+ * emergencia. Si se exige 2FA y el admin no la tiene configurada en Clerk,
+ * `requireAdmin` le devuelve 403 en todo `/admin/*`; si eso incluyera esta
+ * pantalla, encender el interruptor sin 2FA dejaría la cuenta encerrada fuera
+ * de su propio panel, sin forma de volver atrás salvo editando la base a mano.
+ */
+
+adminSecurityRoutes.get("/admin/security-settings", requireAuth, requireAdminRoleOnly, async (c) => {
+  const authUser = c.get("authUser");
+  const setting = await getAdminMfaSetting();
+
+  return success(c, {
+    ...setting,
+    /** Si la cuenta que pregunta tiene 2FA activa en Clerk. */
+    callerMfaEnabled: authUser.mfaVerified === true,
+  });
+});
+
+adminSecurityRoutes.patch("/admin/security-settings", requireAuth, requireAdminRoleOnly, async (c) => {
+  const authUser = c.get("authUser");
+  const body: { requireAdminMfa?: unknown } = await c.req
+    .json<{ requireAdminMfa?: unknown }>()
+    .catch(() => ({}));
+
+  if (typeof body.requireAdminMfa !== "boolean") {
+    return failure(c, 400, "VALIDATION_ERROR", "requireAdminMfa must be a boolean");
+  }
+
+  const setting = await setAdminMfaRequired(body.requireAdminMfa);
+
+  // Cambiar quién puede entrar al panel es justo lo que una bitácora debe
+  // registrar, así que queda en auditoría con el valor nuevo.
+  await createAudit({
+    actor: authUser,
+    entity: "user",
+    action: "status_changed",
+    entityId: "security.requireAdminMfa",
+    metadata: { requireAdminMfa: setting.requireAdminMfa },
+  });
+
+  return success(c, {
+    ...setting,
+    callerMfaEnabled: authUser.mfaVerified === true,
+  });
+});

--- a/apps/backend-api/src/setup-test-env.ts
+++ b/apps/backend-api/src/setup-test-env.ts
@@ -2,6 +2,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 process.env.ALLOW_DEV_AUTH_BYPASS = "true";
+// Marcador de posición: `test-preload` lo sustituye sin condiciones por la URI
+// del servidor en memoria en cuanto arranca. Existe porque `config/env` valida
+// la variable con zod al evaluarse, y basta con que un módulo importe `env`
+// antes de ese momento para que toda la suite reviente. En local no se notaba:
+// el `.env` de desarrollo ya traía la variable, así que solo fallaba en CI.
+process.env.MONGODB_URI = process.env.MONGODB_URI ?? "mongodb://127.0.0.1:27017/terrashare-test";
 process.env.CLERK_JWKS_URL = process.env.CLERK_JWKS_URL ?? "https://example.test/.well-known/jwks.json";
 process.env.CLERK_ISSUER = process.env.CLERK_ISSUER ?? "https://example.test";
 process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY ?? "sk_test_placeholder";

--- a/apps/backend-api/src/test-preload.ts
+++ b/apps/backend-api/src/test-preload.ts
@@ -1,10 +1,13 @@
 // Test preload: spins up an in-memory MongoDB, connects both data layers
 // (native driver + mongoose), and seeds it from the in-memory store fixtures
 // before every test. Wired via bunfig.toml `[test].preload`.
+// Primero de todo: fija las variables de entorno que `config/env` valida al
+// evaluarse. Cualquier import que arrastre `env` debe venir después.
+import "./setup-test-env";
+
 import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
-import "./setup-test-env";
 import mongoose from "mongoose";
 import { connectMongoose, disconnectMongoose } from "./db/mongoose";
 import { __resetRateLimit } from "./middleware/rate-limit";

--- a/apps/backend-api/src/test-preload.ts
+++ b/apps/backend-api/src/test-preload.ts
@@ -8,6 +8,7 @@ import "./setup-test-env";
 import mongoose from "mongoose";
 import { connectMongoose, disconnectMongoose } from "./db/mongoose";
 import { __resetRateLimit } from "./middleware/rate-limit";
+import { invalidateSecuritySettingsCache } from "./lib/security-settings";
 import { getStore, resetStore } from "./store/in-memory-db";
 
 // Maps the in-memory store collections to the Mongo collection names the routes
@@ -27,6 +28,9 @@ function fixtures(): Record<string, Record<string, unknown>[]> {
     // Incluida aunque el store no la siembre: así la colección se vacía entre
     // tests y las notificaciones que crea un test no se filtran al siguiente.
     notifications: [...store.notifications.values()],
+    // El panel de seguridad guarda aquí la exigencia de 2FA (#362). Se vacía
+    // entre tests para que un ajuste no se filtre y bloquee al siguiente.
+    appsettings: [],
   } as unknown as Record<string, Record<string, unknown>[]>;
 }
 
@@ -54,6 +58,9 @@ beforeEach(async () => {
   // Reset the module-level rate-limit counter so cumulative suite requests from
   // the shared test IP don't trip the IP limit and cause spurious 429s.
   __resetRateLimit();
+  // La caché de ajustes de seguridad guarda el valor 10 s; si no se limpia, un
+  // test arrastra la configuración del anterior.
+  invalidateSecuritySettingsCache();
   await seedDatabase();
 });
 

--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useClerk } from "@clerk/clerk-react";
-import { LayoutDashboard, Flag, Map, Users, Mail, LogOut, Sprout, ScrollText, Activity, Scale, CreditCard, DatabaseBackup } from "lucide-react";
+import { LayoutDashboard, Flag, Map, Users, Mail, LogOut, Sprout, ScrollText, Activity, Scale, CreditCard, DatabaseBackup, ShieldCheck } from "lucide-react";
 import ThemeToggle from "./ThemeToggle";
 import "../pages/admin.css";
 
@@ -21,6 +21,7 @@ const NAV = [
   { to: "/dashboard/admin/audit", label: "Auditoria", icon: ScrollText },
   { to: "/dashboard/admin/observability", label: "Observabilidad", icon: Activity },
   { to: "/dashboard/admin/backups", label: "Respaldos", icon: DatabaseBackup },
+  { to: "/dashboard/admin/security", label: "Seguridad", icon: ShieldCheck },
 ];
 
 /** Layout editorial del panel admin: sidebar oscuro + contenido. Sustituye al

--- a/apps/web/src/components/ReviewModal.tsx
+++ b/apps/web/src/components/ReviewModal.tsx
@@ -41,7 +41,11 @@ export default function ReviewModal({ contractId, receiverId, onSubmit, onClose 
       <div
         onClick={(e) => e.stopPropagation()}
         style={{
-          background: "var(--surface, #1a1a2e)",
+          // Mismo caso que en VisitModal: `--surface` no existe, el token es
+          // `--ts-surface`, y sin él salía un azul marino ajeno al tema (#363).
+          background: "var(--ts-surface)",
+          color: "var(--ts-text)",
+          border: "1px solid var(--ts-border)",
           borderRadius: "12px", padding: "2rem",
           maxWidth: "480px", width: "90%",
           boxShadow: "0 20px 60px rgba(0,0,0,0.3)",

--- a/apps/web/src/components/VisitModal.tsx
+++ b/apps/web/src/components/VisitModal.tsx
@@ -55,7 +55,12 @@ export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalP
         aria-modal="true"
         aria-label="Agendar visita"
         style={{
-          background: "var(--surface, #1a1a2e)",
+          // `--surface` no existe: el token del sistema se llama `--ts-surface`.
+          // Sin definir, el modal caía al azul marino de reserva, que no pega
+          // con la paleta verde en ningún tema (#363).
+          background: "var(--ts-surface)",
+          color: "var(--ts-text)",
+          border: "1px solid var(--ts-border)",
           borderRadius: "12px", padding: "2rem",
           maxWidth: "460px", width: "90%",
           boxShadow: "0 20px 60px rgba(0,0,0,0.3)",

--- a/apps/web/src/pages/AdminSecurityPage.tsx
+++ b/apps/web/src/pages/AdminSecurityPage.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+import { ShieldCheck, ShieldAlert, Loader2, KeyRound, TriangleAlert } from "lucide-react";
+
+import {
+  getSecuritySettings,
+  setRequireAdminMfa,
+  type AdminSecuritySettingsDto,
+} from "../services/adminApi";
+import "./admin.css";
+
+/**
+ * Panel de seguridad (#362).
+ *
+ * La exigencia de 2FA para administradores existía desde HU-37, pero solo se
+ * gobernaba con la variable `REQUIRE_ADMIN_MFA` y ninguna pantalla decía si
+ * estaba activa: quien se topaba con el 403 `MFA_REQUIRED` no tenía forma de
+ * saber por qué ni de quitarlo. Esta pantalla lo muestra, lo explica y permite
+ * cambiarlo sin reiniciar el servicio.
+ */
+export default function AdminSecurityPage() {
+  const [settings, setSettings] = useState<AdminSecuritySettingsDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getSecuritySettings()
+      .then((res) => {
+        if (active) setSettings(res.data);
+      })
+      .catch((err: Error) => {
+        if (active) setError(err.message);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const toggle = async () => {
+    if (!settings || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await setRequireAdminMfa(!settings.requireAdminMfa);
+      setSettings(res.data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const required = settings?.requireAdminMfa ?? false;
+  // Encenderla sin 2FA en la propia cuenta cierra el resto del panel. Esta
+  // pantalla sigue accesible a propósito, para poder desandarlo.
+  const wouldLockOut = required && settings?.callerMfaEnabled === false;
+
+  return (
+    <div className="adm-page">
+      <h1 className="adm-title">Seguridad</h1>
+      <p className="adm-sub">Controles de acceso al panel de administración.</p>
+
+      {error ? <div className="adm-empty adm-empty--error">{error}</div> : null}
+
+      {loading ? (
+        <div className="adm-empty">Cargando ajustes de seguridad…</div>
+      ) : !settings ? (
+        <div className="adm-empty">No se pudieron cargar los ajustes.</div>
+      ) : (
+        <div className="adm-sec">
+          <section className="adm-panel">
+            <div className="adm-sec__head">
+              <span className={`adm-sec__icon ${required ? "is-on" : "is-off"}`}>
+                {required ? <ShieldCheck size={20} /> : <ShieldAlert size={20} />}
+              </span>
+              <div>
+                <h2 className="adm-panel__title">Exigir 2FA a los administradores</h2>
+                <p className="adm-sec__text">
+                  Con la exigencia activa, cualquier cuenta con rol admin necesita verificación
+                  en dos pasos configurada en Clerk para usar el panel. Sin ella, la API responde{" "}
+                  <code>403 MFA_REQUIRED</code> en todas las rutas <code>/admin/*</code>.
+                </p>
+              </div>
+            </div>
+
+            <div className="adm-sec__row">
+              <div className="adm-sec__state">
+                <span className={`adm-badge ${required ? "adm-badge--green" : "adm-badge--muted"}`}>
+                  {required ? "Exigida" : "No exigida"}
+                </span>
+                <span className="adm-sec__origin">
+                  {settings.source === "stored"
+                    ? "Fijado desde este panel."
+                    : `Valor por defecto del entorno (REQUIRE_ADMIN_MFA = ${settings.environmentDefault}).`}
+                </span>
+              </div>
+
+              <button
+                type="button"
+                className={`adm-pill ${required ? "" : "adm-pill--cta"}`}
+                onClick={toggle}
+                disabled={saving}
+              >
+                {saving ? <Loader2 size={15} className="adm-spin" /> : null}
+                {required ? "Desactivar" : "Activar"}
+              </button>
+            </div>
+
+            {wouldLockOut ? (
+              <p className="adm-sec__warn">
+                <TriangleAlert size={16} />
+                <span>
+                  Tu cuenta no tiene 2FA configurada, así que el resto del panel te está
+                  rechazando. Esta pantalla sigue accesible para que puedas desactivar la
+                  exigencia o configurar la 2FA en tu perfil.
+                </span>
+              </p>
+            ) : null}
+          </section>
+
+          <section className="adm-panel">
+            <div className="adm-sec__head">
+              <span className={`adm-sec__icon ${settings.callerMfaEnabled ? "is-on" : "is-off"}`}>
+                <KeyRound size={20} />
+              </span>
+              <div>
+                <h2 className="adm-panel__title">Tu cuenta</h2>
+                <p className="adm-sec__text">
+                  {settings.callerMfaEnabled
+                    ? "Tienes la verificación en dos pasos activa en Clerk."
+                    : "No tienes verificación en dos pasos activa en Clerk."}
+                </p>
+              </div>
+            </div>
+
+            {!settings.callerMfaEnabled ? (
+              <ol className="adm-sec__steps">
+                <li>Abre <strong>Mi perfil</strong> y entra a tu cuenta de Clerk.</li>
+                <li>En <strong>Security</strong>, añade un método en dos pasos (app de códigos o SMS).</li>
+                <li>Vuelve a iniciar sesión para que el token refleje el cambio.</li>
+              </ol>
+            ) : null}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/MyLandsPage.tsx
+++ b/apps/web/src/pages/MyLandsPage.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { useUser } from "@clerk/clerk-react";
 import type { LandDto } from "@terrashare/shared";
 import { Plus, Eye, Inbox, MapPin, Map } from "lucide-react";
-import { getMyLands } from "../services/api";
+import { getMyLands, photoSrc } from "../services/api";
 import EmptyState from "../components/EmptyState";
 import "./mylands.css";
 
@@ -21,6 +21,26 @@ const USE_LABELS: Record<string, string> = {
 function useLabel(use?: string): string {
   if (!use) return "Terreno";
   return USE_LABELS[use] ?? use;
+}
+
+/**
+ * Precio a mostrar según la operación del terreno.
+ *
+ * Un terreno de solo venta no tiene renta mensual, así que la tarjeta anunciaba
+ * «$0/mes» en vez del precio de venta (#363).
+ */
+function priceLabel(land: LandDto): string {
+  const monthly = land.priceRule?.pricePerMonth;
+  const sale = land.salePrice;
+
+  if (land.operation === "venta") {
+    return sale ? `$${sale.toLocaleString("es-PA")} en venta` : "Precio a convenir";
+  }
+  const rent = monthly ? `$${monthly.toLocaleString("es-PA")}/mes` : "Precio a convenir";
+  if (land.operation === "ambas" && sale) {
+    return `${rent} · $${sale.toLocaleString("es-PA")} en venta`;
+  }
+  return rent;
 }
 
 export default function MyLandsPage() {
@@ -89,16 +109,19 @@ export default function MyLandsPage() {
             return (
               <Link key={land.id} to="/lands/$id" params={{ id: land.id }} className="ml-card">
                 <div className="ml-card__media">
-                  <div className="ml-card__photo" aria-hidden="true">
-                    <MapPin size={26} strokeWidth={1.4} />
-                  </div>
+                  {land.photos?.[0] ? (
+                    <img className="ml-card__img" src={photoSrc(land.photos[0])} alt="" />
+                  ) : (
+                    <div className="ml-card__photo" aria-hidden="true">
+                      <MapPin size={26} strokeWidth={1.4} />
+                    </div>
+                  )}
                   <span className={`ml-card__badge ${badgeCls}`}>{badgeLabel}</span>
                 </div>
                 <div className="ml-card__body">
                   <div className="ml-card__title">{land.title}</div>
                   <div className="ml-card__meta">
-                    {useLabel(land.allowedUses?.[0])} · $
-                    {land.priceRule?.pricePerMonth?.toLocaleString("es-PA")}/mes
+                    {useLabel(land.allowedUses?.[0])} · {priceLabel(land)}
                   </div>
                   {/* TODO(#136): sin métricas de vistas/solicitudes por terreno todavía. */}
                   <div className="ml-card__stats">

--- a/apps/web/src/pages/admin.css
+++ b/apps/web/src/pages/admin.css
@@ -346,3 +346,68 @@
   .adm-main { padding: 24px 20px; }
   .adm-rep__grid { grid-template-columns: 1fr; }
 }
+
+/* ─── Panel de seguridad (#362) ───────────────────────────────────────────── */
+
+.adm-sec { display: grid; gap: 18px; max-width: 760px; }
+
+.adm-sec__head { display: flex; gap: 14px; align-items: flex-start; }
+
+.adm-sec__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex: none;
+  border-radius: 12px;
+}
+.adm-sec__icon.is-on { color: var(--ts-green); background: var(--ts-tint-green-2); }
+.adm-sec__icon.is-off { color: var(--ts-ink-3, #6b6b63); background: var(--ts-tint-2, #ececed); }
+
+.adm-sec__text { color: var(--ts-sage-2); font-size: 14px; line-height: 1.55; margin: 6px 0 0; }
+.adm-sec__text code {
+  font-size: 12.5px;
+  padding: 1px 5px;
+  border-radius: 5px;
+  background: var(--ts-tint-2, #ececed);
+  color: var(--ts-text);
+}
+
+.adm-sec__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--ts-beige);
+}
+.adm-sec__state { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.adm-sec__origin { color: var(--ts-sage-2); font-size: 13px; }
+
+.adm-sec__warn {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin: 16px 0 0;
+  padding: 12px 14px;
+  border-radius: 10px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: #9a6b1f;
+  background: #f5e9d0;
+}
+.adm-sec__warn svg { flex: none; margin-top: 2px; }
+
+.adm-sec__steps {
+  margin: 16px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  color: var(--ts-sage-2);
+  font-size: 14px;
+  line-height: 1.5;
+}
+.adm-sec__steps strong { color: var(--ts-text); font-weight: 600; }

--- a/apps/web/src/pages/mylands.css
+++ b/apps/web/src/pages/mylands.css
@@ -140,3 +140,12 @@
   .ml-grid { grid-template-columns: 1fr; }
   .ml-head { flex-direction: column; align-items: flex-start; }
 }
+
+/* Foto real del terreno cuando existe; el bloque con icono queda de reserva
+   para las publicaciones que aún no han subido ninguna (#363). */
+.ml-card__img {
+  width: 100%;
+  height: 130px;
+  object-fit: cover;
+  display: block;
+}

--- a/apps/web/src/routes/dashboard.admin.security.tsx
+++ b/apps/web/src/routes/dashboard.admin.security.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AdminRoute } from "../components/route-guards";
+import AdminLayout from "../components/AdminLayout";
+import AdminSecurityPage from "../pages/AdminSecurityPage";
+
+export const Route = createFileRoute("/dashboard/admin/security")({
+  component: () => (
+    <AdminRoute><AdminLayout><AdminSecurityPage /></AdminLayout></AdminRoute>
+  ),
+});

--- a/apps/web/src/services/adminApi.ts
+++ b/apps/web/src/services/adminApi.ts
@@ -231,3 +231,24 @@ export const createBackup = () => request<BackupRecordDto>("POST", "/api/v1/admi
 /** POST /api/v1/admin/backups/:id/verify — restauración probada. */
 export const verifyBackup = (id: string) =>
   request<BackupRecordDto>("POST", `/api/v1/admin/backups/${id}/verify`);
+
+// ─── Seguridad: 2FA de administradores (#362) ────────────────────────────────
+
+export interface AdminSecuritySettingsDto {
+  /** Si ahora mismo se exige 2FA para entrar a `/admin/*`. */
+  requireAdminMfa: boolean;
+  /** `stored` = alguien lo fijó desde el panel; `environment` = valor por defecto. */
+  source: "stored" | "environment";
+  /** Lo que diría `REQUIRE_ADMIN_MFA` si nadie lo hubiera tocado. */
+  environmentDefault: boolean;
+  /** Si la cuenta que consulta tiene la 2FA activa en Clerk. */
+  callerMfaEnabled: boolean;
+}
+
+/** GET /api/v1/admin/security-settings */
+export const getSecuritySettings = () =>
+  request<AdminSecuritySettingsDto>("GET", "/api/v1/admin/security-settings");
+
+/** PATCH /api/v1/admin/security-settings — activa o desactiva la exigencia de 2FA. */
+export const setRequireAdminMfa = (requireAdminMfa: boolean) =>
+  request<AdminSecuritySettingsDto>("PATCH", "/api/v1/admin/security-settings", { requireAdminMfa });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14,6 +14,44 @@
   --glass-shadow: 0 8px 32px rgba(11, 95, 55, 0.08);
 }
 
+/* Tema oscuro para la paleta heredada (#363).
+   Esta hoja es anterior al sistema de tokens `--ts-*` y fijaba una paleta solo
+   clara, pero varias pantallas del panel siguen usándola (contratos, auditoría,
+   privacidad). En tema oscuro el resultado era ilegible: `--leaf-900` es un
+   verde casi negro para los títulos, `--ink-900` el texto, y `.glass-panel` un
+   degradado blanco — es decir, título verde oscuro sobre fondo oscuro y texto
+   crema sobre panel casi blanco.
+   Se redefinen aquí las mismas variables para que la hoja siga al tema, en vez
+   de retocar cada regla que las consume. El selector replica la cascada de
+   `styles/tokens.css`: elección explícita primero, preferencia del SO después. */
+:root[data-theme="dark"] {
+  --leaf-700: #4f8a61;
+  --leaf-900: #7fae8a;         /* títulos: sube a un verde claro legible sobre oscuro */
+  --ink-900: #ece4d3;          /* texto principal: crema */
+  --paper: #1b241d;
+  --danger: #e08074;
+  --success: #6fbf94;
+  --ring: rgba(127, 174, 138, 0.35);
+  --glass-bg: rgba(38, 48, 40, 0.72);
+  --glass-border: rgba(236, 228, 211, 0.12);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --leaf-700: #4f8a61;
+    --leaf-900: #7fae8a;
+    --ink-900: #ece4d3;
+    --paper: #1b241d;
+    --danger: #e08074;
+    --success: #6fbf94;
+    --ring: rgba(127, 174, 138, 0.35);
+    --glass-bg: rgba(38, 48, 40, 0.72);
+    --glass-border: rgba(236, 228, 211, 0.12);
+    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  }
+}
+
 * {
   box-sizing: border-box;
 }
@@ -62,28 +100,24 @@ a {
   position: relative;
 }
 
+/* El degradado y el borde salen de variables (no de un blanco fijo) para que el
+   panel siga al tema: en oscuro era un rectángulo casi blanco que dejaba el
+   texto crema encima ilegible (#363). */
 .glass-panel {
-  background: linear-gradient(135deg, 
-    rgba(255, 255, 255, 0.75) 0%, 
-    rgba(255, 255, 255, 0.55) 100%);
+  background: var(--glass-bg);
+  color: var(--ink-900);
   backdrop-filter: blur(16px) saturate(180%);
   -webkit-backdrop-filter: blur(16px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--glass-border);
   border-radius: 20px;
   padding: clamp(1.5rem, 3vw, 2.5rem);
-  box-shadow: 
-    0 8px 32px rgba(11, 95, 55, 0.1),
-    0 2px 8px rgba(0, 0, 0, 0.04),
-    inset 0 1px 1px rgba(255, 255, 255, 0.8);
+  box-shadow: var(--glass-shadow);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .glass-panel:hover {
   transform: translateY(-2px);
-  box-shadow: 
-    0 12px 40px rgba(11, 95, 55, 0.15),
-    0 4px 12px rgba(0, 0, 0, 0.06),
-    inset 0 1px 1px rgba(255, 255, 255, 0.9);
+  box-shadow: var(--glass-shadow), 0 4px 12px rgba(0, 0, 0, 0.06);
 }
 
 .glass-card {


### PR DESCRIPTION
Dos frentes que salieron del repaso de pantallas con datos reales.

## 1. Panel de seguridad — 2FA de administradores (#362)

`requireAdmin` podía exigir 2FA y responder `403 MFA_REQUIRED`, pero el único control era `REQUIRE_ADMIN_MFA`: ninguna pantalla decía si estaba activa, cambiarla obligaba a reiniciar el servicio, y —lo más serio— encenderla sin 2FA configurada en la cuenta cerraba **todo** `/admin/*`, incluida cualquier ruta que sirviera para volver a apagarla. La única salida era editar Mongo a mano.

- El ajuste pasa a vivir en Mongo (colección `appsettings`), con `REQUIRE_ADMIN_MFA` como valor por defecto mientras nadie lo toque. La respuesta declara su procedencia (`stored` / `environment`) para poder explicarlo en pantalla.
- Nueva pantalla `/dashboard/admin/security`: estado en vigor, de dónde sale, si tu cuenta tiene 2FA en Clerk, interruptor, y los pasos para activarla si no la tienes.
- **Salida de emergencia:** `GET`/`PATCH /admin/security-settings` usan un `requireAdminRoleOnly` nuevo, que comprueba el rol pero nunca la 2FA. Sin eso el interruptor sería una trampa: te encierras y no puedes salir.
- El cambio queda en auditoría.
- Fuera de producción sigue desactivado por defecto, que es como ya se comportaba.

Caché de 10 s sobre la lectura del ajuste: `requireAdmin` corre en cada petición a `/admin/*` y no merece un viaje a Mongo por cada una, pero un cambio desde el panel se nota casi al momento.

## 2. Contraste y tokens (#363)

`src/styles.css` es anterior al sistema `--ts-*` y define una paleta **solo clara** que nadie sobrescribe. Varias pantallas del panel siguen usándola (contratos, detalle de contrato, auditoría, privacidad), y en tema oscuro quedaban ilegibles: títulos en `--leaf-900` (`#063922`, verde casi negro) sobre fondo oscuro, y `.glass-panel` con un degradado blanco fijo que dejaba el texto crema encima invisible.

- Se redefine esa paleta heredada bajo el tema oscuro **en un solo sitio**, replicando la cascada de `styles/tokens.css` (elección explícita primero, preferencia del SO después), en vez de retocar cada regla que la consume.
- `.glass-panel` pasa a leer `--glass-bg` / `--glass-border` / `--glass-shadow` en lugar de blancos fijos.
- `VisitModal` y `ReviewModal` apuntaban a `var(--surface)`, que **no existe** (el token es `--ts-surface`), así que siempre caían al respaldo `#1a1a2e`: un azul marino ajeno a la paleta verde en ambos temas.
- Los terrenos de solo venta anunciaban «$0/mes»; ahora muestran su precio de venta, y los de operación «ambas» muestran los dos.
- Las tarjetas de «Mis terrenos» nunca mostraban la foto de la publicación, solo el marcador de posición.

## Verificación

- Backend `bun test`: **381 pass / 0 fail** (364 antes; +11 de `admin-security.test.ts`, entre ellas las tres que fijan la salida de emergencia). `typecheck` limpio.
- Web `typecheck` y `build` limpios. Playwright `--project=chromium`: **41 passed**.
- En el navegador, con sesión real y datos del seed: la lista de contratos pasa de título verde-sobre-oscuro y panel casi blanco a legible; «Mis terrenos» muestra fotos y «Lote Cerro Azul · $145,000 en venta» donde antes decía «$0/mes». Comprobado que el tema claro no cambia (panel `rgba(255,255,255,0.72)`, título `#063922`).

Closes #362
Closes #363
