### PR TITLE
fix(admin): el listado de terrenos ocultaba 16 de 36 y su columna «Uso» nunca se llenaba (#370)

### DIFF
--- a/apps/backend-api/src/routes/admin-lands.test.ts
+++ b/apps/backend-api/src/routes/admin-lands.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { requestJson } from "../lib/http-test-utils";
+import { Land } from "../db/schemas";
+
+/**
+ * Contrato del listado de terrenos del panel (#370).
+ *
+ * La tabla del panel tiene una columna «Uso» que se quedó vacía en todas las
+ * filas durante meses porque el endpoint no proyectaba `allowedUses`: la
+ * interfaz pedía un campo que la respuesta nunca traía, y nada lo detectaba.
+ * Estas pruebas fijan la forma de la respuesta y el comportamiento de su
+ * paginación para que no vuelva a desincronizarse en silencio.
+ *
+ * Gotcha de bun:test + mongodb-memory-server: lo que se escribe va en
+ * `beforeEach` y el cuerpo del test solo lee.
+ */
+
+const adminHeaders = { "x-dev-user-id": "user_admin_lands", "x-dev-role": "admin" };
+
+describe("GET /admin/lands — forma de la respuesta", () => {
+  beforeEach(async () => {
+    await Land.create({
+      id: "land_admin_shape",
+      ownerId: "user_owner_shape",
+      title: "Finca de contrato",
+      area: 30,
+      allowedUses: ["ganaderia", "agricultura"],
+      location: { province: "Coclé", district: "Penonomé" },
+      priceRule: { currency: "USD", pricePerMonth: 800 },
+      status: "active",
+      operation: "alquiler",
+    });
+  });
+
+  it("incluye allowedUses, que es lo que pinta la columna «Uso» del panel", async () => {
+    const { response, payload } = await requestJson("/api/v1/admin/lands", { headers: adminHeaders });
+    expect(response.status).toBe(200);
+
+    const item = (payload.data.items as { id: string; allowedUses?: string[] }[])
+      .find((l) => l.id === "land_admin_shape");
+
+    expect(item).toBeDefined();
+    expect(item!.allowedUses).toEqual(["ganaderia", "agricultura"]);
+  });
+
+  it("trae los campos que la tabla necesita para cada fila", async () => {
+    const { payload } = await requestJson("/api/v1/admin/lands", { headers: adminHeaders });
+    const item = (payload.data.items as Record<string, unknown>[])
+      .find((l) => l.id === "land_admin_shape")!;
+
+    for (const field of ["id", "ownerId", "ownerEmail", "title", "status", "allowedUses", "createdAt"]) {
+      expect(`${field}:${field in item}`).toBe(`${field}:true`);
+    }
+  });
+
+  it("declara el total real, no solo lo que cabe en la página", async () => {
+    const { payload } = await requestJson("/api/v1/admin/lands?pageSize=1", { headers: adminHeaders });
+
+    expect((payload.data.items as unknown[]).length).toBe(1);
+    // Si el panel se fiara solo de `items.length`, diría que hay un terreno.
+    expect(payload.data.total).toBeGreaterThan(1);
+    expect(payload.data.pagination.totalPages).toBeGreaterThan(1);
+  });
+
+  it("admite pedir una página mayor que la de por defecto", async () => {
+    // La pantalla de moderación pide 100 porque no tiene paginador: sin esto,
+    // los terrenos a partir del 21 quedaban fuera de su alcance.
+    const { payload } = await requestJson("/api/v1/admin/lands?pageSize=100", { headers: adminHeaders });
+
+    expect((payload.data.items as unknown[]).length).toBe(payload.data.total);
+  });
+
+  it("no lo puede consultar quien no es admin", async () => {
+    const { response } = await requestJson("/api/v1/admin/lands", {
+      headers: { "x-dev-user-id": "user_plain" },
+    });
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/backend-api/src/routes/admin.ts
+++ b/apps/backend-api/src/routes/admin.ts
@@ -154,6 +154,9 @@ adminRoutes.get("/admin/lands", requireAuth, requireAdmin, async (c) => {
     ownerEmail: ownerMap.get(l.ownerId)?.email ?? l.ownerId,
     title: l.title,
     status: l.status,
+    // La tabla del panel tiene una columna «Uso» que sin esto no podía llenarse
+    // nunca: mostraba «—» en todas las filas (#370).
+    allowedUses: l.allowedUses,
     createdAt: l.createdAt,
   }));
 

--- a/apps/web/src/pages/AdminAuditPage.tsx
+++ b/apps/web/src/pages/AdminAuditPage.tsx
@@ -115,7 +115,7 @@ export default function AdminAuditPage() {
                 <tbody>
                   {pageEvents.map((e) => (
                     <tr key={e.id}>
-                      <td style={{ fontSize: "0.8rem" }}>{new Date(e.createdAt).toLocaleString()}</td>
+                      <td style={{ fontSize: "0.8rem" }}>{new Date(e.createdAt).toLocaleString("es-PA", { dateStyle: "medium", timeStyle: "short" })}</td>
                       <td><span className={`role-badge role-${e.actorRole}`}>{e.actorRole}</span></td>
                       <td>{entityLabels[e.entity] || e.entity}</td>
                       <td>{actionLabels[e.action] || e.action}</td>

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -138,7 +138,7 @@ export default function ContractDetailPage() {
           <div style={{ fontSize: "0.9rem", opacity: 0.75, display: "flex", flexDirection: "column", gap: "0.35rem" }}>
             <p style={{ margin: 0 }}><strong>Solicitud:</strong> {shortId(contract.rentalRequestId)}</p>
             <p style={{ margin: 0 }}><strong>Período:</strong> {contract.terms?.startsAt || "—"} → {contract.terms?.endsAt || "—"}</p>
-            <p style={{ margin: 0 }}><strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString() : "—"}</p>
+            <p style={{ margin: 0 }}><strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString("es-PA", { dateStyle: "medium" }) : "—"}</p>
           </div>
 
           {/* Descargar el contrato en PDF (HU-101 / #327). */}

--- a/apps/web/src/pages/ContractsPage.tsx
+++ b/apps/web/src/pages/ContractsPage.tsx
@@ -144,7 +144,7 @@ export default function ContractsPage() {
                     <strong>Período:</strong> {contract.terms?.startsAt || "—"} → {contract.terms?.endsAt || "—"}
                   </p>
                   <p style={{ margin: "0.25rem 0" }}>
-                    <strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString() : "—"}
+                    <strong>Creado:</strong> {contract.createdAt ? new Date(contract.createdAt).toLocaleDateString("es-PA", { dateStyle: "medium" }) : "—"}
                   </p>
                 </div>
               </div>

--- a/apps/web/src/pages/admin.css
+++ b/apps/web/src/pages/admin.css
@@ -230,7 +230,7 @@
 .adm-badge--amber { color: #9a6b1f; background: #f5e9d0; }
 .adm-badge--red { color: #9a3b2c; background: #f7e0da; }
 .adm-badge--teal { color: #2f6b63; background: #e3ecec; }
-.adm-badge--muted { color: var(--ts-ink-3, #6b6b63); background: var(--ts-tint-2, #ececed); }
+.adm-badge--muted { color: var(--ts-ink-3); background: var(--ts-tint-2); }
 
 /* Spinner para acciones en curso (respaldos #174). */
 @keyframes admSpin { to { transform: rotate(360deg); } }
@@ -363,14 +363,14 @@
   border-radius: 12px;
 }
 .adm-sec__icon.is-on { color: var(--ts-green); background: var(--ts-tint-green-2); }
-.adm-sec__icon.is-off { color: var(--ts-ink-3, #6b6b63); background: var(--ts-tint-2, #ececed); }
+.adm-sec__icon.is-off { color: var(--ts-ink-3); background: var(--ts-tint-2); }
 
 .adm-sec__text { color: var(--ts-sage-2); font-size: 14px; line-height: 1.55; margin: 6px 0 0; }
 .adm-sec__text code {
   font-size: 12.5px;
   padding: 1px 5px;
   border-radius: 5px;
-  background: var(--ts-tint-2, #ececed);
+  background: var(--ts-tint-2);
   color: var(--ts-text);
 }
 

--- a/apps/web/src/services/adminApi.ts
+++ b/apps/web/src/services/adminApi.ts
@@ -101,8 +101,12 @@ export const listAdminLands = (filters: AdminLandFilters = {}) => {
   const params = new URLSearchParams();
   if (filters.status) params.set("status", filters.status);
   if (filters.search) params.set("search", filters.search);
-  const qs = params.toString();
-  return request<LandDto[]>("GET", `/api/v1/admin/lands${qs ? `?${qs}` : ""}`);
+  // La ruta pagina a 20 por defecto y la pantalla no tiene paginador, así que
+  // los terrenos restantes quedaban fuera del alcance del admin — y esta es la
+  // pantalla de moderación (#370). 100 es el máximo que admite la ruta; por
+  // encima de esa escala hace falta paginador de verdad, igual que en #366.
+  params.set("pageSize", "100");
+  return request<LandDto[]>("GET", `/api/v1/admin/lands?${params.toString()}`);
 };
 
 /** PATCH /api/v1/admin/lands/:landId/status — { status: "active"|"inactive"|"rejected" } */

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -36,6 +36,12 @@
   --ts-beige: #ece2cd;
   --ts-beige-2: #e0dbcb;
 
+  /* neutro frío para chips apagados y fragmentos de código (#370). Se usaban en
+     admin.css antes de existir, con un respaldo claro fijo: en tema oscuro eso
+     pintaba una caja casi blanca con el texto crema encima, ilegible. */
+  --ts-tint-2: #ececed;
+  --ts-ink-3: #6b6b63;
+
   /* texto */
   --ts-text: #24312a;          /* principal */
   --ts-text-secondary: #55654f;
@@ -112,6 +118,8 @@
   --ts-border: #33403a;
   --ts-beige: #2a332c;
   --ts-beige-2: #313a33;
+  --ts-tint-2: #2f3a33;
+  --ts-ink-3: #97a998;
 
   /* texto */
   --ts-text: #ece4d3;
@@ -154,6 +162,8 @@
     --ts-border: #33403a;
     --ts-beige: #2a332c;
     --ts-beige-2: #313a33;
+    --ts-tint-2: #2f3a33;
+    --ts-ink-3: #97a998;
 
     --ts-text: #ece4d3;
     --ts-text-secondary: #b7c1b3;


### PR DESCRIPTION
Hallazgos del recorrido del panel de administración con la cuenta admin y datos reales.

## El listado de terrenos ocultaba 16 de 36

`GET /admin/lands` pagina a 20 por defecto y declara `total: 36`, pero la pantalla ni pedía más ni tiene paginador: el pie decía «20 terrenos» y el resto era inalcanzable.

Es el mismo patrón que el catálogo en #365, **pero aquí pesa más: es la pantalla de moderación**. Un terreno reportado que cayera fuera de la primera página no se podía ocultar ni aprobar desde la interfaz. Ahora pide 100, el máximo de la ruta; paginar de verdad sigue pendiente en #366.

## La columna «Uso» no podía llenarse nunca

La tabla pinta `USE_LABELS[land.allowedUses?.[0]]`, pero la respuesta solo proyectaba `id`, `ownerId`, `ownerEmail`, `title`, `status` y `createdAt`. La interfaz pedía un campo que la API jamás enviaba, así que mostraba «—» en las 36 filas y nada lo detectaba.

Se añade `allowedUses` al endpoint y se crea `admin-lands.test.ts`, que fija la forma de la respuesta, el total real frente al de la página y que `pageSize=100` devuelve todo — para que interfaz y API no vuelvan a desincronizarse en silencio.

## Tokens inexistentes, otra vez

`--ts-tint-2` y `--ts-ink-3` se usaban en `admin.css` **sin estar definidos**, con un respaldo claro fijo (`#ececed`). En tema oscuro eso pinta una caja casi blanca con el texto crema encima: los fragmentos `<code>` del panel de seguridad (`403 MFA_REQUIRED`, `/admin/*`) eran ilegibles. Mismo patrón que `--surface` (#363) y `--leaf-600` (#365).

Los defino en ambos temas y quito los respaldos, que son justo lo que hacía que el fallo pasara desapercibido. Uno de los tres usos era preexistente (`.adm-badge--muted`), los otros dos los introduje yo en #362 copiando el patrón.

## Fechas sin idioma

`AdminAuditPage`, `ContractsPage` y `ContractDetailPage` usaban `toLocaleString()` / `toLocaleDateString()` sin locale, así que el formato dependía del navegador de cada usuario. Fijado a `es-PA` como en el resto de la app.

## Lo que sí funcionaba

Resumen, reportes (listado y detalle con moderación), usuarios, leads, pagos con reembolsos, conciliación, auditoría, observabilidad y respaldos — todos con datos reales.

Dos sustos que resultaron ser míos y no de la app, por si sirve de registro: el botón «Crear respaldo» parecía muerto, y era que mis clics usaban una referencia de elemento obsoleta — con un clic normal funciona y muestra el error del servidor correctamente. Y di por mal documentada la variable `BACKUP_ENCRYPTION_KEY` sin leer `.env.example`, que ya trae el comando para generarla ([comentario en el issue](https://github.com/1ZH13/TerraShare/issues/370#issuecomment-5036492265)).

## Verificación

- Backend: **405 pass / 0 fail** (400 antes; +5 del nuevo `admin-lands.test.ts`). `typecheck` limpio.
- Web: `typecheck` y `build` limpios, `test:unit` 26 pass, Playwright `--project=chromium` **41 passed**.
- En el navegador: el listado pasa de «20 terrenos» a **«36 terrenos»** con **cero** celdas de uso vacías, y los `<code>` del panel de seguridad ya se leen.
- El interruptor de 2FA, probado de verdad: al activarlo, `/admin/users`, `/admin/reports` y `/admin/backups` responden `403 MFA_REQUIRED` mientras `/admin/security-settings` sigue en `200` — la salida de emergencia funciona, y el aviso de bloqueo aparece en pantalla. Desactivado después.

Closes #370
