### PR TITLE
feat(web): pantalla y guardado de búsquedas (HU-99) (#368)

### DIFF
--- a/apps/backend-api/src/db/seed-demo.ts
+++ b/apps/backend-api/src/db/seed-demo.ts
@@ -812,10 +812,14 @@ export function buildDemoData(): Built {
   );
 
   // ── Búsquedas guardadas de la cuenta principal ─────────────────────────────
+  // Las claves son las que entienden el emparejador (`lib/match-saved-searches`)
+  // y la interfaz (`web/src/lib/catalog-filters`): province, district, use,
+  // operation, q, priceMin y priceMax. Sembrar otras (`maxPrice`, `maxSalePrice`)
+  // deja búsquedas que ni avisan ni se pueden reaplicar desde el catálogo.
   const savedSearches = [
     {
       id: "search_001", userId: ME, name: "Ganadería en Coclé hasta $1.500",
-      filters: { province: "Coclé", use: "ganaderia", maxPrice: 1500, operation: "alquiler" },
+      filters: { province: "Coclé", use: "ganaderia", priceMax: 1500, operation: "alquiler" },
       createdAt: daysAgo(28), updatedAt: daysAgo(28),
     },
     {
@@ -824,8 +828,8 @@ export function buildDemoData(): Built {
       createdAt: daysAgo(14), updatedAt: daysAgo(14),
     },
     {
-      id: "search_003", userId: ME, name: "Lotes en venta bajo $150.000",
-      filters: { operation: "venta", maxSalePrice: 150000 },
+      id: "search_003", userId: ME, name: "Terrenos en venta",
+      filters: { operation: "venta" },
       createdAt: daysAgo(4), updatedAt: daysAgo(4),
     },
     {

--- a/apps/backend-api/src/lib/match-saved-searches.test.ts
+++ b/apps/backend-api/src/lib/match-saved-searches.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+
+import { matchesFilters } from "./match-saved-searches";
+import type { ILand } from "../db/schemas";
+
+/**
+ * El emparejador decide qué alertas recibe el usuario (HU-99). Lo que se prueba
+ * aquí sobre todo es que cubra **los mismos campos que el catálogo deja
+ * guardar** (#368): un filtro que la interfaz permite fijar pero el emparejador
+ * ignora produce avisos que incumplen los criterios del propio usuario.
+ */
+
+const land = (over: Partial<ILand> = {}): ILand =>
+  ({
+    id: "land_test",
+    ownerId: "owner_1",
+    title: "Finca Los Naranjos",
+    description: "Hacienda cafetalera con beneficio húmedo",
+    area: 22,
+    allowedUses: ["agricultura"],
+    location: { province: "Chiriquí", district: "Boquete" },
+    availability: {},
+    priceRule: { currency: "USD", pricePerMonth: 2100 },
+    status: "active",
+    operation: "alquiler",
+    ...over,
+  }) as unknown as ILand;
+
+describe("matchesFilters — ubicación y uso", () => {
+  it("acepta un terreno que cumple provincia, distrito y uso", () => {
+    expect(matchesFilters(land(), { province: "Chiriquí", district: "Boquete", use: "agricultura" })).toBe(true);
+  });
+
+  it("descarta otra provincia", () => {
+    expect(matchesFilters(land(), { province: "Coclé" })).toBe(false);
+  });
+
+  it("descarta otro distrito", () => {
+    expect(matchesFilters(land(), { district: "David" })).toBe(false);
+  });
+
+  it("descarta un uso que el terreno no admite", () => {
+    expect(matchesFilters(land(), { use: "ganaderia" })).toBe(false);
+  });
+
+  it("un filtro vacío acepta cualquier terreno", () => {
+    expect(matchesFilters(land(), {})).toBe(true);
+  });
+});
+
+describe("matchesFilters — tipo de operación", () => {
+  it("descarta un alquiler cuando se busca comprar", () => {
+    expect(matchesFilters(land({ operation: "alquiler" } as Partial<ILand>), { operation: "venta" })).toBe(false);
+  });
+
+  it("acepta un terreno de «ambas» tanto para alquiler como para venta", () => {
+    const both = land({ operation: "ambas" } as Partial<ILand>);
+    expect(matchesFilters(both, { operation: "alquiler" })).toBe(true);
+    expect(matchesFilters(both, { operation: "venta" })).toBe(true);
+  });
+
+  it("«todas» no descarta nada", () => {
+    expect(matchesFilters(land({ operation: "venta" } as Partial<ILand>), { operation: "todas" })).toBe(true);
+  });
+});
+
+describe("matchesFilters — texto libre", () => {
+  it("encuentra el término en el título sin distinguir mayúsculas", () => {
+    expect(matchesFilters(land(), { q: "naranjos" })).toBe(true);
+  });
+
+  it("encuentra el término en la descripción", () => {
+    expect(matchesFilters(land(), { q: "cafetalera" })).toBe(true);
+  });
+
+  it("ignora los acentos en los dos sentidos", () => {
+    expect(matchesFilters(land(), { q: "chiriqui" })).toBe(true);
+    expect(matchesFilters(land({ title: "Finca Boqueté" }), { q: "boquete" })).toBe(true);
+  });
+
+  it("descarta un término que no aparece", () => {
+    expect(matchesFilters(land(), { q: "acuicultura" })).toBe(false);
+  });
+
+  it("un texto en blanco no filtra", () => {
+    expect(matchesFilters(land(), { q: "   " })).toBe(true);
+  });
+});
+
+describe("matchesFilters — precio", () => {
+  it("acepta dentro del tramo", () => {
+    expect(matchesFilters(land(), { priceMin: 1000, priceMax: 3000 })).toBe(true);
+  });
+
+  it("descarta por encima del máximo", () => {
+    expect(matchesFilters(land(), { priceMax: 1500 })).toBe(false);
+  });
+
+  it("descarta por debajo del mínimo", () => {
+    expect(matchesFilters(land(), { priceMin: 2500 })).toBe(false);
+  });
+
+  it("un terreno de solo venta no cuela en un tramo «hasta $X»", () => {
+    // Lleva `pricePerMonth: 0`, que antes pasaba cualquier máximo.
+    const forSale = land({ operation: "venta", priceRule: { currency: "USD", pricePerMonth: 0 } } as Partial<ILand>);
+    expect(matchesFilters(forSale, { priceMax: 500 })).toBe(false);
+  });
+
+  it("sin filtro de precio, el terreno de venta sí entra", () => {
+    const forSale = land({ operation: "venta", priceRule: { currency: "USD", pricePerMonth: 0 } } as Partial<ILand>);
+    expect(matchesFilters(forSale, { operation: "venta" })).toBe(true);
+  });
+});
+
+describe("matchesFilters — combinaciones", () => {
+  it("exige que se cumplan todos los criterios a la vez", () => {
+    const filters = { province: "Chiriquí", use: "agricultura", operation: "alquiler", priceMax: 2500, q: "naranjos" };
+    expect(matchesFilters(land(), filters)).toBe(true);
+    // Basta con que uno falle.
+    expect(matchesFilters(land(), { ...filters, priceMax: 1000 })).toBe(false);
+    expect(matchesFilters(land(), { ...filters, q: "estanques" })).toBe(false);
+  });
+});

--- a/apps/backend-api/src/lib/match-saved-searches.ts
+++ b/apps/backend-api/src/lib/match-saved-searches.ts
@@ -2,17 +2,55 @@ import { SavedSearch, Notification, User } from "../db/schemas";
 import type { ILand, LandUse } from "../db/schemas";
 import { sendEmail } from "./email";
 
-function matchesFilters(land: ILand, filters: Record<string, unknown>): boolean {
+/**
+ * ¿Un terreno recién publicado cumple los criterios de una búsqueda guardada?
+ *
+ * Debe cubrir **los mismos campos que el catálogo deja guardar** (#368). Si el
+ * emparejador ignora un filtro que la interfaz permite fijar, el usuario recibe
+ * alertas que incumplen los criterios que él mismo puso, que es peor que no
+ * recibir ninguna.
+ *
+ * Exportada para poder probarla sin tocar la base ni el correo.
+ */
+export function matchesFilters(land: ILand, filters: Record<string, unknown>): boolean {
   if (filters.province && land.location?.province !== filters.province) return false;
   if (filters.district && land.location?.district !== filters.district) return false;
   if (filters.use && land.allowedUses && !land.allowedUses.includes(filters.use as LandUse)) return false;
-  if (typeof filters.priceMin === "number" && land.priceRule?.pricePerMonth != null) {
-    if (land.priceRule.pricePerMonth < filters.priceMin) return false;
+
+  // Tipo de operación: «ambas» satisface tanto a quien busca alquiler como a
+  // quien busca compra, igual que en el filtro del catálogo.
+  if (filters.operation && filters.operation !== "todas") {
+    if (land.operation !== filters.operation && land.operation !== "ambas") return false;
   }
-  if (typeof filters.priceMax === "number" && land.priceRule?.pricePerMonth != null) {
-    if (land.priceRule.pricePerMonth > filters.priceMax) return false;
+
+  // Texto libre sobre título, descripción y ubicación, sin distinguir mayúsculas
+  // ni acentos (quien guarda «boquete» espera que «Boquete» cuente).
+  if (typeof filters.q === "string" && filters.q.trim()) {
+    const haystack = normalize(
+      [land.title, land.description, land.location?.province, land.location?.district]
+        .filter(Boolean)
+        .join(" "),
+    );
+    if (!haystack.includes(normalize(filters.q))) return false;
   }
+
+  // El precio solo se compara contra terrenos que efectivamente se alquilan: uno
+  // de solo venta lleva `pricePerMonth: 0` y colaría en cualquier tramo «hasta
+  // $X» (mismo fallo que se corrigió en la interfaz en #365).
+  const monthly = land.operation === "venta" ? null : land.priceRule?.pricePerMonth ?? null;
+  if (typeof filters.priceMin === "number" && monthly != null) {
+    if (monthly < filters.priceMin) return false;
+  }
+  if (typeof filters.priceMax === "number") {
+    if (monthly == null || monthly > filters.priceMax) return false;
+  }
+
   return true;
+}
+
+/** Minúsculas y sin diacríticos, para comparar texto escrito por personas. */
+function normalize(value: string): string {
+  return value.toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "");
 }
 
 /**
@@ -36,8 +74,8 @@ export async function matchSavedSearches(newLand: ILand): Promise<void> {
         id: `ntf_${crypto.randomUUID()}`,
         userId: search.userId,
         type: "saved_search_match",
-        title: "Nuevo terreno coincide con tu busqueda",
-        body: `El terreno "${newLand.title}" coincide con tu busqueda guardada "${search.name}".`,
+        title: "Nuevo terreno coincide con tu búsqueda",
+        body: `El terreno "${newLand.title}" coincide con tu búsqueda guardada "${search.name}".`,
         read: false,
       });
 
@@ -47,7 +85,7 @@ export async function matchSavedSearches(newLand: ILand): Promise<void> {
         await sendEmail({
           to: user.email,
           subject: `Nuevo terreno: ${newLand.title}`,
-          html: `<p>El terreno <strong>${newLand.title}</strong> coincide con tu busqueda guardada "<em>${search.name}</em>".</p>`,
+          html: `<p>El terreno <strong>${newLand.title}</strong> coincide con tu búsqueda guardada «<em>${search.name}</em>».</p>`,
         });
       }
     } catch (err) {

--- a/apps/web/src/components/SaveSearchModal.tsx
+++ b/apps/web/src/components/SaveSearchModal.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import { BookmarkPlus } from "lucide-react";
+
+import { FIELD_STYLE, BUTTON_STYLE, PRIMARY_BUTTON_STYLE } from "./modal-styles";
+
+interface SaveSearchModalProps {
+  /** Resumen legible de los filtros que se van a guardar. */
+  summary: string;
+  /** Nombre sugerido, derivado de los propios filtros. */
+  suggestedName: string;
+  onSubmit: (name: string) => Promise<void>;
+  onClose: () => void;
+}
+
+/**
+ * Pone nombre a la búsqueda antes de guardarla (HU-99 / #368).
+ *
+ * Muestra el resumen de lo que se guarda porque, una vez creada, la búsqueda
+ * genera avisos por correo: conviene que el usuario vea con qué criterios se
+ * está suscribiendo, no solo que ponga un nombre a ciegas.
+ */
+export default function SaveSearchModal({ summary, suggestedName, onSubmit, onClose }: SaveSearchModalProps) {
+  const [name, setName] = useState(suggestedName);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async () => {
+    if (!name.trim()) {
+      setError("Ponle un nombre para reconocerla después");
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    try {
+      await onSubmit(name.trim());
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudo guardar la búsqueda");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, zIndex: 1000,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        background: "rgba(0,0,0,0.5)", backdropFilter: "blur(4px)",
+      }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Guardar búsqueda"
+        style={{
+          background: "var(--ts-surface)",
+          color: "var(--ts-text)",
+          border: "1px solid var(--ts-border)",
+          borderRadius: "12px", padding: "2rem",
+          maxWidth: "460px", width: "90%",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.3)",
+        }}
+      >
+        <h2 style={{ margin: "0 0 0.5rem", fontSize: "1.25rem" }}>Guardar búsqueda</h2>
+        <p style={{ margin: "0 0 1.25rem", fontSize: "0.85rem", opacity: 0.75, lineHeight: 1.5 }}>
+          Te avisaremos por correo cuando se publique un terreno que encaje.
+        </p>
+
+        <p
+          style={{
+            margin: "0 0 1.25rem", padding: "0.75rem",
+            borderRadius: "8px", background: "var(--ts-bg)",
+            border: "1px solid var(--ts-border)",
+            fontSize: "0.85rem", lineHeight: 1.5,
+          }}
+        >
+          <strong style={{ display: "block", marginBottom: "0.25rem" }}>Criterios</strong>
+          {summary}
+        </p>
+
+        <label style={{ fontSize: "0.85rem" }}>
+          Nombre
+          <input
+            type="text"
+            value={name}
+            maxLength={60}
+            autoFocus
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSubmit();
+            }}
+            style={FIELD_STYLE}
+          />
+        </label>
+
+        {error && (
+          <p style={{ color: "var(--ts-clay)", fontSize: "0.85rem", margin: "0.75rem 0 0" }}>{error}</p>
+        )}
+
+        <div style={{ display: "flex", gap: "0.75rem", justifyContent: "flex-end", marginTop: "1.5rem" }}>
+          <button type="button" onClick={onClose} style={BUTTON_STYLE}>
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !name.trim()}
+            style={{
+              ...PRIMARY_BUTTON_STYLE,
+              cursor: submitting ? "default" : "pointer",
+              opacity: submitting || !name.trim() ? 0.6 : 1,
+            }}
+          >
+            <BookmarkPlus size={16} />
+            {submitting ? "Guardando…" : "Guardar búsqueda"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/UserDashboardLayout.tsx
+++ b/apps/web/src/components/UserDashboardLayout.tsx
@@ -37,6 +37,7 @@ export default function UserDashboardLayout({ children, onSignOut }: UserDashboa
     { label: "Mis terrenos", onClick: () => navigate({ to: "/dashboard/lands" }) },
     { label: "Contratos", onClick: () => navigate({ to: "/dashboard/contracts" }) },
     { label: "Visitas", onClick: () => navigate({ to: "/dashboard/visits" }) },
+    { label: "Búsquedas guardadas", onClick: () => navigate({ to: "/dashboard/searches" }) },
     { label: "Pagos", onClick: () => navigate({ to: "/dashboard/payments" }) },
     { label: "Privacidad", onClick: () => navigate({ to: "/dashboard/privacy" }) },
   ];

--- a/apps/web/src/lib/catalog-filters.test.ts
+++ b/apps/web/src/lib/catalog-filters.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  ANY_OPERATION,
+  ANY_PROVINCE,
+  ANY_USE,
+  EMPTY_FILTERS,
+  NO_PRICE_LIMIT,
+  describeFilters,
+  filtersToParams,
+  hasAnyFilter,
+  paramsToFilters,
+  suggestName,
+} from "./catalog-filters";
+
+/**
+ * Estas claves son el contrato entre el catálogo, las búsquedas guardadas y el
+ * emparejador del backend (#368): si cambian de nombre o de forma, las alertas
+ * dejan de corresponderse con lo que el usuario guardó.
+ */
+
+describe("filtersToParams", () => {
+  it("omite los criterios sin filtrar, para no mandar centinelas al backend", () => {
+    expect(filtersToParams(EMPTY_FILTERS)).toEqual({});
+  });
+
+  it("incluye solo lo que está activo", () => {
+    expect(
+      filtersToParams({ q: "  boquete  ", use: "agricultura", province: ANY_PROVINCE, operation: "venta", maxPrice: 1500 }),
+    ).toEqual({ q: "boquete", use: "agricultura", operation: "venta", priceMax: 1500 });
+  });
+
+  it("el precio sale como número, que es lo que exige el emparejador del backend", () => {
+    // Con un texto, `typeof filters.priceMax === "number"` falla en el servidor
+    // y la alerta deja de filtrar por precio sin avisar.
+    expect(typeof filtersToParams({ ...EMPTY_FILTERS, maxPrice: 1500 }).priceMax).toBe("number");
+  });
+
+  it("el tope del desplegable no se guarda como filtro de precio", () => {
+    expect(filtersToParams({ ...EMPTY_FILTERS, maxPrice: NO_PRICE_LIMIT }).priceMax).toBeUndefined();
+  });
+});
+
+describe("paramsToFilters", () => {
+  it("sin parámetros devuelve los filtros vacíos", () => {
+    expect(paramsToFilters(undefined)).toEqual(EMPTY_FILTERS);
+    expect(paramsToFilters({})).toEqual(EMPTY_FILTERS);
+  });
+
+  it("acepta priceMax como número o como texto", () => {
+    expect(paramsToFilters({ priceMax: 900 }).maxPrice).toBe(900);
+    expect(paramsToFilters({ priceMax: "900" }).maxPrice).toBe(900);
+  });
+
+  it("un priceMax ilegible no rompe: cae al tope", () => {
+    expect(paramsToFilters({ priceMax: "mucho" }).maxPrice).toBe(NO_PRICE_LIMIT);
+  });
+
+  it("ida y vuelta conserva los criterios", () => {
+    const original = { q: "café", use: "agricultura", province: "Chiriquí", operation: "alquiler", maxPrice: 2000 };
+    expect(paramsToFilters(filtersToParams(original))).toEqual(original);
+  });
+});
+
+describe("hasAnyFilter", () => {
+  it("es falso sin ningún criterio", () => {
+    expect(hasAnyFilter(EMPTY_FILTERS)).toBe(false);
+    expect(hasAnyFilter({ ...EMPTY_FILTERS, q: "   " })).toBe(false);
+  });
+
+  it("es cierto en cuanto hay uno", () => {
+    expect(hasAnyFilter({ ...EMPTY_FILTERS, province: "Coclé" })).toBe(true);
+    expect(hasAnyFilter({ ...EMPTY_FILTERS, maxPrice: 500 })).toBe(true);
+    expect(hasAnyFilter({ ...EMPTY_FILTERS, q: "río" })).toBe(true);
+  });
+});
+
+describe("describeFilters", () => {
+  it("resume los criterios activos en orden legible", () => {
+    expect(
+      describeFilters({ operation: "alquiler", use: "ganaderia", province: "Coclé", priceMax: "1500" }),
+    ).toBe("En alquiler · Ganadería · Coclé · hasta $1,500/mes");
+  });
+
+  it("entrecomilla el texto libre", () => {
+    expect(describeFilters({ q: "boquete" })).toBe("«boquete»");
+  });
+
+  it("sin criterios lo dice explícitamente", () => {
+    expect(describeFilters({})).toBe("Cualquier terreno");
+  });
+});
+
+describe("suggestName", () => {
+  it("propone el resumen como nombre", () => {
+    expect(suggestName({ ...EMPTY_FILTERS, province: "Chiriquí", use: "agricultura" }))
+      .toBe("Agricultura · Chiriquí");
+  });
+
+  it("sin criterios propone algo con sentido en vez de «Cualquier terreno»", () => {
+    expect(suggestName(EMPTY_FILTERS)).toBe("Todos los terrenos");
+  });
+
+  it("respeta los valores centinela de los desplegables", () => {
+    expect(suggestName({ q: "", use: ANY_USE, province: ANY_PROVINCE, operation: ANY_OPERATION, maxPrice: NO_PRICE_LIMIT }))
+      .toBe("Todos los terrenos");
+  });
+});

--- a/apps/web/src/lib/catalog-filters.ts
+++ b/apps/web/src/lib/catalog-filters.ts
@@ -1,0 +1,123 @@
+/**
+ * Filtros del catálogo: forma común, ida y vuelta a la URL, y resumen legible
+ * (HU-99 / #368).
+ *
+ * Vive aparte porque tres sitios necesitan hablar el mismo idioma: el catálogo
+ * (que los aplica), el guardado de búsquedas (que los persiste) y la pantalla
+ * de búsquedas guardadas (que los resume y los vuelve a aplicar). El backend
+ * emparejador (`lib/match-saved-searches.ts`) lee estas mismas claves, así que
+ * renombrar una aquí obliga a tocarlo también.
+ */
+
+/** Valor que representa «sin filtrar» en los desplegables. */
+export const ANY_USE = "todos";
+export const ANY_PROVINCE = "todas";
+export const ANY_OPERATION = "todas";
+/** Tope del desplegable de precio; por encima se considera «sin filtrar». */
+export const NO_PRICE_LIMIT = 1_000_000;
+
+export interface CatalogFilterState {
+  q: string;
+  use: string;
+  province: string;
+  operation: string;
+  maxPrice: number;
+}
+
+export const EMPTY_FILTERS: CatalogFilterState = {
+  q: "",
+  use: ANY_USE,
+  province: ANY_PROVINCE,
+  operation: ANY_OPERATION,
+  maxPrice: NO_PRICE_LIMIT,
+};
+
+const USE_LABELS: Record<string, string> = {
+  agricultura: "Agricultura",
+  ganaderia: "Ganadería",
+  forestal: "Forestal",
+  acuicultura: "Acuicultura",
+  mixto: "Uso mixto",
+  otro: "Otro",
+};
+
+const OPERATION_LABELS: Record<string, string> = {
+  alquiler: "En alquiler",
+  venta: "En venta",
+};
+
+/** ¿Hay algo que guardar? Una búsqueda sin criterios no merece una alerta. */
+export function hasAnyFilter(f: CatalogFilterState): boolean {
+  return (
+    f.q.trim() !== ""
+    || f.use !== ANY_USE
+    || f.province !== ANY_PROVINCE
+    || f.operation !== ANY_OPERATION
+    || f.maxPrice < NO_PRICE_LIMIT
+  );
+}
+
+/**
+ * Filtros → objeto plano para guardar y para la URL. Solo se incluyen los
+ * criterios activos: así el emparejador del backend no recibe claves con
+ * valores centinela («todas») que tendría que aprender a ignorar.
+ */
+export function filtersToParams(f: CatalogFilterState): Record<string, string | number> {
+  const params: Record<string, string | number> = {};
+  if (f.q.trim()) params.q = f.q.trim();
+  if (f.use !== ANY_USE) params.use = f.use;
+  if (f.province !== ANY_PROVINCE) params.province = f.province;
+  if (f.operation !== ANY_OPERATION) params.operation = f.operation;
+  // Número, no texto: el emparejador del backend comprueba
+  // `typeof filters.priceMax === "number"` y descartaría un "1500" en silencio,
+  // así que las alertas nunca filtrarían por precio. Además, serializado como
+  // texto el router lo mete entrecomillado en la URL (`priceMax=%221500%22`) y
+  // al volver a leerlo `Number('"1500"')` es NaN.
+  if (f.maxPrice < NO_PRICE_LIMIT) params.priceMax = f.maxPrice;
+  return params;
+}
+
+/** Objeto plano (de la URL o de una búsqueda guardada) → filtros del catálogo. */
+export function paramsToFilters(params: Record<string, unknown> | undefined): CatalogFilterState {
+  if (!params) return { ...EMPTY_FILTERS };
+
+  const str = (key: string): string | undefined => {
+    const value = params[key];
+    return typeof value === "string" && value.trim() ? value : undefined;
+  };
+
+  const rawMax = params.priceMax;
+  const maxPrice = typeof rawMax === "number"
+    ? rawMax
+    : typeof rawMax === "string" && rawMax.trim() && Number.isFinite(Number(rawMax))
+      ? Number(rawMax)
+      : NO_PRICE_LIMIT;
+
+  return {
+    q: str("q") ?? "",
+    use: str("use") ?? ANY_USE,
+    province: str("province") ?? ANY_PROVINCE,
+    operation: str("operation") ?? ANY_OPERATION,
+    maxPrice,
+  };
+}
+
+/** Resumen en una línea, para las tarjetas de búsquedas guardadas. */
+export function describeFilters(params: Record<string, unknown> | undefined): string {
+  const f = paramsToFilters(params);
+  const parts: string[] = [];
+
+  if (f.operation !== ANY_OPERATION) parts.push(OPERATION_LABELS[f.operation] ?? f.operation);
+  if (f.use !== ANY_USE) parts.push(USE_LABELS[f.use] ?? f.use);
+  if (f.province !== ANY_PROVINCE) parts.push(f.province);
+  if (f.maxPrice < NO_PRICE_LIMIT) parts.push(`hasta $${f.maxPrice.toLocaleString("es-PA")}/mes`);
+  if (f.q) parts.push(`«${f.q}»`);
+
+  return parts.length > 0 ? parts.join(" · ") : "Cualquier terreno";
+}
+
+/** Nombre sugerido al guardar, para no obligar a inventarlo desde cero. */
+export function suggestName(f: CatalogFilterState): string {
+  const summary = describeFilters(filtersToParams(f));
+  return summary === "Cualquier terreno" ? "Todos los terrenos" : summary;
+}

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import type { LandDto } from "@terrashare/shared";
 import {
   Search,
@@ -13,9 +13,21 @@ import {
   Heart,
   Columns2,
   ArrowRight,
+  Bookmark,
+  BookmarkPlus,
 } from "lucide-react";
 import { listLands, photoSrc } from "../services/api";
 import { formatLandPriceShort, monthlyPrice } from "../lib/land-price";
+import {
+  type CatalogFilterState,
+  filtersToParams,
+  hasAnyFilter,
+  describeFilters,
+  paramsToFilters,
+  suggestName,
+} from "../lib/catalog-filters";
+import { createSavedSearch } from "../services/api";
+import SaveSearchModal from "../components/SaveSearchModal";
 import PanamaMap from "../components/LazyPanamaMap";
 import EmptyState from "../components/EmptyState";
 import { useFavorites } from "../hooks/useFavorites";
@@ -47,8 +59,25 @@ function formatUse(use?: string): string {
   return USE_LABELS[use] ?? use;
 }
 
+/**
+ * Opciones del desplegable de precio, añadiendo el valor activo si no está
+ * entre las predefinidas.
+ *
+ * Una búsqueda guardada puede traer cualquier tope (p. ej. $1.500). Sin esto,
+ * el `select` no encuentra su valor, se queda mostrando «Precio» y el usuario
+ * ve un filtro aplicado que la interfaz niega estar aplicando.
+ */
+function priceOptionsWith(active: number) {
+  if (active >= 1_000_000 || PRICE_OPTIONS.some((o) => o.value === active)) {
+    return PRICE_OPTIONS;
+  }
+  return [...PRICE_OPTIONS, { label: `Hasta $${active.toLocaleString("es-PA")}`, value: active }]
+    .sort((a, b) => a.value - b.value);
+}
+
 export default function CatalogPage() {
   const navigate = useNavigate();
+  const search = useSearch({ strict: false });
 
   const [lands, setLands] = useState<LandDto[]>([]);
   const [status, setStatus] = useState<LoadState>("loading");
@@ -66,13 +95,24 @@ export default function CatalogPage() {
   } = useCompareLands();
   const [compareToast, setCompareToast] = useState<string | null>(null);
 
-  const [query, setQuery] = useState("");
-  const [use, setUse] = useState("todos");
-  const [province, setProvince] = useState("todas");
-  const [maxPrice, setMaxPrice] = useState(1_000_000);
+  // Los filtros pueden venir en la URL: así una búsqueda guardada se «aplica»
+  // navegando aquí, y de paso el catálogo filtrado es un enlace compartible
+  // (HU-99 / #368).
+  const initialFilters = paramsToFilters(search as Record<string, unknown>);
+
+  const [query, setQuery] = useState(initialFilters.q);
+  const [use, setUse] = useState(initialFilters.use);
+  const [province, setProvince] = useState(initialFilters.province);
+  const [maxPrice, setMaxPrice] = useState(initialFilters.maxPrice);
   // Tipo de operación (#365). El campo `operation` existe en el backend desde
   // #249; el filtro llevaba desde entonces pintado como «Pronto».
-  const [operation, setOperation] = useState("todas");
+  const [operation, setOperation] = useState(initialFilters.operation);
+
+  // Guardar búsqueda (HU-99 / #368).
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [saveFeedback, setSaveFeedback] = useState("");
+
+  const currentFilters: CatalogFilterState = { q: query, use, province, operation, maxPrice };
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -209,7 +249,7 @@ export default function CatalogPage() {
             onChange={(e) => setMaxPrice(Number(e.target.value))}
             aria-label="Filtrar por precio"
           >
-            {PRICE_OPTIONS.map((opt) => (
+            {priceOptionsWith(maxPrice).map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
@@ -237,7 +277,37 @@ export default function CatalogPage() {
             <ChevronDown size={14} />
           </span>
         </label>
+
+        {/* Guardar la búsqueda actual (HU-99 / #368). Sin criterios no tiene
+            sentido: una alerta «de cualquier terreno» sería solo ruido. */}
+        <button
+          type="button"
+          className="cat-pill cat-pill--action"
+          onClick={() => { setSaveFeedback(""); setSaveOpen(true); }}
+          disabled={!hasAnyFilter(currentFilters)}
+          title={
+            hasAnyFilter(currentFilters)
+              ? "Guardar esta búsqueda y recibir avisos"
+              : "Elige algún filtro para poder guardar la búsqueda"
+          }
+        >
+          <span className="cat-pill__icon">
+            <BookmarkPlus size={15} />
+          </span>
+          Guardar búsqueda
+        </button>
+
+        <Link to="/dashboard/searches" className="cat-pill cat-pill--action">
+          <span className="cat-pill__icon">
+            <Bookmark size={15} />
+          </span>
+          Mis búsquedas
+        </Link>
       </div>
+
+      {saveFeedback && (
+        <p className="cat-savefeedback" role="status">{saveFeedback}</p>
+      )}
 
       {/* lista + mapa */}
       <div className="cat-body">
@@ -427,6 +497,18 @@ export default function CatalogPage() {
         <div className="cmp-toast" role="status">
           {compareToast}
         </div>
+      )}
+
+      {saveOpen && (
+        <SaveSearchModal
+          summary={describeFilters(filtersToParams(currentFilters))}
+          suggestedName={suggestName(currentFilters)}
+          onClose={() => setSaveOpen(false)}
+          onSubmit={async (name) => {
+            await createSavedSearch({ name, filters: filtersToParams(currentFilters) });
+            setSaveFeedback(`Búsqueda «${name}» guardada. Te avisaremos de los terrenos que encajen.`);
+          }}
+        />
       )}
     </div>
   );

--- a/apps/web/src/pages/SavedSearchesPage.tsx
+++ b/apps/web/src/pages/SavedSearchesPage.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Bookmark, Search, Trash2, Loader2 } from "lucide-react";
+
+import { listSavedSearches, deleteSavedSearch, type SavedSearchDto } from "../services/api";
+import { describeFilters, filtersToParams, paramsToFilters } from "../lib/catalog-filters";
+import EmptyState from "../components/EmptyState";
+import "./searches.css";
+
+type LoadState = "loading" | "ready" | "error";
+
+function formatDate(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("es-PA", { day: "numeric", month: "long", year: "numeric" });
+}
+
+/**
+ * Búsquedas guardadas (HU-99 / #368).
+ *
+ * El backend y el cliente existían desde #325, pero ninguna pantalla los usaba:
+ * no había forma de crear, ver ni borrar una búsqueda desde la app, así que las
+ * alertas por correo eran inalcanzables en la práctica.
+ */
+export default function SavedSearchesPage() {
+  const [searches, setSearches] = useState<SavedSearchDto[]>([]);
+  const [status, setStatus] = useState<LoadState>("loading");
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    listSavedSearches()
+      .then((data) => {
+        if (!active) return;
+        setSearches(data);
+        setStatus("ready");
+      })
+      .catch(() => active && setStatus("error"));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleDelete = async (id: string, name: string) => {
+    setDeleting(id);
+    setError(null);
+    try {
+      const ok = await deleteSavedSearch(id);
+      if (ok) {
+        setSearches((prev) => prev.filter((s) => s.id !== id));
+      } else {
+        setError(`No se pudo eliminar «${name}».`);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : `No se pudo eliminar «${name}».`);
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  return (
+    <div className="srch">
+      <header className="srch-head">
+        <div>
+          <h1 className="srch-title">Búsquedas guardadas</h1>
+          <p className="srch-sub">
+            Te avisamos por correo cuando se publica un terreno que encaja con tus criterios.
+          </p>
+        </div>
+        <Link to="/catalog" className="srch-cta">
+          <Search size={16} /> Buscar terrenos
+        </Link>
+      </header>
+
+      {error && <div className="srch-error" role="alert">{error}</div>}
+
+      {status === "loading" ? (
+        <div className="srch-state">Cargando tus búsquedas…</div>
+      ) : status === "error" ? (
+        <div className="srch-state srch-state--error">
+          No pudimos cargar tus búsquedas guardadas. Inténtalo de nuevo en un momento.
+        </div>
+      ) : searches.length === 0 ? (
+        <EmptyState
+          icon={Bookmark}
+          title="Todavía no has guardado ninguna búsqueda"
+          description="Filtra el catálogo a tu gusto y pulsa «Guardar búsqueda» para recibir avisos de los terrenos nuevos que encajen."
+          action={{ label: "Ir al catálogo", to: "/catalog" }}
+        />
+      ) : (
+        <ul className="srch-list">
+          {searches.map((s) => (
+            <li key={s.id} className="srch-card">
+              <div className="srch-card__body">
+                <h2 className="srch-card__name">{s.name}</h2>
+                <p className="srch-card__filters">{describeFilters(s.filters)}</p>
+                {formatDate(s.createdAt) && (
+                  <p className="srch-card__date">Guardada el {formatDate(s.createdAt)}</p>
+                )}
+              </div>
+              <div className="srch-card__actions">
+                <Link
+                  to="/catalog"
+                  // Los mismos criterios viajan como parámetros de la URL, así
+                  // que «Aplicar» deja el catálogo tal cual estaba al guardar.
+                  search={filtersToParams(paramsToFilters(s.filters))}
+                  className="srch-apply"
+                >
+                  <Search size={15} /> Aplicar
+                </Link>
+                <button
+                  type="button"
+                  className="srch-delete"
+                  onClick={() => handleDelete(s.id, s.name)}
+                  disabled={deleting === s.id}
+                  aria-label={`Eliminar la búsqueda ${s.name}`}
+                >
+                  {deleting === s.id ? <Loader2 size={15} className="srch-spin" /> : <Trash2 size={15} />}
+                  Eliminar
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -291,3 +291,23 @@
   .cat-card { flex-direction: column; }
   .cat-card__thumb { width: 100%; height: 150px; }
 }
+
+/* Guardar búsqueda (HU-99 / #368) */
+.cat-pill--action {
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.cat-pill--action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cat-savefeedback {
+  margin: 0 0 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: var(--ts-tint-green-2);
+  color: var(--ts-green);
+  font-size: 13.5px;
+}

--- a/apps/web/src/pages/searches.css
+++ b/apps/web/src/pages/searches.css
@@ -1,0 +1,150 @@
+/* Búsquedas guardadas (HU-99 / #368) */
+
+.srch {
+  width: min(920px, 92vw);
+  margin: 0 auto;
+  padding: 32px 0 64px;
+}
+
+.srch-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+
+.srch-title {
+  font-family: var(--ts-font-serif);
+  font-weight: 500;
+  font-size: 34px;
+  letter-spacing: -0.02em;
+  margin: 0 0 6px;
+  color: var(--ts-text);
+}
+
+.srch-sub {
+  margin: 0;
+  color: var(--ts-sage-2);
+  font-size: 15px;
+  max-width: 56ch;
+  line-height: 1.5;
+}
+
+.srch-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: var(--ts-radius-pill);
+  background: var(--ts-green);
+  color: var(--ts-on-green);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.srch-state {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--ts-sage-2);
+  font-size: 14px;
+}
+.srch-state--error { color: var(--ts-clay); }
+
+.srch-error {
+  margin-bottom: 20px;
+  padding: 12px 16px;
+  border-radius: var(--ts-radius);
+  background: var(--ts-clay-tint);
+  color: var(--ts-clay);
+  font-size: 14px;
+}
+
+.srch-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.srch-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  padding: 20px 22px;
+  border-radius: var(--ts-radius-lg);
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+}
+
+.srch-card__body { min-width: 0; flex: 1; }
+
+.srch-card__name {
+  font-family: var(--ts-font-serif);
+  font-size: 19px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  color: var(--ts-text);
+}
+
+.srch-card__filters {
+  margin: 0;
+  color: var(--ts-text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.srch-card__date {
+  margin: 6px 0 0;
+  color: var(--ts-sage-2);
+  font-size: 12.5px;
+}
+
+.srch-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.srch-apply,
+.srch-delete {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 16px;
+  border-radius: var(--ts-radius-pill);
+  font-size: 13.5px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  border: 1px solid var(--ts-border);
+  background: transparent;
+  color: var(--ts-text);
+}
+
+.srch-apply {
+  border-color: var(--ts-green);
+  color: var(--ts-green);
+}
+.srch-apply:hover { background: var(--ts-tint-green-2); }
+
+.srch-delete { color: var(--ts-clay); border-color: var(--ts-clay-tint); }
+.srch-delete:hover:not(:disabled) { background: var(--ts-clay-tint); }
+.srch-delete:disabled { opacity: 0.6; cursor: default; }
+
+@keyframes srchSpin { to { transform: rotate(360deg); } }
+.srch-spin { animation: srchSpin 0.8s linear infinite; }
+
+@media (max-width: 600px) {
+  .srch-card { align-items: stretch; }
+  .srch-card__actions { width: 100%; }
+  .srch-apply, .srch-delete { flex: 1; justify-content: center; }
+}

--- a/apps/web/src/routes/dashboard.searches.tsx
+++ b/apps/web/src/routes/dashboard.searches.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "../components/route-guards";
+import UserDashboardLayout from "../components/UserDashboardLayout";
+import SavedSearchesPage from "../pages/SavedSearchesPage";
+
+export const Route = createFileRoute("/dashboard/searches")({
+  component: () => (
+    <ProtectedRoute><UserDashboardLayout><SavedSearchesPage /></UserDashboardLayout></ProtectedRoute>
+  ),
+});


### PR DESCRIPTION
HU-99 (búsquedas guardadas + alertas) contaba como requisito entregado en `docs/REQUISITOS_FUNCIONALES_30.md`, pero **no existía ninguna interfaz**. Los tres endpoints, el emparejador y las tres funciones del cliente estaban hechos desde #325 y ninguna ruta ni componente los llamaba: no había forma de crear, ver ni borrar una búsqueda, así que las alertas por correo eran inalcanzables en la práctica.

## Qué se añade

- **Guardar desde el catálogo.** Botón que toma los filtros activos y abre un modal con el nombre sugerido y **el resumen de los criterios a la vista** — la búsqueda genera avisos por correo, conviene ver a qué te estás suscribiendo. Deshabilitado sin filtros: una alerta «de cualquier terreno» sería solo ruido.
- **Pantalla `/dashboard/searches`**: lista con el resumen de criterios y la fecha, «Aplicar» y «Eliminar», más su estado vacío. Entrada nueva en el menú de usuario.
- **Filtros en la URL del catálogo.** «Aplicar» navega con los criterios como parámetros, así que el catálogo queda como estaba al guardar; de propina, un catálogo filtrado ya es un enlace compartible.
- **`lib/catalog-filters.ts`**: la forma de los filtros, su ida y vuelta a la URL y su resumen legible, en un solo sitio. Lo comparten el catálogo, el guardado y la pantalla de búsquedas, y sus claves son el contrato con el emparejador del backend.

## Coherencia entre lo que se guarda y lo que avisa

`matchesFilters` entendía provincia, distrito, uso y precio, pero el catálogo filtra además por **tipo de operación** y **texto libre**. Guardar esos dos sin más habría producido alertas que incumplen los criterios que el propio usuario fijó — peor que no recibir ninguna. Se extiende para cubrir lo mismo que se puede guardar («ambas» cuenta para las dos caras; el texto ignora mayúsculas y acentos) y **se le añaden tests, que no tenía ninguno**. De paso, un terreno de solo venta ya no cuela en un tramo «hasta $X» por llevar `pricePerMonth: 0`, el mismo fallo que se corrigió en la interfaz en #365.

## Dos bugs que aparecieron al verificarlo en el navegador

1. **El precio se serializaba como texto.** El emparejador comprueba `typeof filters.priceMax === "number"`, así que una búsqueda creada desde la interfaz **nunca habría filtrado por precio** en las alertas. Además el router lo metía entrecomillado en la URL (`priceMax=%221500%22`) y al releerlo `Number('"1500"')` es `NaN`: al aplicar una búsqueda, el filtro de precio se perdía en silencio.
2. **El desplegable de precio no podía mostrar un tope fuera de su lista.** Una búsqueda con $1.500 aplicaba el filtro, pero el `select` se quedaba en «Precio», negando estar filtrando.

También: el seed guardaba `maxPrice`/`maxSalePrice`, claves que ni el emparejador ni la interfaz entienden, y al texto de la notificación le faltaban las tildes.

## Verificación

- Backend: **400 pass / 0 fail** (381 antes; +19 del nuevo `match-saved-searches.test.ts`). `typecheck` limpio.
- Web: `typecheck` y `build` limpios. `test:unit` **26 pass** (+15 de `catalog-filters.test.ts`). Playwright `--project=chromium`: **41 passed**.
- En el navegador, con sesión real, el ciclo completo: crear una búsqueda desde el catálogo → aparece en la lista → «Aplicar» restaura los cuatro filtros y la URL queda `?use=ganaderia&province=Coclé&operation=alquiler&priceMax=1500` → «Eliminar» la quita sin recargar. Comprobado que se persiste con `priceMax` **numérico**.
- **La alerta de verdad:** publicando un terreno que encaja (ganadería, Coclé, alquiler, $900), saltaron las notificaciones de las **dos** búsquedas que lo cumplen —incluida la creada desde la interfaz— y de ninguna de las otras tres.

Closes #368
