### PR TITLE
fix(web): catálogo truncado, precios de venta como «$0/mes» y reseñas recibidas invisibles (#365)

### DIFF
--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -12,6 +12,7 @@ import { requireAuth } from "./middleware/require-auth";
 import { authRoutes } from "./routes/auth";
 import { healthRoutes } from "./routes/health";
 import { adminRoutes } from "./routes/admin";
+import { adminSecurityRoutes } from "./routes/admin-security";
 import { landRoutes } from "./routes/lands";
 import { favoriteRoutes } from "./routes/favorites";
 import { leadRoutes } from "./routes/leads";
@@ -71,6 +72,7 @@ export function createApp() {
   app.route("/api/v1", healthRoutes);
   app.route("/api/v1", authRoutes);
   app.route("/api/v1", adminRoutes);
+  app.route("/api/v1", adminSecurityRoutes);
   app.route("/api/v1", backupRoutes);
   app.route("/api/v1", landRoutes);
   app.route("/api/v1", favoriteRoutes);

--- a/apps/backend-api/src/db/schemas.ts
+++ b/apps/backend-api/src/db/schemas.ts
@@ -514,6 +514,25 @@ const NotificationSchema = new Schema<INotification>({
 
 export const Notification = mongoose.models.Notification || mongoose.model<INotification>("Notification", NotificationSchema);
 
+/**
+ * Ajuste de la aplicación editable en caliente (#362). Sustituye a las
+ * variables de entorno para lo que un administrador debe poder cambiar sin
+ * reiniciar el servicio, como la exigencia de 2FA.
+ */
+export interface IAppSetting extends Document {
+  key: string;
+  value: unknown;
+  updatedAt: Date;
+}
+
+const AppSettingSchema = new Schema<IAppSetting>({
+  key: { type: String, required: true, unique: true },
+  value: { type: Schema.Types.Mixed },
+}, { timestamps: true });
+
+export const AppSetting = mongoose.models.AppSetting
+  || mongoose.model<IAppSetting>("AppSetting", AppSettingSchema);
+
 /** Búsqueda guardada de un usuario; alimenta las alertas de nuevos terrenos (HU-99 #325). */
 export interface ISavedSearch extends Document {
   id: string;

--- a/apps/backend-api/src/db/seed-demo.ts
+++ b/apps/backend-api/src/db/seed-demo.ts
@@ -545,7 +545,10 @@ export function buildDemoData(): Built {
       location: {
         province: spec.province,
         district: spec.district,
-        corregimiento: pick(PROVINCES[spec.province] ?? [spec.district]),
+        // Se omite a propósito: la lista por provincia son DISTRITOS, y
+        // reutilizarla aquí ponía cosas como «corregimiento: David» dentro de
+        // Boquete. Mejor no mostrar el dato que mostrarlo mal.
+        corregimiento: undefined,
         lat: 7.5 + rng() * 1.9,
         lng: -82.5 + rng() * 4.5,
       },

--- a/apps/backend-api/src/lib/security-settings.ts
+++ b/apps/backend-api/src/lib/security-settings.ts
@@ -1,0 +1,80 @@
+/**
+ * Ajustes de seguridad que se pueden cambiar en caliente (#362).
+ *
+ * Hasta ahora la exigencia de 2FA a los administradores solo se controlaba con
+ * la variable `REQUIRE_ADMIN_MFA`, así que para cambiarla había que tocar el
+ * entorno y reiniciar, y ninguna pantalla decía si estaba activa. El resultado
+ * práctico era un 403 `MFA_REQUIRED` sin explicación y sin forma de quitarlo.
+ *
+ * Ahora el valor vive en Mongo y la variable de entorno queda como valor por
+ * defecto para cuando nadie lo ha tocado todavía.
+ */
+import { AppSetting } from "../db/schemas";
+import { env } from "../config/env";
+
+export const REQUIRE_ADMIN_MFA_KEY = "security.requireAdminMfa";
+
+/** De dónde sale el valor que está en vigor. */
+export type SettingSource = "stored" | "environment";
+
+export interface AdminMfaSetting {
+  requireAdminMfa: boolean;
+  source: SettingSource;
+  /** Valor por defecto del entorno, para poder explicarlo en la interfaz. */
+  environmentDefault: boolean;
+}
+
+/**
+ * Caché breve: `requireAdmin` corre en cada petición a `/admin/*` y no merece
+ * una lectura a Mongo por cada una. 10 s hace que un cambio desde el panel se
+ * note casi al momento sin castigar el camino caliente.
+ */
+const CACHE_TTL_MS = 10_000;
+let cached: { value: AdminMfaSetting; at: number } | null = null;
+
+/** Vacía la caché. Se llama al guardar, y desde los tests. */
+export function invalidateSecuritySettingsCache(): void {
+  cached = null;
+}
+
+async function readStoredValue(): Promise<boolean | null> {
+  try {
+    const doc = await AppSetting.findOne({ key: REQUIRE_ADMIN_MFA_KEY }).lean();
+    if (!doc) return null;
+    return (doc as { value?: unknown }).value === true;
+  } catch {
+    // Si Mongo no responde, se cae al valor del entorno en vez de romper la
+    // autorización: es preferible un fallo de configuración a un 500.
+    return null;
+  }
+}
+
+/** Ajuste en vigor, con su procedencia. */
+export async function getAdminMfaSetting(): Promise<AdminMfaSetting> {
+  const now = Date.now();
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.value;
+
+  const stored = await readStoredValue();
+  const value: AdminMfaSetting = stored === null
+    ? { requireAdminMfa: env.requireAdminMfa, source: "environment", environmentDefault: env.requireAdminMfa }
+    : { requireAdminMfa: stored, source: "stored", environmentDefault: env.requireAdminMfa };
+
+  cached = { value, at: now };
+  return value;
+}
+
+/** Atajo para el middleware: solo el booleano en vigor. */
+export async function isAdminMfaRequired(): Promise<boolean> {
+  return (await getAdminMfaSetting()).requireAdminMfa;
+}
+
+/** Guarda el ajuste y devuelve el estado resultante. */
+export async function setAdminMfaRequired(required: boolean): Promise<AdminMfaSetting> {
+  await AppSetting.updateOne(
+    { key: REQUIRE_ADMIN_MFA_KEY },
+    { $set: { key: REQUIRE_ADMIN_MFA_KEY, value: required } },
+    { upsert: true },
+  );
+  invalidateSecuritySettingsCache();
+  return getAdminMfaSetting();
+}

--- a/apps/backend-api/src/middleware/require-auth.ts
+++ b/apps/backend-api/src/middleware/require-auth.ts
@@ -6,6 +6,7 @@ import { failure } from "../lib/api-response";
 import type { AuthContextUser } from "../types";
 import { resolveClerkAuthUser } from "../lib/clerk-user";
 import { getStore } from "../store/in-memory-db";
+import { isAdminMfaRequired } from "../lib/security-settings";
 import { User } from "../db/schemas";
 import type { AppEnv } from "../types";
 
@@ -140,6 +141,23 @@ export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   }
 };
 
+/**
+ * Solo comprueba el rol, **sin** la exigencia de 2FA.
+ *
+ * Es la salida de emergencia del panel de seguridad (#362): si la exigencia
+ * está activa y el admin no tiene 2FA en su cuenta, todas las rutas `/admin/*`
+ * le responden 403 — incluida la que serviría para desactivarla. Sin esta
+ * excepción, encender el interruptor sin 2FA configurado deja la cuenta fuera
+ * de su propio panel y solo se puede arreglar tocando la base a mano.
+ */
+export const requireAdminRoleOnly: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const authUser = c.get("authUser");
+  if (!authUser || authUser.role !== "admin") {
+    return failure(c, 403, "FORBIDDEN", "Admin role required");
+  }
+  await next();
+};
+
 export const requireAdmin: MiddlewareHandler<AppEnv> = async (c, next) => {
   const authUser = c.get("authUser");
   if (!authUser || authUser.role !== "admin") {
@@ -148,7 +166,9 @@ export const requireAdmin: MiddlewareHandler<AppEnv> = async (c, next) => {
 
   const hasDevHeader = Boolean(c.req.header("x-dev-user-id") || c.req.header("x-dev-role"));
   const isDevBypass = hasDevHeader && env.allowDevAuthBypass;
-  if (env.requireAdminMfa && !isDevBypass && authUser.mfaVerified !== true) {
+  // El ajuste guardado manda sobre `REQUIRE_ADMIN_MFA`, para poder cambiarlo
+  // desde el panel sin reiniciar el servicio.
+  if (!isDevBypass && (await isAdminMfaRequired()) && authUser.mfaVerified !== true) {
     return failure(c, 403, "MFA_REQUIRED", "Admin must have MFA enabled");
   }
 

--- a/apps/backend-api/src/routes/admin-security.test.ts
+++ b/apps/backend-api/src/routes/admin-security.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { createApp } from "../app";
+import { AppSetting } from "../db/schemas";
+import { invalidateSecuritySettingsCache, REQUIRE_ADMIN_MFA_KEY } from "../lib/security-settings";
+
+/**
+ * Panel de seguridad: exigencia de 2FA a los administradores (#362).
+ *
+ * Lo que estas pruebas fijan es sobre todo la **salida de emergencia**: la
+ * pantalla que apaga la exigencia no puede quedar detrás de la propia
+ * exigencia, o encenderla sin 2FA configurada encierra a la cuenta fuera de su
+ * panel sin forma de volver atrás.
+ *
+ * Gotcha de bun:test + mongodb-memory-server: escribir en el cuerpo del test y
+ * leer después puede colgarse, así que lo que se escribe se siembra en
+ * `beforeEach` y el cuerpo solo lee (salvo las pruebas del PATCH, que son una
+ * sola escritura y su respuesta).
+ */
+
+const app = createApp();
+
+const adminHeaders = { "x-dev-user-id": "admin_sec_test", "x-dev-role": "admin" };
+const userHeaders = { "x-dev-user-id": "user_sec_test", "x-dev-role": "user" };
+
+const get = (path: string, headers: Record<string, string>) =>
+  app.request(path, { headers });
+
+const patch = (path: string, headers: Record<string, string>, body: unknown) =>
+  app.request(path, {
+    method: "PATCH",
+    headers: { ...headers, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("GET /admin/security-settings", () => {
+  it("devuelve el ajuste en vigor y si quien pregunta tiene 2FA", async () => {
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(typeof body.data.requireAdminMfa).toBe("boolean");
+    expect(["stored", "environment"]).toContain(body.data.source);
+    expect(typeof body.data.environmentDefault).toBe("boolean");
+    expect(typeof body.data.callerMfaEnabled).toBe("boolean");
+  });
+
+  it("fuera de producción la 2FA no se exige por defecto", async () => {
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    const body = await res.json();
+
+    expect(body.data.requireAdminMfa).toBe(false);
+    // Sin nada guardado, el valor sale del entorno.
+    expect(body.data.source).toBe("environment");
+  });
+
+  it("un usuario sin rol admin no puede verlo", async () => {
+    const res = await get("/api/v1/admin/security-settings", userHeaders);
+    expect(res.status).toBe(403);
+  });
+
+  it("sin autenticar responde 401", async () => {
+    const res = await app.request("/api/v1/admin/security-settings");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("PATCH /admin/security-settings", () => {
+  it("guarda la exigencia y la respuesta pasa a declararse como guardada", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, { requireAdminMfa: true });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.requireAdminMfa).toBe(true);
+    expect(body.data.source).toBe("stored");
+  });
+
+  it("rechaza un valor que no sea booleano", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, { requireAdminMfa: "sí" });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("rechaza un cuerpo sin el campo", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("un usuario sin rol admin no puede cambiarlo", async () => {
+    const res = await patch("/api/v1/admin/security-settings", userHeaders, { requireAdminMfa: true });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("la exigencia activa no encierra al admin fuera del panel", () => {
+  beforeEach(async () => {
+    // 2FA exigida y guardada, que es el escenario que dejaba fuera a la cuenta.
+    await AppSetting.updateOne(
+      { key: REQUIRE_ADMIN_MFA_KEY },
+      { $set: { key: REQUIRE_ADMIN_MFA_KEY, value: true } },
+      { upsert: true },
+    );
+    invalidateSecuritySettingsCache();
+  });
+
+  it("el ajuste guardado queda en vigor y se declara como tal", async () => {
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    const body = await res.json();
+
+    expect(body.data.requireAdminMfa).toBe(true);
+    expect(body.data.source).toBe("stored");
+  });
+
+  it("con la exigencia activa, la pantalla de seguridad sigue accesible", async () => {
+    // Es la salida de emergencia: si esto respondiera 403, no habría manera de
+    // apagar la exigencia desde la interfaz.
+    const res = await get("/api/v1/admin/security-settings", adminHeaders);
+    expect(res.status).toBe(200);
+  });
+
+  it("con la exigencia activa, se puede volver a apagar", async () => {
+    const res = await patch("/api/v1/admin/security-settings", adminHeaders, { requireAdminMfa: false });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.requireAdminMfa).toBe(false);
+  });
+});

--- a/apps/backend-api/src/routes/admin-security.ts
+++ b/apps/backend-api/src/routes/admin-security.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+
+import { failure, success } from "../lib/api-response";
+import { requireAuth, requireAdminRoleOnly } from "../middleware/require-auth";
+import { getAdminMfaSetting, setAdminMfaRequired } from "../lib/security-settings";
+import { createAuditEvent as createAudit } from "../store/audit";
+import type { AppEnv } from "../types";
+
+export const adminSecurityRoutes = new Hono<AppEnv>();
+
+/**
+ * Panel de seguridad (#362).
+ *
+ * Estas dos rutas usan `requireAdminRoleOnly` **a propósito**: son la salida de
+ * emergencia. Si se exige 2FA y el admin no la tiene configurada en Clerk,
+ * `requireAdmin` le devuelve 403 en todo `/admin/*`; si eso incluyera esta
+ * pantalla, encender el interruptor sin 2FA dejaría la cuenta encerrada fuera
+ * de su propio panel, sin forma de volver atrás salvo editando la base a mano.
+ */
+
+adminSecurityRoutes.get("/admin/security-settings", requireAuth, requireAdminRoleOnly, async (c) => {
+  const authUser = c.get("authUser");
+  const setting = await getAdminMfaSetting();
+
+  return success(c, {
+    ...setting,
+    /** Si la cuenta que pregunta tiene 2FA activa en Clerk. */
+    callerMfaEnabled: authUser.mfaVerified === true,
+  });
+});
+
+adminSecurityRoutes.patch("/admin/security-settings", requireAuth, requireAdminRoleOnly, async (c) => {
+  const authUser = c.get("authUser");
+  const body: { requireAdminMfa?: unknown } = await c.req
+    .json<{ requireAdminMfa?: unknown }>()
+    .catch(() => ({}));
+
+  if (typeof body.requireAdminMfa !== "boolean") {
+    return failure(c, 400, "VALIDATION_ERROR", "requireAdminMfa must be a boolean");
+  }
+
+  const setting = await setAdminMfaRequired(body.requireAdminMfa);
+
+  // Cambiar quién puede entrar al panel es justo lo que una bitácora debe
+  // registrar, así que queda en auditoría con el valor nuevo.
+  await createAudit({
+    actor: authUser,
+    entity: "user",
+    action: "status_changed",
+    entityId: "security.requireAdminMfa",
+    metadata: { requireAdminMfa: setting.requireAdminMfa },
+  });
+
+  return success(c, {
+    ...setting,
+    callerMfaEnabled: authUser.mfaVerified === true,
+  });
+});

--- a/apps/backend-api/src/setup-test-env.ts
+++ b/apps/backend-api/src/setup-test-env.ts
@@ -2,6 +2,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 process.env.ALLOW_DEV_AUTH_BYPASS = "true";
+// Marcador de posición: `test-preload` lo sustituye sin condiciones por la URI
+// del servidor en memoria en cuanto arranca. Existe porque `config/env` valida
+// la variable con zod al evaluarse, y basta con que un módulo importe `env`
+// antes de ese momento para que toda la suite reviente. En local no se notaba:
+// el `.env` de desarrollo ya traía la variable, así que solo fallaba en CI.
+process.env.MONGODB_URI = process.env.MONGODB_URI ?? "mongodb://127.0.0.1:27017/terrashare-test";
 process.env.CLERK_JWKS_URL = process.env.CLERK_JWKS_URL ?? "https://example.test/.well-known/jwks.json";
 process.env.CLERK_ISSUER = process.env.CLERK_ISSUER ?? "https://example.test";
 process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY ?? "sk_test_placeholder";

--- a/apps/backend-api/src/test-preload.ts
+++ b/apps/backend-api/src/test-preload.ts
@@ -1,10 +1,13 @@
 // Test preload: spins up an in-memory MongoDB, connects both data layers
 // (native driver + mongoose), and seeds it from the in-memory store fixtures
 // before every test. Wired via bunfig.toml `[test].preload`.
+// Primero de todo: fija las variables de entorno que `config/env` valida al
+// evaluarse. Cualquier import que arrastre `env` debe venir después.
+import "./setup-test-env";
+
 import { afterAll, beforeEach } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
-import "./setup-test-env";
 import mongoose from "mongoose";
 import { connectMongoose, disconnectMongoose } from "./db/mongoose";
 import { __resetRateLimit } from "./middleware/rate-limit";

--- a/apps/backend-api/src/test-preload.ts
+++ b/apps/backend-api/src/test-preload.ts
@@ -8,6 +8,7 @@ import "./setup-test-env";
 import mongoose from "mongoose";
 import { connectMongoose, disconnectMongoose } from "./db/mongoose";
 import { __resetRateLimit } from "./middleware/rate-limit";
+import { invalidateSecuritySettingsCache } from "./lib/security-settings";
 import { getStore, resetStore } from "./store/in-memory-db";
 
 // Maps the in-memory store collections to the Mongo collection names the routes
@@ -27,6 +28,9 @@ function fixtures(): Record<string, Record<string, unknown>[]> {
     // Incluida aunque el store no la siembre: así la colección se vacía entre
     // tests y las notificaciones que crea un test no se filtran al siguiente.
     notifications: [...store.notifications.values()],
+    // El panel de seguridad guarda aquí la exigencia de 2FA (#362). Se vacía
+    // entre tests para que un ajuste no se filtre y bloquee al siguiente.
+    appsettings: [],
   } as unknown as Record<string, Record<string, unknown>[]>;
 }
 
@@ -54,6 +58,9 @@ beforeEach(async () => {
   // Reset the module-level rate-limit counter so cumulative suite requests from
   // the shared test IP don't trip the IP limit and cause spurious 429s.
   __resetRateLimit();
+  // La caché de ajustes de seguridad guarda el valor 10 s; si no se limpia, un
+  // test arrastra la configuración del anterior.
+  invalidateSecuritySettingsCache();
   await seedDatabase();
 });
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
+    "test:unit": "bun test src/",
     "preview": "vite preview",
     "preview:static": "vite build && bun scripts/serve-static.mjs",
     "test:e2e": "playwright test",

--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useClerk } from "@clerk/clerk-react";
-import { LayoutDashboard, Flag, Map, Users, Mail, LogOut, Sprout, ScrollText, Activity, Scale, CreditCard, DatabaseBackup } from "lucide-react";
+import { LayoutDashboard, Flag, Map, Users, Mail, LogOut, Sprout, ScrollText, Activity, Scale, CreditCard, DatabaseBackup, ShieldCheck } from "lucide-react";
 import ThemeToggle from "./ThemeToggle";
 import "../pages/admin.css";
 
@@ -21,6 +21,7 @@ const NAV = [
   { to: "/dashboard/admin/audit", label: "Auditoria", icon: ScrollText },
   { to: "/dashboard/admin/observability", label: "Observabilidad", icon: Activity },
   { to: "/dashboard/admin/backups", label: "Respaldos", icon: DatabaseBackup },
+  { to: "/dashboard/admin/security", label: "Seguridad", icon: ShieldCheck },
 ];
 
 /** Layout editorial del panel admin: sidebar oscuro + contenido. Sustituye al

--- a/apps/web/src/components/PanamaMap.tsx
+++ b/apps/web/src/components/PanamaMap.tsx
@@ -3,6 +3,7 @@ import { MapContainer, TileLayer, Marker, Popup, GeoJSON, useMap } from "react-l
 import "leaflet/dist/leaflet.css";
 import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
 import "leaflet-defaulticon-compatibility";
+import { formatLandPriceShort } from "../lib/land-price";
 import { getLandPosition } from "../data/province-centers";
 
 type LandLike = Record<string, any>;
@@ -83,7 +84,7 @@ function MapPin({ land, onClick }: { land: LandLike; onClick: (land: LandLike) =
           <span className="popup-badge">{land.allowedUses?.[0]}</span>
           <h4>{land.title}</h4>
           <p>{land.location?.province} · {land.location?.district}</p>
-          <strong>${land.priceRule?.pricePerMonth}/mes</strong>
+          <strong>{formatLandPriceShort(land)}</strong>
         </div>
       </Popup>
     </Marker>

--- a/apps/web/src/components/ReviewModal.tsx
+++ b/apps/web/src/components/ReviewModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Star } from "lucide-react";
+import { FIELD_STYLE, BUTTON_STYLE, PRIMARY_BUTTON_STYLE } from "./modal-styles";
 
 interface ReviewModalProps {
   contractId: string;
@@ -85,11 +86,10 @@ export default function ReviewModal({ contractId, receiverId, onSubmit, onClose 
           maxLength={500}
           rows={3}
           style={{
-            width: "100%", boxSizing: "border-box",
-            padding: "0.75rem", borderRadius: "8px",
-            border: "1px solid rgba(255,255,255,0.15)",
-            background: "rgba(255,255,255,0.05)",
-            color: "inherit", fontFamily: "inherit", fontSize: "0.9rem",
+            ...FIELD_STYLE,
+            boxSizing: "border-box",
+            marginTop: 0,
+            padding: "0.75rem",
             resize: "vertical",
           }}
         />
@@ -103,11 +103,7 @@ export default function ReviewModal({ contractId, receiverId, onSubmit, onClose 
         <div style={{ display: "flex", gap: "0.75rem", justifyContent: "flex-end", marginTop: "1rem" }}>
           <button
             onClick={onClose}
-            style={{
-              padding: "0.5rem 1rem", borderRadius: "8px",
-              border: "1px solid rgba(255,255,255,0.15)", background: "transparent",
-              color: "inherit", cursor: "pointer", fontSize: "0.9rem",
-            }}
+            style={BUTTON_STYLE}
           >
             Cancelar
           </button>
@@ -115,11 +111,12 @@ export default function ReviewModal({ contractId, receiverId, onSubmit, onClose 
             onClick={handleSubmit}
             disabled={submitting || rating < 1}
             style={{
-              padding: "0.5rem 1.5rem", borderRadius: "8px",
-              border: "none", background: "var(--leaf-600, #059669)",
-              color: "#fff", cursor: submitting ? "not-allowed" : "pointer",
+              // `--leaf-600` tampoco existía: caía a un verde esmeralda que no
+              // es el de la marca (#365).
+              ...PRIMARY_BUTTON_STYLE,
+              padding: "0.5rem 1.5rem",
+              cursor: submitting ? "not-allowed" : "pointer",
               opacity: submitting || rating < 1 ? 0.6 : 1,
-              fontSize: "0.9rem", fontWeight: 600,
             }}
           >
             {submitting ? "Enviando..." : "Enviar reseña"}

--- a/apps/web/src/components/ReviewModal.tsx
+++ b/apps/web/src/components/ReviewModal.tsx
@@ -41,7 +41,11 @@ export default function ReviewModal({ contractId, receiverId, onSubmit, onClose 
       <div
         onClick={(e) => e.stopPropagation()}
         style={{
-          background: "var(--surface, #1a1a2e)",
+          // Mismo caso que en VisitModal: `--surface` no existe, el token es
+          // `--ts-surface`, y sin él salía un azul marino ajeno al tema (#363).
+          background: "var(--ts-surface)",
+          color: "var(--ts-text)",
+          border: "1px solid var(--ts-border)",
           borderRadius: "12px", padding: "2rem",
           maxWidth: "480px", width: "90%",
           boxShadow: "0 20px 60px rgba(0,0,0,0.3)",

--- a/apps/web/src/components/VisitModal.tsx
+++ b/apps/web/src/components/VisitModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CalendarClock } from "lucide-react";
+import { FIELD_STYLE, BUTTON_STYLE, PRIMARY_BUTTON_STYLE } from "./modal-styles";
 
 interface VisitModalProps {
   landTitle: string;
@@ -80,7 +81,7 @@ export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalP
               value={date}
               min={todayIso()}
               onChange={(e) => setDate(e.target.value)}
-              style={{ width: "100%", marginTop: "0.25rem", padding: "0.5rem", borderRadius: "8px" }}
+              style={FIELD_STYLE}
             />
           </label>
           <label style={{ flex: 1, fontSize: "0.85rem" }}>
@@ -89,7 +90,7 @@ export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalP
               type="time"
               value={time}
               onChange={(e) => setTime(e.target.value)}
-              style={{ width: "100%", marginTop: "0.25rem", padding: "0.5rem", borderRadius: "8px" }}
+              style={FIELD_STYLE}
             />
           </label>
         </div>
@@ -100,7 +101,7 @@ export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalP
           onChange={(e) => setMessage(e.target.value)}
           maxLength={500}
           rows={3}
-          style={{ width: "100%", padding: "0.5rem", borderRadius: "8px", resize: "vertical" }}
+          style={{ ...FIELD_STYLE, marginTop: 0, resize: "vertical" }}
         />
 
         {error && (
@@ -111,7 +112,7 @@ export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalP
           <button
             type="button"
             onClick={onClose}
-            style={{ padding: "0.5rem 1rem", borderRadius: "8px", cursor: "pointer" }}
+            style={BUTTON_STYLE}
           >
             Cancelar
           </button>
@@ -120,11 +121,9 @@ export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalP
             onClick={handleSubmit}
             disabled={submitting || !date || !time}
             style={{
-              padding: "0.5rem 1rem", borderRadius: "8px",
+              ...PRIMARY_BUTTON_STYLE,
               cursor: submitting ? "default" : "pointer",
               opacity: submitting || !date || !time ? 0.6 : 1,
-              display: "inline-flex", alignItems: "center", gap: "0.4rem",
-              fontSize: "0.9rem", fontWeight: 600,
             }}
           >
             <CalendarClock size={16} />

--- a/apps/web/src/components/VisitModal.tsx
+++ b/apps/web/src/components/VisitModal.tsx
@@ -55,7 +55,12 @@ export default function VisitModal({ landTitle, onSubmit, onClose }: VisitModalP
         aria-modal="true"
         aria-label="Agendar visita"
         style={{
-          background: "var(--surface, #1a1a2e)",
+          // `--surface` no existe: el token del sistema se llama `--ts-surface`.
+          // Sin definir, el modal caía al azul marino de reserva, que no pega
+          // con la paleta verde en ningún tema (#363).
+          background: "var(--ts-surface)",
+          color: "var(--ts-text)",
+          border: "1px solid var(--ts-border)",
           borderRadius: "12px", padding: "2rem",
           maxWidth: "460px", width: "90%",
           boxShadow: "0 20px 60px rgba(0,0,0,0.3)",

--- a/apps/web/src/components/modal-styles.ts
+++ b/apps/web/src/components/modal-styles.ts
@@ -1,0 +1,45 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Estilos compartidos por los modales con formulario (`VisitModal`,
+ * `ReviewModal`) — #365.
+ *
+ * Ambos se escribieron con estilos en línea y sin fijar colores en los campos,
+ * así que los `input` y `textarea` se quedaban con el aspecto por defecto del
+ * navegador: cajas blancas dentro de un modal oscuro. Al declararlos con los
+ * tokens del sistema, los campos siguen al tema igual que el resto.
+ */
+
+export const FIELD_STYLE: CSSProperties = {
+  width: "100%",
+  marginTop: "0.25rem",
+  padding: "0.5rem",
+  borderRadius: "8px",
+  background: "var(--ts-bg)",
+  color: "var(--ts-text)",
+  border: "1px solid var(--ts-border)",
+  fontFamily: "inherit",
+  fontSize: "0.9rem",
+};
+
+export const BUTTON_STYLE: CSSProperties = {
+  padding: "0.5rem 1rem",
+  borderRadius: "8px",
+  cursor: "pointer",
+  background: "transparent",
+  color: "var(--ts-text)",
+  border: "1px solid var(--ts-border)",
+  fontFamily: "inherit",
+  fontSize: "0.9rem",
+};
+
+export const PRIMARY_BUTTON_STYLE: CSSProperties = {
+  ...BUTTON_STYLE,
+  background: "var(--ts-green)",
+  color: "var(--ts-on-green)",
+  border: "1px solid var(--ts-green)",
+  fontWeight: 600,
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "0.4rem",
+};

--- a/apps/web/src/lib/land-price.test.ts
+++ b/apps/web/src/lib/land-price.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import type { LandDto } from "@terrashare/shared";
+
+import { formatLandPrice, formatLandPriceShort, monthlyPrice, salePrice } from "./land-price";
+
+/**
+ * El caso que originó el helper (#365): un terreno de solo venta lleva
+ * `pricePerMonth: 0`, y `typeof 0 === "number"` es cierto, así que todas las
+ * pantallas anunciaban «$0/mes» en vez del precio de venta.
+ */
+
+const land = (over: Partial<LandDto>): LandDto =>
+  ({
+    id: "land_test",
+    ownerId: "owner",
+    title: "Terreno",
+    area: 10,
+    allowedUses: ["agricultura"],
+    location: { province: "Panamá", district: "Chepo" },
+    availability: {},
+    priceRule: { currency: "USD", pricePerMonth: 0 },
+    status: "active",
+    operation: "alquiler",
+    ...over,
+  }) as LandDto;
+
+describe("formatLandPrice", () => {
+  it("muestra la renta mensual de un terreno de alquiler", () => {
+    const result = formatLandPrice(land({ operation: "alquiler", priceRule: { currency: "USD", pricePerMonth: 1250 } }));
+    expect(result).toBe("$1,250/mes");
+  });
+
+  it("muestra el precio de venta, no «$0/mes», en un terreno de solo venta", () => {
+    const result = formatLandPrice(land({ operation: "venta", salePrice: 145000 }));
+    expect(result).toBe("$145,000 en venta");
+    expect(result).not.toContain("/mes");
+  });
+
+  it("muestra los dos precios cuando el terreno admite ambas operaciones", () => {
+    const result = formatLandPrice(
+      land({ operation: "ambas", priceRule: { currency: "USD", pricePerMonth: 780 }, salePrice: 96000 }),
+    );
+    expect(result).toBe("$780/mes · $96,000 en venta");
+  });
+
+  it("cae a «Precio a convenir» si no hay ningún precio utilizable", () => {
+    expect(formatLandPrice(land({ operation: "venta" }))).toBe("Precio a convenir");
+    expect(formatLandPrice(land({ operation: "alquiler" }))).toBe("Precio a convenir");
+  });
+});
+
+describe("formatLandPriceShort", () => {
+  it("prioriza la renta cuando existe", () => {
+    const result = formatLandPriceShort(
+      land({ operation: "ambas", priceRule: { currency: "USD", pricePerMonth: 780 }, salePrice: 96000 }),
+    );
+    expect(result).toBe("$780/mes");
+  });
+
+  it("cae al precio de venta si el terreno no se alquila", () => {
+    expect(formatLandPriceShort(land({ operation: "venta", salePrice: 145000 }))).toBe("$145,000");
+  });
+
+  it("cae a «A consultar» sin precios", () => {
+    expect(formatLandPriceShort(land({ operation: "alquiler" }))).toBe("A consultar");
+  });
+});
+
+describe("monthlyPrice / salePrice", () => {
+  it("el 0 cuenta como «sin renta», no como gratis", () => {
+    expect(monthlyPrice(land({ operation: "alquiler", priceRule: { currency: "USD", pricePerMonth: 0 } }))).toBeNull();
+  });
+
+  it("un terreno de alquiler no expone precio de venta aunque lo lleve el documento", () => {
+    expect(salePrice(land({ operation: "alquiler", salePrice: 50000 }))).toBeNull();
+  });
+
+  it("un terreno de venta no expone renta aunque lleve pricePerMonth", () => {
+    expect(monthlyPrice(land({ operation: "venta", priceRule: { currency: "USD", pricePerMonth: 900 } }))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/land-price.ts
+++ b/apps/web/src/lib/land-price.ts
@@ -1,0 +1,70 @@
+/**
+ * Formato del precio de un terreno según su operación (#365).
+ *
+ * Cada pantalla lo resolvía por su cuenta y todas cometían el mismo error:
+ * comprobar `typeof pricePerMonth === "number"`, que es cierto para `0`. Un
+ * terreno de solo venta no tiene renta mensual y su `pricePerMonth` vale 0, así
+ * que el catálogo, la home, el comparador, el detalle y «Mis terrenos»
+ * anunciaban «$0/mes» en vez del precio de venta.
+ *
+ * Al centralizarlo, además, el terreno de operación «ambas» pasa a mostrar sus
+ * dos precios en lugar de solo la renta.
+ */
+
+/**
+ * Forma mínima que necesita el formateo. Es estructural en vez de `LandDto`
+ * porque `PanamaMap` trabaja con objetos sueltos (`Record<string, any>`) y no
+ * merece un casteo solo para pedir el precio.
+ */
+export interface LandPriceInput {
+  operation?: string | null;
+  priceRule?: { pricePerMonth?: number | null } | null;
+  salePrice?: number | null;
+}
+
+const money = (value: number): string => `$${value.toLocaleString("es-PA")}`;
+
+/** Renta mensual, o `null` si el terreno no se alquila. */
+export function monthlyPrice(land: LandPriceInput): number | null {
+  if (land.operation === "venta") return null;
+  const monthly = land.priceRule?.pricePerMonth;
+  // El 0 se trata como «sin renta», no como gratis: es el valor que llevan los
+  // terrenos que solo se venden.
+  return typeof monthly === "number" && monthly > 0 ? monthly : null;
+}
+
+/** Precio de venta, o `null` si el terreno no está en venta. */
+export function salePrice(land: LandPriceInput): number | null {
+  if (land.operation !== "venta" && land.operation !== "ambas") return null;
+  const sale = land.salePrice;
+  return typeof sale === "number" && sale > 0 ? sale : null;
+}
+
+/**
+ * Etiqueta completa: «$1,250/mes», «$145,000 en venta», los dos separados por
+ * punto medio si el terreno admite ambas operaciones, o «Precio a convenir».
+ */
+export function formatLandPrice(land: LandPriceInput): string {
+  const monthly = monthlyPrice(land);
+  const sale = salePrice(land);
+
+  const parts: string[] = [];
+  if (monthly !== null) parts.push(`${money(monthly)}/mes`);
+  if (sale !== null) parts.push(`${money(sale)} en venta`);
+
+  return parts.length > 0 ? parts.join(" · ") : "Precio a convenir";
+}
+
+/**
+ * Versión corta para tarjetas estrechas, donde no cabe la doble etiqueta:
+ * prioriza la renta y cae al precio de venta.
+ */
+export function formatLandPriceShort(land: LandPriceInput): string {
+  const monthly = monthlyPrice(land);
+  if (monthly !== null) return `${money(monthly)}/mes`;
+
+  const sale = salePrice(land);
+  if (sale !== null) return `${money(sale)}`;
+
+  return "A consultar";
+}

--- a/apps/web/src/pages/AdminSecurityPage.tsx
+++ b/apps/web/src/pages/AdminSecurityPage.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+import { ShieldCheck, ShieldAlert, Loader2, KeyRound, TriangleAlert } from "lucide-react";
+
+import {
+  getSecuritySettings,
+  setRequireAdminMfa,
+  type AdminSecuritySettingsDto,
+} from "../services/adminApi";
+import "./admin.css";
+
+/**
+ * Panel de seguridad (#362).
+ *
+ * La exigencia de 2FA para administradores existía desde HU-37, pero solo se
+ * gobernaba con la variable `REQUIRE_ADMIN_MFA` y ninguna pantalla decía si
+ * estaba activa: quien se topaba con el 403 `MFA_REQUIRED` no tenía forma de
+ * saber por qué ni de quitarlo. Esta pantalla lo muestra, lo explica y permite
+ * cambiarlo sin reiniciar el servicio.
+ */
+export default function AdminSecurityPage() {
+  const [settings, setSettings] = useState<AdminSecuritySettingsDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getSecuritySettings()
+      .then((res) => {
+        if (active) setSettings(res.data);
+      })
+      .catch((err: Error) => {
+        if (active) setError(err.message);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const toggle = async () => {
+    if (!settings || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await setRequireAdminMfa(!settings.requireAdminMfa);
+      setSettings(res.data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const required = settings?.requireAdminMfa ?? false;
+  // Encenderla sin 2FA en la propia cuenta cierra el resto del panel. Esta
+  // pantalla sigue accesible a propósito, para poder desandarlo.
+  const wouldLockOut = required && settings?.callerMfaEnabled === false;
+
+  return (
+    <div className="adm-page">
+      <h1 className="adm-title">Seguridad</h1>
+      <p className="adm-sub">Controles de acceso al panel de administración.</p>
+
+      {error ? <div className="adm-empty adm-empty--error">{error}</div> : null}
+
+      {loading ? (
+        <div className="adm-empty">Cargando ajustes de seguridad…</div>
+      ) : !settings ? (
+        <div className="adm-empty">No se pudieron cargar los ajustes.</div>
+      ) : (
+        <div className="adm-sec">
+          <section className="adm-panel">
+            <div className="adm-sec__head">
+              <span className={`adm-sec__icon ${required ? "is-on" : "is-off"}`}>
+                {required ? <ShieldCheck size={20} /> : <ShieldAlert size={20} />}
+              </span>
+              <div>
+                <h2 className="adm-panel__title">Exigir 2FA a los administradores</h2>
+                <p className="adm-sec__text">
+                  Con la exigencia activa, cualquier cuenta con rol admin necesita verificación
+                  en dos pasos configurada en Clerk para usar el panel. Sin ella, la API responde{" "}
+                  <code>403 MFA_REQUIRED</code> en todas las rutas <code>/admin/*</code>.
+                </p>
+              </div>
+            </div>
+
+            <div className="adm-sec__row">
+              <div className="adm-sec__state">
+                <span className={`adm-badge ${required ? "adm-badge--green" : "adm-badge--muted"}`}>
+                  {required ? "Exigida" : "No exigida"}
+                </span>
+                <span className="adm-sec__origin">
+                  {settings.source === "stored"
+                    ? "Fijado desde este panel."
+                    : `Valor por defecto del entorno (REQUIRE_ADMIN_MFA = ${settings.environmentDefault}).`}
+                </span>
+              </div>
+
+              <button
+                type="button"
+                className={`adm-pill ${required ? "" : "adm-pill--cta"}`}
+                onClick={toggle}
+                disabled={saving}
+              >
+                {saving ? <Loader2 size={15} className="adm-spin" /> : null}
+                {required ? "Desactivar" : "Activar"}
+              </button>
+            </div>
+
+            {wouldLockOut ? (
+              <p className="adm-sec__warn">
+                <TriangleAlert size={16} />
+                <span>
+                  Tu cuenta no tiene 2FA configurada, así que el resto del panel te está
+                  rechazando. Esta pantalla sigue accesible para que puedas desactivar la
+                  exigencia o configurar la 2FA en tu perfil.
+                </span>
+              </p>
+            ) : null}
+          </section>
+
+          <section className="adm-panel">
+            <div className="adm-sec__head">
+              <span className={`adm-sec__icon ${settings.callerMfaEnabled ? "is-on" : "is-off"}`}>
+                <KeyRound size={20} />
+              </span>
+              <div>
+                <h2 className="adm-panel__title">Tu cuenta</h2>
+                <p className="adm-sec__text">
+                  {settings.callerMfaEnabled
+                    ? "Tienes la verificación en dos pasos activa en Clerk."
+                    : "No tienes verificación en dos pasos activa en Clerk."}
+                </p>
+              </div>
+            </div>
+
+            {!settings.callerMfaEnabled ? (
+              <ol className="adm-sec__steps">
+                <li>Abre <strong>Mi perfil</strong> y entra a tu cuenta de Clerk.</li>
+                <li>En <strong>Security</strong>, añade un método en dos pasos (app de códigos o SMS).</li>
+                <li>Vuelve a iniciar sesión para que el token refleje el cambio.</li>
+              </ol>
+            ) : null}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -15,6 +15,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import { listLands, photoSrc } from "../services/api";
+import { formatLandPriceShort, monthlyPrice } from "../lib/land-price";
 import PanamaMap from "../components/LazyPanamaMap";
 import EmptyState from "../components/EmptyState";
 import { useFavorites } from "../hooks/useFavorites";
@@ -69,6 +70,9 @@ export default function CatalogPage() {
   const [use, setUse] = useState("todos");
   const [province, setProvince] = useState("todas");
   const [maxPrice, setMaxPrice] = useState(1_000_000);
+  // Tipo de operación (#365). El campo `operation` existe en el backend desde
+  // #249; el filtro llevaba desde entonces pintado como «Pronto».
+  const [operation, setOperation] = useState("todas");
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -86,7 +90,13 @@ export default function CatalogPage() {
 
   useEffect(() => {
     let active = true;
-    listLands()
+    // El catálogo filtra, ordena y pinta el mapa **en el cliente**, así que
+    // necesita el conjunto completo. Sin `pageSize`, el backend devolvía su
+    // página por defecto de 20 y el resto de terrenos era inalcanzable: no hay
+    // paginador en esta pantalla, así que desaparecían sin previo aviso.
+    // 100 es el máximo que admite la ruta; por encima de esa escala habría que
+    // mover los filtros al servidor y paginar de verdad (#366).
+    listLands({ pageSize: 100 })
       .then((data) => {
         if (!active) return;
         setLands(data);
@@ -113,18 +123,26 @@ export default function CatalogPage() {
   const filtered = useMemo(() => {
     return lands.filter((land) => {
       const landUse = land.allowedUses?.[0] ?? "otro";
-      const price = land.priceRule?.pricePerMonth ?? 0;
       const matchesUse = use === "todos" || landUse === use;
       const matchesProvince = province === "todas" || land.location?.province === province;
-      const matchesPrice = price <= maxPrice;
+      // El filtro de precio solo aplica a lo que se alquila: un terreno de solo
+      // venta no tiene renta con la que compararse, y contarlo como 0 lo colaba
+      // en todos los tramos «hasta $X».
+      const monthly = monthlyPrice(land);
+      const matchesPrice = maxPrice >= 1_000_000 || (monthly !== null && monthly <= maxPrice);
+      // «ambas» cuenta para las dos caras del filtro.
+      const matchesOperation =
+        operation === "todas"
+        || land.operation === operation
+        || land.operation === "ambas";
       const haystack = [land.title, land.location?.province, land.location?.district, land.description]
         .filter(Boolean)
         .join(" ")
         .toLowerCase();
       const matchesQuery = !query || haystack.includes(query.toLowerCase());
-      return matchesUse && matchesProvince && matchesPrice && matchesQuery;
+      return matchesUse && matchesProvince && matchesPrice && matchesOperation && matchesQuery;
     });
-  }, [lands, use, province, maxPrice, query]);
+  }, [lands, use, province, maxPrice, operation, query]);
 
   const selectedLand = filtered.find((l) => l.id === selectedId) ?? filtered[0] ?? null;
 
@@ -202,15 +220,23 @@ export default function CatalogPage() {
           </span>
         </label>
 
-        {/* TODO(#140): el tipo de operación (alquiler/venta) aún no existe en el
-            backend; el filtro se muestra como "próximamente". */}
-        <span className="cat-pill cat-pill--soon" role="note" title="Disponible próximamente">
+        <label className="cat-pill">
           <span className="cat-pill__icon">
             <Tag size={15} />
           </span>
-          Alquiler / Venta
-          <span className="cat-soon__tag">Pronto</span>
-        </span>
+          <select
+            value={operation}
+            onChange={(e) => setOperation(e.target.value)}
+            aria-label="Filtrar por tipo de operación"
+          >
+            <option value="todas">Alquiler / Venta</option>
+            <option value="alquiler">En alquiler</option>
+            <option value="venta">En venta</option>
+          </select>
+          <span className="cat-pill__chev">
+            <ChevronDown size={14} />
+          </span>
+        </label>
       </div>
 
       {/* lista + mapa */}
@@ -251,7 +277,7 @@ export default function CatalogPage() {
           ) : (
             <div className="cat-list">
               {filtered.map((land) => {
-                const price = land.priceRule?.pricePerMonth;
+                const monthly = monthlyPrice(land);
                 return (
                   <button
                     key={land.id}
@@ -326,13 +352,13 @@ export default function CatalogPage() {
                         <MapPin size={14} /> {land.location?.province} · {land.area} ha
                       </div>
                       <div className="cat-card__price">
-                        {typeof price === "number" ? (
+                        {monthly !== null ? (
                           <>
-                            ${price.toLocaleString("es-PA")}
+                            ${monthly.toLocaleString("es-PA")}
                             <span>/mes</span>
                           </>
                         ) : (
-                          <span style={{ fontSize: "14px" }}>Precio a consultar</span>
+                          <span style={{ fontSize: "14px" }}>{formatLandPriceShort(land)}</span>
                         )}
                       </div>
                     </div>
@@ -354,10 +380,7 @@ export default function CatalogPage() {
               <div style={{ minWidth: 0 }}>
                 <div className="cat-mapcard__title">{selectedLand.title}</div>
                 <div className="cat-mapcard__sub">
-                  {selectedLand.location?.province}
-                  {typeof selectedLand.priceRule?.pricePerMonth === "number"
-                    ? ` · $${selectedLand.priceRule.pricePerMonth.toLocaleString("es-PA")}/mes`
-                    : ""}
+                  {selectedLand.location?.province} · {formatLandPriceShort(selectedLand)}
                 </div>
               </div>
               <div className="cat-mapcard__actions">

--- a/apps/web/src/pages/ComparePage.tsx
+++ b/apps/web/src/pages/ComparePage.tsx
@@ -12,6 +12,7 @@ import {
 import { getLandById, photoSrc } from "../services/api";
 import { useCompareLands } from "../hooks/useCompareLands";
 import EmptyState from "../components/EmptyState";
+import { formatLandPrice } from "../lib/land-price";
 import "./compare.css";
 
 const USE_LABELS: Record<string, string> = {
@@ -40,16 +41,9 @@ function formatAvailable(iso?: string): string {
   return d.toLocaleDateString("es-PA", { day: "numeric", month: "short", year: "numeric" });
 }
 
-function formatPrice(land: LandDto): string {
-  const monthly = land.priceRule?.pricePerMonth;
-  if (typeof monthly === "number") {
-    return `$${monthly.toLocaleString("es-PA")}/mes`;
-  }
-  if (typeof land.salePrice === "number") {
-    return `$${land.salePrice.toLocaleString("es-PA")}`;
-  }
-  return "A consultar";
-}
+// El formato vive en `lib/land-price` para que todas las pantallas coincidan y
+// ninguna vuelva a tratar el `pricePerMonth: 0` de una venta como renta (#365).
+const formatPrice = formatLandPrice;
 
 function formatLocation(land: LandDto): string {
   const parts = [land.location?.province, land.location?.district].filter(Boolean);

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -53,14 +53,22 @@ export default function ContractDetailPage() {
   }, [user, contractId]);
 
   useEffect(() => {
-    if (!contract || contract.status !== "completed") return;
-    const receiverId = user?.id === contract.ownerId ? contract.tenantId : contract.ownerId;
-    getReviewsByUser(receiverId, contractId).then((r) => {
-      setReviews(r);
-      const mine = r.find((rev) => rev.senderId === user?.id);
+    if (!contract || contract.status !== "completed" || !user) return;
+    const counterpartId = user.id === contract.ownerId ? contract.tenantId : contract.ownerId;
+
+    // Hacen falta las DOS caras (#365). Antes solo se pedían las reseñas
+    // recibidas por la contraparte —que por definición son las que envié yo—,
+    // así que el bloque «Reseñas recibidas», que filtra por `senderId !== yo`,
+    // se quedaba vacío siempre, hubiera o no una reseña sobre mí.
+    Promise.all([
+      getReviewsByUser(counterpartId, contractId),
+      getReviewsByUser(user.id, contractId),
+    ]).then(([sent, received]) => {
+      setReviews(received);
+      const mine = sent.find((rev) => rev.senderId === user.id);
       if (mine) setMyReview(mine);
     });
-  }, [contract, user]);
+  }, [contract, user, contractId]);
 
   const handleReviewSubmit = async (rating: number, comment: string) => {
     if (!user || !contract) return;
@@ -72,8 +80,8 @@ export default function ContractDetailPage() {
       comment: comment || undefined,
     });
     if (review) {
+      // `reviews` guarda solo las recibidas; la recién enviada es `myReview`.
       setMyReview(review);
-      setReviews((prev) => [...prev, review]);
     }
   };
 

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -22,6 +22,7 @@ import { getChats, getMyFavorites, getMyLands, listRentalRequests, photoSrc } fr
 import { getDisplayName } from "../components/authDisplay";
 import { useAppMode } from "../components/AppLayout";
 import EmptyState from "../components/EmptyState";
+import { formatLandPrice, formatLandPriceShort, monthlyPrice } from "../lib/land-price";
 import "./home.css";
 
 type LoadState = "loading" | "ready" | "error";
@@ -233,11 +234,13 @@ function BuscoHome({ name }: { name: string }) {
                       {land.location?.province ?? "—"} · {land.area} ha
                     </span>
                   </span>
-                  {typeof land.priceRule?.pricePerMonth === "number" && (
+                  {monthlyPrice(land) !== null ? (
                     <span className="hm-favcard__price">
-                      ${land.priceRule.pricePerMonth.toLocaleString("es-PA")}
+                      ${monthlyPrice(land)!.toLocaleString("es-PA")}
                       <span>/mes</span>
                     </span>
+                  ) : (
+                    <span className="hm-favcard__price">{formatLandPriceShort(land)}</span>
                   )}
                 </Link>
               ))}
@@ -408,8 +411,7 @@ function OfrezcoHome() {
                   <div className="hm-pub__body">
                     <div className="hm-pub__title">{land.title}</div>
                     <div className="hm-pub__meta">
-                      {useLabel(land.allowedUses?.[0])} · $
-                      {land.priceRule?.pricePerMonth?.toLocaleString("es-PA")}/mes
+                      {useLabel(land.allowedUses?.[0])} · {formatLandPrice(land)}
                     </div>
                     <div className="hm-pub__stats">
                       <span className="hm-pub__stat">

--- a/apps/web/src/pages/LandDetailPage.tsx
+++ b/apps/web/src/pages/LandDetailPage.tsx
@@ -25,6 +25,7 @@ import { createChat, getLandById, createReport, getOwnerPublicProfile, photoSrc,
 import VisitModal from "../components/VisitModal";
 import type { ReportReason } from "../services/api";
 import { useFavorites } from "../hooks/useFavorites";
+import { monthlyPrice } from "../lib/land-price";
 import "./detail.css";
 
 const REPORT_REASONS: { value: ReportReason; label: string }[] = [
@@ -226,7 +227,7 @@ export default function LandDetailPage() {
 
   const operation = getOperation(land);
   const isSale = operation === "venta" || operation === "ambas";
-  const monthly = land.priceRule?.pricePerMonth;
+  const monthly = monthlyPrice(land);
   const loc = land.location;
 
   // Especificaciones a partir de datos reales (agua/acceso/suelo llegan con #138).
@@ -482,7 +483,7 @@ export default function LandDetailPage() {
                   ) : (
                     "A consultar"
                   )
-                ) : typeof monthly === "number" ? (
+                ) : monthly !== null ? (
                   <>
                     ${monthly.toLocaleString("es-PA")}
                     <span>/mes</span>

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -15,6 +15,7 @@ import {
   ImageIcon,
 } from "lucide-react";
 import { listLands, photoSrc } from "../services/api";
+import { monthlyPrice } from "../lib/land-price";
 import { isAdminUser } from "../components/authDisplay";
 import ThemeToggle from "../components/ThemeToggle";
 import "./landing.css";
@@ -68,7 +69,8 @@ function toFeatured(land: LandDto): FeaturedCard {
     use: USE_LABELS[land.allowedUses?.[0]] ?? "Terreno",
     area: land.area,
     province: land.location?.province ?? "Panamá",
-    price: land.priceRule?.pricePerMonth ?? null,
+    // Solo la renta: las tarjetas de la landing muestran «$X/mes» (#365).
+    price: monthlyPrice(land),
     to: `/lands/${land.id}`,
     cover: land.photos?.[0] ? photoSrc(land.photos[0]) : undefined,
   };

--- a/apps/web/src/pages/MyLandsPage.tsx
+++ b/apps/web/src/pages/MyLandsPage.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { useUser } from "@clerk/clerk-react";
 import type { LandDto } from "@terrashare/shared";
 import { Plus, Eye, Inbox, MapPin, Map } from "lucide-react";
-import { getMyLands } from "../services/api";
+import { getMyLands, photoSrc } from "../services/api";
 import EmptyState from "../components/EmptyState";
 import "./mylands.css";
 
@@ -21,6 +21,26 @@ const USE_LABELS: Record<string, string> = {
 function useLabel(use?: string): string {
   if (!use) return "Terreno";
   return USE_LABELS[use] ?? use;
+}
+
+/**
+ * Precio a mostrar según la operación del terreno.
+ *
+ * Un terreno de solo venta no tiene renta mensual, así que la tarjeta anunciaba
+ * «$0/mes» en vez del precio de venta (#363).
+ */
+function priceLabel(land: LandDto): string {
+  const monthly = land.priceRule?.pricePerMonth;
+  const sale = land.salePrice;
+
+  if (land.operation === "venta") {
+    return sale ? `$${sale.toLocaleString("es-PA")} en venta` : "Precio a convenir";
+  }
+  const rent = monthly ? `$${monthly.toLocaleString("es-PA")}/mes` : "Precio a convenir";
+  if (land.operation === "ambas" && sale) {
+    return `${rent} · $${sale.toLocaleString("es-PA")} en venta`;
+  }
+  return rent;
 }
 
 export default function MyLandsPage() {
@@ -89,16 +109,19 @@ export default function MyLandsPage() {
             return (
               <Link key={land.id} to="/lands/$id" params={{ id: land.id }} className="ml-card">
                 <div className="ml-card__media">
-                  <div className="ml-card__photo" aria-hidden="true">
-                    <MapPin size={26} strokeWidth={1.4} />
-                  </div>
+                  {land.photos?.[0] ? (
+                    <img className="ml-card__img" src={photoSrc(land.photos[0])} alt="" />
+                  ) : (
+                    <div className="ml-card__photo" aria-hidden="true">
+                      <MapPin size={26} strokeWidth={1.4} />
+                    </div>
+                  )}
                   <span className={`ml-card__badge ${badgeCls}`}>{badgeLabel}</span>
                 </div>
                 <div className="ml-card__body">
                   <div className="ml-card__title">{land.title}</div>
                   <div className="ml-card__meta">
-                    {useLabel(land.allowedUses?.[0])} · $
-                    {land.priceRule?.pricePerMonth?.toLocaleString("es-PA")}/mes
+                    {useLabel(land.allowedUses?.[0])} · {priceLabel(land)}
                   </div>
                   {/* TODO(#136): sin métricas de vistas/solicitudes por terreno todavía. */}
                   <div className="ml-card__stats">

--- a/apps/web/src/pages/admin.css
+++ b/apps/web/src/pages/admin.css
@@ -346,3 +346,68 @@
   .adm-main { padding: 24px 20px; }
   .adm-rep__grid { grid-template-columns: 1fr; }
 }
+
+/* ─── Panel de seguridad (#362) ───────────────────────────────────────────── */
+
+.adm-sec { display: grid; gap: 18px; max-width: 760px; }
+
+.adm-sec__head { display: flex; gap: 14px; align-items: flex-start; }
+
+.adm-sec__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex: none;
+  border-radius: 12px;
+}
+.adm-sec__icon.is-on { color: var(--ts-green); background: var(--ts-tint-green-2); }
+.adm-sec__icon.is-off { color: var(--ts-ink-3, #6b6b63); background: var(--ts-tint-2, #ececed); }
+
+.adm-sec__text { color: var(--ts-sage-2); font-size: 14px; line-height: 1.55; margin: 6px 0 0; }
+.adm-sec__text code {
+  font-size: 12.5px;
+  padding: 1px 5px;
+  border-radius: 5px;
+  background: var(--ts-tint-2, #ececed);
+  color: var(--ts-text);
+}
+
+.adm-sec__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--ts-beige);
+}
+.adm-sec__state { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.adm-sec__origin { color: var(--ts-sage-2); font-size: 13px; }
+
+.adm-sec__warn {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin: 16px 0 0;
+  padding: 12px 14px;
+  border-radius: 10px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: #9a6b1f;
+  background: #f5e9d0;
+}
+.adm-sec__warn svg { flex: none; margin-top: 2px; }
+
+.adm-sec__steps {
+  margin: 16px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  color: var(--ts-sage-2);
+  font-size: 14px;
+  line-height: 1.5;
+}
+.adm-sec__steps strong { color: var(--ts-text); font-weight: 600; }

--- a/apps/web/src/pages/mylands.css
+++ b/apps/web/src/pages/mylands.css
@@ -140,3 +140,12 @@
   .ml-grid { grid-template-columns: 1fr; }
   .ml-head { flex-direction: column; align-items: flex-start; }
 }
+
+/* Foto real del terreno cuando existe; el bloque con icono queda de reserva
+   para las publicaciones que aún no han subido ninguna (#363). */
+.ml-card__img {
+  width: 100%;
+  height: 130px;
+  object-fit: cover;
+  display: block;
+}

--- a/apps/web/src/routes/dashboard.admin.security.tsx
+++ b/apps/web/src/routes/dashboard.admin.security.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AdminRoute } from "../components/route-guards";
+import AdminLayout from "../components/AdminLayout";
+import AdminSecurityPage from "../pages/AdminSecurityPage";
+
+export const Route = createFileRoute("/dashboard/admin/security")({
+  component: () => (
+    <AdminRoute><AdminLayout><AdminSecurityPage /></AdminLayout></AdminRoute>
+  ),
+});

--- a/apps/web/src/services/adminApi.ts
+++ b/apps/web/src/services/adminApi.ts
@@ -231,3 +231,24 @@ export const createBackup = () => request<BackupRecordDto>("POST", "/api/v1/admi
 /** POST /api/v1/admin/backups/:id/verify — restauración probada. */
 export const verifyBackup = (id: string) =>
   request<BackupRecordDto>("POST", `/api/v1/admin/backups/${id}/verify`);
+
+// ─── Seguridad: 2FA de administradores (#362) ────────────────────────────────
+
+export interface AdminSecuritySettingsDto {
+  /** Si ahora mismo se exige 2FA para entrar a `/admin/*`. */
+  requireAdminMfa: boolean;
+  /** `stored` = alguien lo fijó desde el panel; `environment` = valor por defecto. */
+  source: "stored" | "environment";
+  /** Lo que diría `REQUIRE_ADMIN_MFA` si nadie lo hubiera tocado. */
+  environmentDefault: boolean;
+  /** Si la cuenta que consulta tiene la 2FA activa en Clerk. */
+  callerMfaEnabled: boolean;
+}
+
+/** GET /api/v1/admin/security-settings */
+export const getSecuritySettings = () =>
+  request<AdminSecuritySettingsDto>("GET", "/api/v1/admin/security-settings");
+
+/** PATCH /api/v1/admin/security-settings — activa o desactiva la exigencia de 2FA. */
+export const setRequireAdminMfa = (requireAdminMfa: boolean) =>
+  request<AdminSecuritySettingsDto>("PATCH", "/api/v1/admin/security-settings", { requireAdminMfa });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14,6 +14,44 @@
   --glass-shadow: 0 8px 32px rgba(11, 95, 55, 0.08);
 }
 
+/* Tema oscuro para la paleta heredada (#363).
+   Esta hoja es anterior al sistema de tokens `--ts-*` y fijaba una paleta solo
+   clara, pero varias pantallas del panel siguen usándola (contratos, auditoría,
+   privacidad). En tema oscuro el resultado era ilegible: `--leaf-900` es un
+   verde casi negro para los títulos, `--ink-900` el texto, y `.glass-panel` un
+   degradado blanco — es decir, título verde oscuro sobre fondo oscuro y texto
+   crema sobre panel casi blanco.
+   Se redefinen aquí las mismas variables para que la hoja siga al tema, en vez
+   de retocar cada regla que las consume. El selector replica la cascada de
+   `styles/tokens.css`: elección explícita primero, preferencia del SO después. */
+:root[data-theme="dark"] {
+  --leaf-700: #4f8a61;
+  --leaf-900: #7fae8a;         /* títulos: sube a un verde claro legible sobre oscuro */
+  --ink-900: #ece4d3;          /* texto principal: crema */
+  --paper: #1b241d;
+  --danger: #e08074;
+  --success: #6fbf94;
+  --ring: rgba(127, 174, 138, 0.35);
+  --glass-bg: rgba(38, 48, 40, 0.72);
+  --glass-border: rgba(236, 228, 211, 0.12);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --leaf-700: #4f8a61;
+    --leaf-900: #7fae8a;
+    --ink-900: #ece4d3;
+    --paper: #1b241d;
+    --danger: #e08074;
+    --success: #6fbf94;
+    --ring: rgba(127, 174, 138, 0.35);
+    --glass-bg: rgba(38, 48, 40, 0.72);
+    --glass-border: rgba(236, 228, 211, 0.12);
+    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  }
+}
+
 * {
   box-sizing: border-box;
 }
@@ -62,28 +100,24 @@ a {
   position: relative;
 }
 
+/* El degradado y el borde salen de variables (no de un blanco fijo) para que el
+   panel siga al tema: en oscuro era un rectángulo casi blanco que dejaba el
+   texto crema encima ilegible (#363). */
 .glass-panel {
-  background: linear-gradient(135deg, 
-    rgba(255, 255, 255, 0.75) 0%, 
-    rgba(255, 255, 255, 0.55) 100%);
+  background: var(--glass-bg);
+  color: var(--ink-900);
   backdrop-filter: blur(16px) saturate(180%);
   -webkit-backdrop-filter: blur(16px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--glass-border);
   border-radius: 20px;
   padding: clamp(1.5rem, 3vw, 2.5rem);
-  box-shadow: 
-    0 8px 32px rgba(11, 95, 55, 0.1),
-    0 2px 8px rgba(0, 0, 0, 0.04),
-    inset 0 1px 1px rgba(255, 255, 255, 0.8);
+  box-shadow: var(--glass-shadow);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .glass-panel:hover {
   transform: translateY(-2px);
-  box-shadow: 
-    0 12px 40px rgba(11, 95, 55, 0.15),
-    0 4px 12px rgba(0, 0, 0, 0.06),
-    inset 0 1px 1px rgba(255, 255, 255, 0.9);
+  box-shadow: var(--glass-shadow), 0 4px 12px rgba(0, 0, 0, 0.06);
 }
 
 .glass-card {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -31,5 +31,9 @@
       "@terrashare/shared": ["../../packages/shared/src/index.ts"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  /* Los unitarios corren con el runner de Bun (`bun run test:unit`), que trae
+     sus propios tipos. `tsc` no los conoce y no vale la pena añadir una
+     dependencia de tipos solo para eso. */
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
> **Apilado sobre #364.** Mientras ese no se mergee, el diff de aquí incluye también sus commits. Mergea #364 primero.

Hallazgos del recorrido de pantallas con datos reales del seed.

## El catálogo ocultaba 12 terrenos sin avisar

`CatalogPage` llamaba a `listLands()` sin `pageSize`, así que recibía la página por defecto del backend (20). Pero filtra, ordena y pinta el mapa **en el cliente**, y no tiene paginador: con 32 terrenos activos, 12 eran sencillamente inalcanzables desde la interfaz. Ahora pide 100, que es el máximo de la ruta.

Es un techo, no una solución: por encima de esa escala hay que mover los filtros al servidor y paginar de verdad. Queda como #366, con el comentario correspondiente en el código.

## «$0/mes» en todas las superficies

Cinco pantallas resolvían el precio por su cuenta y las cinco cometían el mismo error: comprobar `typeof pricePerMonth === "number"`, que es **cierto para `0`**. Un terreno de solo venta no tiene renta y lleva 0, así que catálogo, home, comparador, detalle, «Mis terrenos» y el popup del mapa anunciaban «$0/mes» en lugar del precio de venta. El filtro de precio, además, los contaba como 0 y los colaba en todos los tramos «hasta $X».

El formato pasa a `lib/land-price` (10 tests), y de paso el terreno de operación «ambas» muestra ahora sus dos precios en vez de solo la renta.

## «Reseñas recibidas» no podía funcionar

`ContractDetailPage` pedía `getReviewsByUser(contraparte, contrato)` — las reseñas **recibidas por la otra parte**, que por definición son las que envié yo — y luego renderizaba ese mismo array filtrando `senderId !== yo`. La intersección es vacía siempre, hubiera o no una reseña sobre mí. Ahora se consultan las dos caras.

## Dos cosas más

- El filtro «Alquiler / Venta» seguía pintado como «Pronto», con un `TODO(#140)` que decía que el backend no tenía el tipo de operación. Lo tiene desde #249. Ahora es un `select` real, y «ambas» cuenta para las dos caras.
- `VisitModal` y `ReviewModal` no fijaban color en sus campos, así que salían cajas blancas dentro de un modal oscuro. `ReviewModal` usaba además bordes `rgba(255,255,255,0.15)` fijos (ilegibles en tema claro) y `var(--leaf-600)`, otra variable inexistente que caía a un esmeralda ajeno a la marca. Los estilos se comparten ahora en `components/modal-styles.ts`.
- El seed ponía distritos en el campo `corregimiento` («corregimiento: David» dentro de Boquete). Se omite: mejor no mostrar el dato que mostrarlo mal.

## Verificación

- Web: `typecheck` y `build` limpios. Nuevo `bun run test:unit` (runner de Bun, sin dependencias nuevas): **10 pass**. Playwright `--project=chromium`: **41 passed**.
- Backend: **381 pass / 0 fail**, `typecheck` limpio.
- En el navegador, con sesión real: el catálogo pasa de «20 terrenos» a «32 terrenos» y de un «$0/mes» a **cero**; el filtro de operación deja 14 terrenos en venta con sus precios correctos; el contrato `contract_d12` muestra por fin la reseña que recibió; el modal de visita abre sobre `rgb(30,38,33)` en vez del azul marino, y el PDF del contrato descarga 1.716 bytes con firma `%PDF-`.

Closes #365
