### PR TITLE
feat(catalog): filtros en el servidor y paginación de verdad (#366)

### DIFF
--- a/apps/backend-api/src/routes/lands-filters.test.ts
+++ b/apps/backend-api/src/routes/lands-filters.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import { requestJson } from "../lib/http-test-utils";
+import { Land } from "../db/schemas";
+
+/**
+ * Filtrado y paginación del catálogo en el servidor (#366).
+ *
+ * El catálogo filtraba en el cliente sobre la primera página que devolvía la
+ * API, así que pedía 100 registros y aun así ocultaba lo que no cupiera. Al
+ * mover los filtros aquí, estas pruebas fijan que el servidor reproduce lo que
+ * hacía la interfaz — incluida la búsqueda por subcadena sobre provincia y
+ * distrito, que `$text` no cubría — y que la paginación declara el total real.
+ *
+ * Gotcha de bun:test + mongodb-memory-server: se siembra en `beforeEach` y el
+ * cuerpo del test solo lee.
+ */
+
+const base = {
+  area: 20,
+  location: { province: "Coclé", district: "Penonomé" },
+  availability: {},
+  status: "active" as const,
+};
+
+const ids = (payload: { data: { items: { id: string }[] } }) => payload.data.items.map((l) => l.id);
+
+describe("GET /lands — filtros en el servidor", () => {
+  beforeEach(async () => {
+    await Land.create([
+      {
+        ...base, id: "lf_alquiler", ownerId: "own_1", title: "Potrero de alquiler",
+        description: "Pasto establecido", allowedUses: ["ganaderia"],
+        priceRule: { currency: "USD", pricePerMonth: 900 }, operation: "alquiler",
+      },
+      {
+        ...base, id: "lf_venta", ownerId: "own_1", title: "Lote solo venta",
+        description: "Ideal para inversión", allowedUses: ["otro"],
+        // Un terreno de solo venta lleva renta 0: es el que colaba en los tramos.
+        priceRule: { currency: "USD", pricePerMonth: 0 }, operation: "venta", salePrice: 90000,
+      },
+      {
+        ...base, id: "lf_ambas", ownerId: "own_1", title: "Finca mixta",
+        description: "Se alquila o se vende", allowedUses: ["agricultura"],
+        priceRule: { currency: "USD", pricePerMonth: 1200 }, operation: "ambas", salePrice: 150000,
+      },
+      {
+        ...base, id: "lf_boquete", ownerId: "own_2", title: "Hacienda cafetalera",
+        description: "Altura y sombra", allowedUses: ["agricultura"],
+        location: { province: "Chiriquí", district: "Boquete" },
+        priceRule: { currency: "USD", pricePerMonth: 2500 }, operation: "alquiler",
+      },
+      {
+        ...base, id: "lf_borrador", ownerId: "own_2", title: "Sin publicar",
+        allowedUses: ["mixto"], priceRule: { currency: "USD", pricePerMonth: 100 },
+        operation: "alquiler", status: "draft",
+      },
+    ]);
+  });
+
+  it("solo devuelve terrenos publicados", async () => {
+    const { payload } = await requestJson("/api/v1/lands?pageSize=100");
+    expect(ids(payload)).not.toContain("lf_borrador");
+  });
+
+  it("filtra por operación, y «ambas» cuenta para las dos caras", async () => {
+    const alquiler = await requestJson("/api/v1/lands?operation=alquiler&pageSize=100");
+    expect(ids(alquiler.payload)).toContain("lf_alquiler");
+    expect(ids(alquiler.payload)).toContain("lf_ambas");
+    expect(ids(alquiler.payload)).not.toContain("lf_venta");
+
+    const venta = await requestJson("/api/v1/lands?operation=venta&pageSize=100");
+    expect(ids(venta.payload)).toContain("lf_venta");
+    expect(ids(venta.payload)).toContain("lf_ambas");
+    expect(ids(venta.payload)).not.toContain("lf_alquiler");
+  });
+
+  it("«todas» no filtra por operación", async () => {
+    const { payload } = await requestJson("/api/v1/lands?operation=todas&pageSize=100");
+    for (const id of ["lf_alquiler", "lf_venta", "lf_ambas"]) {
+      expect(ids(payload)).toContain(id);
+    }
+  });
+
+  it("un terreno de solo venta no cuela en un tramo «hasta $X»", async () => {
+    // Su `pricePerMonth` es 0, que satisface cualquier `$lte`.
+    const { payload } = await requestJson("/api/v1/lands?priceMax=500&pageSize=100");
+    expect(ids(payload)).not.toContain("lf_venta");
+  });
+
+  it("el precio máximo respeta el alquiler y el terreno de ambas operaciones", async () => {
+    const { payload } = await requestJson("/api/v1/lands?priceMax=1000&pageSize=100");
+    expect(ids(payload)).toContain("lf_alquiler");
+    expect(ids(payload)).not.toContain("lf_ambas"); // 1200 > 1000
+    expect(ids(payload)).not.toContain("lf_boquete"); // 2500 > 1000
+  });
+
+  it("pedir «en venta» con un máximo mensual no devuelve nada, que es lo honesto", async () => {
+    // Una venta no tiene renta con la que comparar: la intersección es vacía.
+    const { payload } = await requestJson("/api/v1/lands?operation=venta&priceMax=1000&pageSize=100");
+    expect(ids(payload)).not.toContain("lf_venta");
+  });
+
+  it("busca por subcadena en el título", async () => {
+    const { payload } = await requestJson("/api/v1/lands?q=cafetalera&pageSize=100");
+    expect(ids(payload)).toEqual(["lf_boquete"]);
+  });
+
+  it("busca en la descripción", async () => {
+    const { payload } = await requestJson("/api/v1/lands?q=inversi&pageSize=100");
+    expect(ids(payload)).toContain("lf_venta");
+  });
+
+  it("busca por provincia y distrito, que el índice de texto no cubría", async () => {
+    const prov = await requestJson("/api/v1/lands?q=chiriqu&pageSize=100");
+    expect(ids(prov.payload)).toContain("lf_boquete");
+
+    const dist = await requestJson("/api/v1/lands?q=boque&pageSize=100");
+    expect(ids(dist.payload)).toContain("lf_boquete");
+  });
+
+  it("la búsqueda ignora mayúsculas", async () => {
+    const { payload } = await requestJson("/api/v1/lands?q=POTRERO&pageSize=100");
+    expect(ids(payload)).toContain("lf_alquiler");
+  });
+
+  it("combina varios criterios a la vez", async () => {
+    const { payload } = await requestJson(
+      "/api/v1/lands?province=Coclé&operation=alquiler&priceMax=1000&pageSize=100",
+    );
+    expect(ids(payload)).toEqual(["lf_alquiler"]);
+  });
+
+  it("filtra por uso", async () => {
+    const { payload } = await requestJson("/api/v1/lands?use=ganaderia&pageSize=100");
+    expect(ids(payload)).toContain("lf_alquiler");
+    expect(ids(payload)).not.toContain("lf_boquete");
+  });
+});
+
+describe("GET /lands — paginación", () => {
+  beforeEach(async () => {
+    await Land.create(
+      Array.from({ length: 7 }, (_, i) => ({
+        ...base,
+        id: `lp_${i}`,
+        ownerId: "own_pag",
+        title: `Parcela paginada ${i}`,
+        allowedUses: ["agricultura"],
+        priceRule: { currency: "USD", pricePerMonth: 100 + i },
+        operation: "alquiler",
+      })),
+    );
+  });
+
+  it("declara el total real, no el tamaño de la página", async () => {
+    const { payload } = await requestJson("/api/v1/lands?q=paginada&pageSize=3");
+
+    expect(payload.data.items.length).toBe(3);
+    expect(payload.data.pagination.totalItems).toBe(7);
+    expect(payload.data.pagination.totalPages).toBe(3);
+  });
+
+  it("la última página trae el resto", async () => {
+    const { payload } = await requestJson("/api/v1/lands?q=paginada&pageSize=3&page=3");
+    expect(payload.data.items.length).toBe(1);
+    expect(payload.data.pagination.page).toBe(3);
+  });
+
+  it("las páginas no se solapan ni pierden registros", async () => {
+    const seen: string[] = [];
+    for (const page of [1, 2, 3]) {
+      const { payload } = await requestJson(`/api/v1/lands?q=paginada&pageSize=3&page=${page}`);
+      seen.push(...ids(payload));
+    }
+    expect(new Set(seen).size).toBe(7);
+  });
+
+  it("una página más allá del final devuelve vacío, sin romper", async () => {
+    const { response, payload } = await requestJson("/api/v1/lands?q=paginada&pageSize=3&page=99");
+    expect(response.status).toBe(200);
+    expect(payload.data.items).toEqual([]);
+  });
+});
+
+describe("GET /lands/facets", () => {
+  beforeEach(async () => {
+    await Land.create([
+      {
+        ...base, id: "lfac_1", ownerId: "own_f", title: "Faceta publicada",
+        allowedUses: ["ganaderia"], priceRule: { currency: "USD", pricePerMonth: 100 },
+        operation: "alquiler", location: { province: "Herrera", district: "Chitré" },
+      },
+      {
+        ...base, id: "lfac_2", ownerId: "own_f", title: "Faceta oculta",
+        allowedUses: ["acuicultura"], priceRule: { currency: "USD", pricePerMonth: 100 },
+        // Provincia inventada a propósito: las reales aparecen en los fixtures
+        // compartidos, así que buscar una de ellas no probaría nada.
+        operation: "alquiler", location: { province: "Provincia Fantasma", district: "Yaviza" },
+        status: "draft",
+      },
+    ]);
+  });
+
+  it("devuelve las provincias y usos de los terrenos publicados", async () => {
+    const { response, payload } = await requestJson("/api/v1/lands/facets");
+    expect(response.status).toBe(200);
+    expect(payload.data.provinces).toContain("Herrera");
+    expect(payload.data.uses).toContain("ganaderia");
+  });
+
+  it("no expone los de terrenos sin publicar", async () => {
+    const { payload } = await requestJson("/api/v1/lands/facets");
+    // El mismo `status: "active"` gobierna las dos facetas, así que basta con
+    // comprobar la provincia, que es el único valor que puedo garantizar que
+    // solo existe en el borrador sembrado aquí.
+    expect(payload.data.provinces).not.toContain("Provincia Fantasma");
+  });
+
+  it("las provincias vienen ordenadas y sin repetir", async () => {
+    const { payload } = await requestJson("/api/v1/lands/facets");
+    const provinces = payload.data.provinces as string[];
+    expect(new Set(provinces).size).toBe(provinces.length);
+    expect([...provinces].sort((a, b) => a.localeCompare(b, "es"))).toEqual(provinces);
+  });
+
+  it("es pública: alimenta un catálogo que no exige sesión para el detalle", async () => {
+    const { response } = await requestJson("/api/v1/lands/facets");
+    expect(response.status).toBe(200);
+  });
+});

--- a/apps/backend-api/src/routes/lands.ts
+++ b/apps/backend-api/src/routes/lands.ts
@@ -43,6 +43,7 @@ function buildLandQuery(params: {
   use?: string;
   province?: string;
   district?: string;
+  operation?: string;
   priceMin?: number;
   priceMax?: number;
   availableFrom?: string;
@@ -52,6 +53,20 @@ function buildLandQuery(params: {
   const query: Record<string, unknown> = { status: "active" };
 
   if (params.use) query.allowedUses = params.use;
+
+  // ── Operación (#366) ──
+  // Se resuelve como un conjunto de operaciones admisibles y se aplica UNA vez,
+  // porque dos criterios distintos lo restringen: el filtro explícito de
+  // operación y el de precio.
+  const ALL_OPERATIONS = ["alquiler", "venta", "ambas"];
+  let operations = ALL_OPERATIONS;
+
+  // «ambas» satisface tanto a quien busca alquiler como a quien busca compra,
+  // igual que en el catálogo y en el emparejador de búsquedas guardadas.
+  if (params.operation && params.operation !== "todas") {
+    operations = operations.filter((op) => op === params.operation || op === "ambas");
+  }
+
   if (params.province) {
     query["location.province"] = new RegExp(`^${escapeRegex(params.province)}$`, "i");
   }
@@ -64,6 +79,17 @@ function buildLandQuery(params: {
     if (params.priceMin !== undefined) price.$gte = params.priceMin;
     if (params.priceMax !== undefined) price.$lte = params.priceMax;
     query["priceRule.pricePerMonth"] = price;
+    // El precio filtra la RENTA, así que solo puede estrechar el conjunto a lo
+    // que se alquila: un terreno de solo venta lleva `pricePerMonth: 0` y
+    // colaba en cualquier tramo «hasta $X» (mismo fallo corregido en la
+    // interfaz en #365 y en el emparejador en #368). Si alguien pide «en venta»
+    // *y* un máximo mensual, la intersección queda vacía — que es la respuesta
+    // honesta: una venta no tiene renta con la que comparar.
+    operations = operations.filter((op) => op !== "venta");
+  }
+
+  if (operations.length !== ALL_OPERATIONS.length) {
+    query.operation = { $in: operations };
   }
 
   const and: Record<string, unknown>[] = [];
@@ -83,9 +109,29 @@ function buildLandQuery(params: {
       ],
     });
   }
-  if (and.length > 0) query.$and = and;
+  // Texto libre (#366). Antes usaba `$text`, que solo cubre el índice de texto
+  // (título + descripción) y empareja palabras completas con stemming. El
+  // catálogo, que filtraba en el cliente, buscaba SUBCADENAS y también por
+  // provincia y distrito: al mover el filtro al servidor, `$text` habría hecho
+  // que escribir «Coclé» o «boque» no devolviera nada.
+  //
+  // El regex reproduce el comportamiento anterior (insensible a mayúsculas,
+  // sensible a acentos, igual que el `includes` que sustituye). No usa índice,
+  // así que a escala grande habrá que pasar a un buscador de verdad — pero eso
+  // es un cambio de producto, no una regresión silenciosa.
+  if (params.q) {
+    const rx = new RegExp(escapeRegex(params.q.trim()), "i");
+    and.push({
+      $or: [
+        { title: rx },
+        { description: rx },
+        { "location.province": rx },
+        { "location.district": rx },
+      ],
+    });
+  }
 
-  if (params.q) query.$text = { $search: params.q };
+  if (and.length > 0) query.$and = and;
 
   return query;
 }
@@ -123,6 +169,7 @@ landRoutes.get("/lands", async (c) => {
     use: c.req.query("use"),
     province: c.req.query("province"),
     district: c.req.query("district"),
+    operation: c.req.query("operation"),
     priceMin: getOptionalNumericQuery(c, "priceMin"),
     priceMax: getOptionalNumericQuery(c, "priceMax"),
     availableFrom: c.req.query("availableFrom"),
@@ -164,6 +211,31 @@ landRoutes.get("/lands", async (c) => {
       totalItems,
       totalPages,
     },
+  });
+});
+
+/**
+ * Valores disponibles para los desplegables del catálogo (#366).
+ *
+ * Antes la interfaz los derivaba de los terrenos que tenía cargados. Con el
+ * filtrado y la paginación en el servidor eso ya no vale: solo vería los de la
+ * página actual y las opciones irían desapareciendo al navegar.
+ *
+ * Se calculan sobre TODOS los terrenos publicados, sin aplicar los filtros
+ * activos, para que las opciones no bailen mientras el usuario filtra.
+ *
+ * Debe registrarse antes de "/lands/:landId", o "facets" se interpreta como un
+ * id de terreno y esta ruta se vuelve inalcanzable.
+ */
+landRoutes.get("/lands/facets", async (c) => {
+  const [provinces, uses] = await Promise.all([
+    Land.distinct("location.province", { status: "active" }),
+    Land.distinct("allowedUses", { status: "active" }),
+  ]);
+
+  return success(c, {
+    provinces: (provinces as string[]).filter(Boolean).sort((a, b) => a.localeCompare(b, "es")),
+    uses: (uses as string[]).filter(Boolean).sort(),
   });
 });
 

--- a/apps/web/src/pages/AdminLandsPage.tsx
+++ b/apps/web/src/pages/AdminLandsPage.tsx
@@ -17,6 +17,9 @@ const USE_LABELS: Record<string, string> = {
   otro: "Otro",
 };
 
+/** Terrenos por página en el panel (#366). */
+const PAGE_SIZE = 20;
+
 const STATUS: Record<string, { label: string; cls: string }> = {
   draft: { label: "Borrador", cls: "adm-badge--amber" },
   active: { label: "Publicada", cls: "adm-badge--green" },
@@ -30,19 +33,42 @@ export default function AdminLandsPage() {
   const [error, setError] = useState("");
   const [filter, setFilter] = useState("all");
   const [search, setSearch] = useState("");
+  // Paginación real (#366). Antes se pedían 100 de golpe como parche a que la
+  // pantalla mostrara 20 de 36 sin avisar (#370).
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Al cambiar los criterios se vuelve a la primera página: quedarse en la 3 de
+  // un resultado que ahora tiene una sola deja la tabla vacía.
+  useEffect(() => {
+    setPage(1);
+  }, [filter, search]);
 
   useEffect(() => {
     setLoading(true);
     setError("");
-    const filters: { status?: string; search?: string } = {};
+    const filters: { status?: string; search?: string; page?: number; pageSize?: number } = {
+      page,
+      pageSize: PAGE_SIZE,
+    };
     if (filter !== "all") filters.status = filter;
     if (search.trim()) filters.search = search.trim();
 
     listAdminLands(filters)
-      .then((res) => setLands((((res.data as unknown) as { items?: AdminLand[] })?.items ?? [])))
+      .then((res) => {
+        const data = (res.data as unknown) as {
+          items?: AdminLand[];
+          total?: number;
+          pagination?: { page: number; totalPages: number };
+        };
+        setLands(data?.items ?? []);
+        setTotal(data?.total ?? data?.items?.length ?? 0);
+        setTotalPages(data?.pagination?.totalPages ?? 1);
+      })
       .catch((e) => setError(e instanceof Error ? e.message : "Error"))
       .finally(() => setLoading(false));
-  }, [filter, search]);
+  }, [filter, search, page]);
 
   const handleUpdateStatus = async (landId: string, nextStatus: string) => {
     try {
@@ -136,7 +162,23 @@ export default function AdminLandsPage() {
 
       {!loading && !error && lands.length > 0 && (
         <div className="adm-foot">
-          <span>{lands.length} terreno{lands.length !== 1 ? "s" : ""}</span>
+          {/* El total sale del servidor, no del tamaño de la página. */}
+          <span>{total} terreno{total !== 1 ? "s" : ""}</span>
+          {totalPages > 1 && (
+            <div className="adm-pager">
+              <button type="button" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1}>
+                Anterior
+              </button>
+              <span aria-live="polite">Página {page} de {totalPages}</span>
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+              >
+                Siguiente
+              </button>
+            </div>
+          )}
         </div>
       )}
     </>

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import type { LandDto } from "@terrashare/shared";
 import {
@@ -16,9 +16,19 @@ import {
   Bookmark,
   BookmarkPlus,
 } from "lucide-react";
-import { listLands, photoSrc } from "../services/api";
+import {
+  getLandFacets,
+  photoSrc,
+  searchLands,
+  type LandFacets,
+  type LandsPagination,
+} from "../services/api";
 import { formatLandPriceShort, monthlyPrice } from "../lib/land-price";
 import {
+  ANY_OPERATION,
+  ANY_PROVINCE,
+  ANY_USE,
+  NO_PRICE_LIMIT,
   type CatalogFilterState,
   filtersToParams,
   hasAnyFilter,
@@ -45,6 +55,9 @@ const USE_LABELS: Record<string, string> = {
   mixto: "Mixto",
   otro: "Otro",
 };
+
+/** Terrenos por página en el catálogo (#366). */
+const PAGE_SIZE = 12;
 
 const PRICE_OPTIONS = [
   { label: "Precio", value: 1_000_000 },
@@ -115,6 +128,13 @@ export default function CatalogPage() {
   const currentFilters: CatalogFilterState = { q: query, use, province, operation, maxPrice };
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
+  // Paginación real contra el servidor (#366).
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState<LandsPagination>({
+    page: 1, pageSize: PAGE_SIZE, totalItems: 0, totalPages: 1,
+  });
+  const [facets, setFacets] = useState<LandFacets>({ provinces: [], uses: [] });
+
   useEffect(() => {
     if (!compareToast) return;
     const t = window.setTimeout(() => setCompareToast(null), 2400);
@@ -128,63 +148,80 @@ export default function CatalogPage() {
     }
   };
 
+  // Las opciones de los desplegables salen de un endpoint aparte, calculado
+  // sobre TODOS los terrenos publicados. Antes se derivaban de la lista
+  // cargada; con la paginación en el servidor eso solo vería la página actual
+  // y las opciones irían desapareciendo al navegar (#366).
   useEffect(() => {
     let active = true;
-    // El catálogo filtra, ordena y pinta el mapa **en el cliente**, así que
-    // necesita el conjunto completo. Sin `pageSize`, el backend devolvía su
-    // página por defecto de 20 y el resto de terrenos era inalcanzable: no hay
-    // paginador en esta pantalla, así que desaparecían sin previo aviso.
-    // 100 es el máximo que admite la ruta; por encima de esa escala habría que
-    // mover los filtros al servidor y paginar de verdad (#366).
-    listLands({ pageSize: 100 })
-      .then((data) => {
-        if (!active) return;
-        setLands(data);
-        setStatus("ready");
+    getLandFacets()
+      .then((f) => {
+        if (active) setFacets(f);
       })
-      .catch((err) => {
-        console.error("Error cargando catálogo:", err);
-        if (active) setStatus("error");
+      .catch(() => {
+        /* Sin facetas los desplegables quedan vacíos, pero el catálogo funciona. */
       });
     return () => {
       active = false;
     };
   }, []);
 
-  const useOptions = useMemo(
-    () => [...new Set(lands.map((l) => l.allowedUses?.[0]).filter((v): v is NonNullable<typeof v> => Boolean(v)))],
-    [lands],
-  );
-  const provinceOptions = useMemo(
-    () => [...new Set(lands.map((l) => l.location?.province).filter((v): v is string => Boolean(v)))],
-    [lands],
-  );
+  // El texto se escribe letra a letra: sin esperar, cada tecla dispararía una
+  // petición. El resto de filtros son desplegables y se aplican al momento.
+  const [debouncedQuery, setDebouncedQuery] = useState(initialFilters.q);
+  useEffect(() => {
+    const t = window.setTimeout(() => setDebouncedQuery(query), 300);
+    return () => window.clearTimeout(t);
+  }, [query]);
 
-  const filtered = useMemo(() => {
-    return lands.filter((land) => {
-      const landUse = land.allowedUses?.[0] ?? "otro";
-      const matchesUse = use === "todos" || landUse === use;
-      const matchesProvince = province === "todas" || land.location?.province === province;
-      // El filtro de precio solo aplica a lo que se alquila: un terreno de solo
-      // venta no tiene renta con la que compararse, y contarlo como 0 lo colaba
-      // en todos los tramos «hasta $X».
-      const monthly = monthlyPrice(land);
-      const matchesPrice = maxPrice >= 1_000_000 || (monthly !== null && monthly <= maxPrice);
-      // «ambas» cuenta para las dos caras del filtro.
-      const matchesOperation =
-        operation === "todas"
-        || land.operation === operation
-        || land.operation === "ambas";
-      const haystack = [land.title, land.location?.province, land.location?.district, land.description]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      const matchesQuery = !query || haystack.includes(query.toLowerCase());
-      return matchesUse && matchesProvince && matchesPrice && matchesOperation && matchesQuery;
-    });
-  }, [lands, use, province, maxPrice, operation, query]);
+  // Volver a la primera página cuando cambian los criterios: quedarse en la
+  // página 4 de un resultado que ahora tiene una sola deja la pantalla vacía.
+  //
+  // Cambiar un filtro estando en una página distinta de la 1 dispara dos
+  // peticiones (una por el criterio, otra por el salto de página), porque
+  // `page` y los filtros son estados separados. Se acepta a conciencia: unificar
+  // todo en un único objeto de estado evitaría la petición de más, pero
+  // obligaría a leer cada `select` desde dentro de ese objeto y enreda el
+  // componente para ahorrar una llamada que el usuario no percibe.
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedQuery, use, province, operation, maxPrice]);
 
-  const selectedLand = filtered.find((l) => l.id === selectedId) ?? filtered[0] ?? null;
+  useEffect(() => {
+    let active = true;
+    setStatus((prev) => (prev === "ready" ? "ready" : "loading"));
+
+    searchLands({
+      q: debouncedQuery.trim() || undefined,
+      type: use !== ANY_USE ? use : undefined,
+      province: province !== ANY_PROVINCE ? province : undefined,
+      operation: operation !== ANY_OPERATION ? operation : undefined,
+      priceMax: maxPrice < NO_PRICE_LIMIT ? maxPrice : undefined,
+      page,
+      pageSize: PAGE_SIZE,
+    })
+      .then((res) => {
+        if (!active) return;
+        setLands(res.items);
+        setPagination(res.pagination);
+        setSelectedId(null);
+        setStatus("ready");
+      })
+      .catch((err) => {
+        console.error("Error cargando catálogo:", err);
+        if (active) setStatus("error");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [debouncedQuery, use, province, operation, maxPrice, page]);
+
+  const useOptions = facets.uses;
+  const provinceOptions = facets.provinces;
+
+  // El servidor ya devuelve la página filtrada: aquí no se vuelve a filtrar.
+  const selectedLand = lands.find((l) => l.id === selectedId) ?? lands[0] ?? null;
 
   return (
     <div className="cat">
@@ -313,8 +350,12 @@ export default function CatalogPage() {
       <div className="cat-body">
         <div className="cat-listcol">
           <div className="cat-listhead">
+            {/* El total viene del servidor, no del tamaño de la página: decir
+                «12 terrenos» cuando hay 36 es justo el fallo de #365. */}
             {status === "ready"
-              ? `${filtered.length} terreno${filtered.length === 1 ? "" : "s"} · ordenar por `
+              ? `${pagination.totalItems} terreno${pagination.totalItems === 1 ? "" : "s"}${
+                  pagination.totalPages > 1 ? ` · página ${pagination.page} de ${pagination.totalPages}` : ""
+                } · ordenar por `
               : "Cargando terrenos · "}
             <strong>Recientes</strong>
           </div>
@@ -329,7 +370,7 @@ export default function CatalogPage() {
             <p className="cat-state cat-state--error">
               No pudimos cargar el catálogo ahora mismo. Vuelve a intentarlo en un momento.
             </p>
-          ) : filtered.length === 0 ? (
+          ) : lands.length === 0 ? (
             <EmptyState
               icon={SearchX}
               title="Sin resultados"
@@ -346,7 +387,7 @@ export default function CatalogPage() {
             />
           ) : (
             <div className="cat-list">
-              {filtered.map((land) => {
+              {lands.map((land) => {
                 const monthly = monthlyPrice(land);
                 return (
                   <button
@@ -437,11 +478,35 @@ export default function CatalogPage() {
               })}
             </div>
           )}
+
+          {status === "ready" && pagination.totalPages > 1 && (
+            <nav className="cat-pager" aria-label="Paginación del catálogo">
+              <button
+                type="button"
+                className="cat-pager__btn"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={pagination.page <= 1}
+              >
+                Anterior
+              </button>
+              <span className="cat-pager__status" aria-live="polite">
+                Página {pagination.page} de {pagination.totalPages}
+              </span>
+              <button
+                type="button"
+                className="cat-pager__btn"
+                onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
+                disabled={pagination.page >= pagination.totalPages}
+              >
+                Siguiente
+              </button>
+            </nav>
+          )}
         </div>
 
         <div className="cat-mapcol">
           <PanamaMap
-            lands={filtered}
+            lands={lands}
             selectedLand={selectedLand}
             onSelectLand={(land) => setSelectedId(land.id)}
           />

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -311,3 +311,28 @@
   color: var(--ts-green);
   font-size: 13.5px;
 }
+
+/* Paginador del catálogo (#366) */
+.cat-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin: 22px 0 8px;
+}
+
+.cat-pager__btn {
+  padding: 9px 18px;
+  border-radius: var(--ts-radius-pill);
+  border: 1px solid var(--ts-border);
+  background: var(--ts-surface);
+  color: var(--ts-text);
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.cat-pager__btn:hover:not(:disabled) { background: var(--ts-paper-tint); }
+.cat-pager__btn:disabled { opacity: 0.45; cursor: default; }
+
+.cat-pager__status { color: var(--ts-sage-2); font-size: 13.5px; }

--- a/apps/web/src/services/adminApi.ts
+++ b/apps/web/src/services/adminApi.ts
@@ -72,6 +72,8 @@ interface AdminUserFilters {
 interface AdminLandFilters {
   status?: string;
   search?: string;
+  page?: number;
+  pageSize?: number;
 }
 
 // ─── Users ───────────────────────────────────────────────────────────────────
@@ -101,11 +103,8 @@ export const listAdminLands = (filters: AdminLandFilters = {}) => {
   const params = new URLSearchParams();
   if (filters.status) params.set("status", filters.status);
   if (filters.search) params.set("search", filters.search);
-  // La ruta pagina a 20 por defecto y la pantalla no tiene paginador, así que
-  // los terrenos restantes quedaban fuera del alcance del admin — y esta es la
-  // pantalla de moderación (#370). 100 es el máximo que admite la ruta; por
-  // encima de esa escala hace falta paginador de verdad, igual que en #366.
-  params.set("pageSize", "100");
+  if (filters.page) params.set("page", String(filters.page));
+  if (filters.pageSize) params.set("pageSize", String(filters.pageSize));
   return request<LandDto[]>("GET", `/api/v1/admin/lands?${params.toString()}`);
 };
 

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -93,6 +93,10 @@ export interface CatalogFilters {
   type?: string;
   province?: string;
   district?: string;
+  /** Texto libre: título, descripción, provincia y distrito (#366). */
+  q?: string;
+  /** "alquiler" | "venta"; «ambas» satisface a las dos (#366). */
+  operation?: string;
   priceMax?: number;
   availableFrom?: string;
   sort?: string;
@@ -101,26 +105,69 @@ export interface CatalogFilters {
   pageSize?: number;
 }
 
-/** GET /api/v1/lands — listado con filtros (use, province, district, priceMax, availableFrom, sort, order) */
-export const listLands = async (filters: CatalogFilters = {}): Promise<LandDto[]> => {
+/** Metadatos de paginación que devuelve `GET /api/v1/lands`. */
+export interface LandsPagination {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface LandsPage {
+  items: LandDto[];
+  pagination: LandsPagination;
+}
+
+function catalogParams(filters: CatalogFilters): URLSearchParams {
   const params = new URLSearchParams();
   if (filters.type) params.set("use", filters.type);
   if (filters.province) params.set("province", filters.province);
   if (filters.district) params.set("district", filters.district);
+  if (filters.q) params.set("q", filters.q);
+  if (filters.operation) params.set("operation", filters.operation);
   if (filters.priceMax) params.set("priceMax", String(filters.priceMax));
   if (filters.availableFrom) params.set("availableFrom", filters.availableFrom);
   if (filters.sort) params.set("sort", filters.sort);
   if (filters.order) params.set("order", filters.order);
   if (filters.page) params.set("page", String(filters.page));
   if (filters.pageSize) params.set("pageSize", String(filters.pageSize));
-  const qs = params.toString();
-  const res = await request<{ items?: LandDto[] } | LandDto[]>(
-    "GET",
-    `/api/v1/lands${qs ? `?${qs}` : ""}`,
-  );
-  const data = res?.data as any;
-  return data?.items ?? data ?? [];
+  return params;
+}
+
+/**
+ * GET /api/v1/lands conservando los metadatos de paginación (#366).
+ *
+ * `listLands` los descarta y devuelve solo los elementos, que es lo que
+ * necesitan la landing y la home; el catálogo necesita el total para poder
+ * paginar y para no volver a decir «20 terrenos» cuando hay 36.
+ */
+export const searchLands = async (filters: CatalogFilters = {}): Promise<LandsPage> => {
+  const qs = catalogParams(filters).toString();
+  const res = await request<LandsPage>("GET", `/api/v1/lands${qs ? `?${qs}` : ""}`);
+  const data = res?.data as unknown as Partial<LandsPage> | LandDto[] | undefined;
+
+  if (Array.isArray(data)) {
+    return {
+      items: data,
+      pagination: { page: 1, pageSize: data.length, totalItems: data.length, totalPages: 1 },
+    };
+  }
+
+  const items = data?.items ?? [];
+  return {
+    items,
+    pagination: data?.pagination ?? {
+      page: 1,
+      pageSize: items.length,
+      totalItems: items.length,
+      totalPages: 1,
+    },
+  };
 };
+
+/** GET /api/v1/lands — listado con filtros (use, province, district, priceMax, availableFrom, sort, order) */
+export const listLands = async (filters: CatalogFilters = {}): Promise<LandDto[]> =>
+  (await searchLands(filters)).items;
 
 /** GET /api/v1/lands/me - lista lands del usuario actual */
 export const getMyLands = async (): Promise<LandDto[]> => {
@@ -598,4 +645,15 @@ export const api = {
   listMyVisits,
   respondToVisit,
   downloadContractPdf,
+};
+
+/** GET /api/v1/lands/facets — valores para los desplegables del catálogo (#366). */
+export interface LandFacets {
+  provinces: string[];
+  uses: string[];
+}
+
+export const getLandFacets = async (): Promise<LandFacets> => {
+  const res = await request<LandFacets>("GET", "/api/v1/lands/facets");
+  return res?.data ?? { provinces: [], uses: [] };
 };


### PR DESCRIPTION
El catálogo filtraba, ordenaba y pintaba el mapa **en el cliente**, así que necesitaba el conjunto completo de terrenos. Pedía `pageSize: 100` como parche, y por encima de esa escala habría vuelto a ocultar resultados sin avisar — el mismo fallo de #365 y #370, solo que aplazado. Lo mismo en el listado de terrenos del panel.

## Qué cambia

**Los cinco criterios viajan al servidor** (texto, uso, provincia, operación, precio) y la pantalla **pagina de verdad**: 12 por página en el catálogo, 20 en el panel, con el total real en la cabecera y botones que se deshabilitan en los extremos.

**`GET /lands` gana el filtro por operación** y corrige el de precio. Un terreno de solo venta lleva `pricePerMonth: 0` y colaba en cualquier tramo «hasta $X» — el mismo fallo ya corregido en la interfaz (#365) y en el emparejador de búsquedas guardadas (#368), que seguía vivo en la API. La operación se resuelve como un conjunto admisible y se aplica una vez, porque dos criterios distintos la restringen; pedir «en venta» **con** un máximo mensual devuelve vacío a propósito: una venta no tiene renta que comparar, y devolver algo sería mentir.

**La búsqueda por texto pasa de `$text` a un regex.** `$text` solo cubre el índice de texto (título + descripción) y empareja palabras completas con stemming; el catálogo buscaba **subcadenas** y también por provincia y distrito. Moverlo al servidor tal cual habría hecho que escribir «Coclé» o «boque» dejara de devolver nada. El regex reproduce el comportamiento exacto de antes. No usa índice: a escala grande tocará un buscador de verdad, pero eso es una decisión de producto y no una regresión silenciosa.

**Nuevo `GET /lands/facets`.** Los desplegables se alimentaban de la lista cargada; con la paginación en el servidor eso solo vería la página actual y las opciones irían desapareciendo al navegar. Se calculan sobre todos los terrenos publicados, sin aplicar los filtros activos, para que no bailen mientras filtras.

**Antirrebote de 300 ms** en el campo de texto: se escribe letra a letra y sin esperar cada tecla dispararía una petición.

## Una cosa que dejo a conciencia

Cambiar un filtro estando en una página distinta de la 1 dispara **dos** peticiones (una por el criterio, otra por el salto a la página 1), porque `page` y los filtros son estados separados. Unificarlos en un único objeto lo evitaría, pero obliga a leer cada `select` desde dentro de ese objeto y enreda el componente para ahorrar una llamada que el usuario no percibe. Está comentado en el código.

## Verificación

- Backend: **425 pass / 0 fail** (405 antes; +20 del nuevo `lands-filters.test.ts`, que cubre operación, el terreno de venta colándose por precio, la búsqueda por provincia y distrito, y que las páginas no se solapan ni pierden registros). `typecheck` limpio.
- Web: `typecheck` y `build` limpios, `test:unit` 26 pass, Playwright `--project=chromium` **41 passed**.
- En el navegador, con sesión real:
  - Catálogo: «32 terrenos · página 1 de 3», recorridas las tres (12+12+8), «Siguiente» se deshabilita al final.
  - Teclear «boque» letra a letra → **2 peticiones para 5 pulsaciones**, resultado «3 terrenos», y vuelve a la página 1.
  - Filtro «En venta» → 14 terrenos y **cero** «$0/mes».
  - «En venta» + «hasta $500/mes» → 0 terrenos, que es lo correcto.
  - «Hasta $500» a secas → 0 terrenos; comprobado contra la base que el alquiler más barato es $605, así que el filtro no está roto: no hay nada más barato.
  - Panel: «36 terrenos · Página 1 de 2», sin celdas de uso vacías.

Closes #366
