### PR TITLE
fix(web): el tema oscuro se activaba solo con el SO en oscuro (#373)

### DIFF
--- a/apps/web/src/lib/theme.test.ts
+++ b/apps/web/src/lib/theme.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { DEFAULT_THEME, THEME_STORAGE_KEY, getInitialTheme } from "./theme";
+
+/**
+ * El tema por defecto es el claro y NO depende del sistema operativo (#373).
+ * Antes se caía a `prefers-color-scheme`, así que cualquiera con Windows en
+ * oscuro abría TerraShare en oscuro sin haberlo pedido nunca.
+ *
+ * `matchMedia` se falsea diciendo siempre «el SO prefiere oscuro»: si el tema
+ * vuelve a consultarlo, estas pruebas lo cazan.
+ */
+describe("getInitialTheme", () => {
+  const store = new Map<string, string>();
+  let originalMatchMedia: unknown;
+
+  beforeEach(() => {
+    store.clear();
+    globalThis.localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+
+    originalMatchMedia = (globalThis as { matchMedia?: unknown }).matchMedia;
+    (globalThis as { matchMedia?: unknown }).matchMedia = () => ({ matches: true });
+  });
+
+  afterEach(() => {
+    (globalThis as { matchMedia?: unknown }).matchMedia = originalMatchMedia;
+  });
+
+  it("usa el tema claro cuando no hay preferencia guardada, aunque el SO esté en oscuro", () => {
+    expect(getInitialTheme()).toBe("light");
+    expect(DEFAULT_THEME).toBe("light");
+  });
+
+  it("respeta la elección guardada del usuario", () => {
+    store.set(THEME_STORAGE_KEY, "dark");
+    expect(getInitialTheme()).toBe("dark");
+
+    store.set(THEME_STORAGE_KEY, "light");
+    expect(getInitialTheme()).toBe("light");
+  });
+
+  it("ignora valores corruptos en localStorage y cae al claro", () => {
+    store.set(THEME_STORAGE_KEY, "system");
+    expect(getInitialTheme()).toBe("light");
+  });
+});

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,10 +1,18 @@
 /* Control del tema claro/oscuro (#278).
    El atributo `data-theme` en <html> decide el tema (ver src/styles/tokens.css).
-   La preferencia explícita se guarda en localStorage; si no hay ninguna se
-   respeta la del sistema operativo. El script anti-flash en __root.tsx aplica
-   esta misma lógica antes del primer pintado. */
+   La preferencia explícita se guarda en localStorage; si no hay ninguna se usa
+   el tema CLARO, que es el predeterminado de la marca. El script anti-flash en
+   __root.tsx aplica esta misma lógica antes del primer pintado.
+
+   Deliberadamente NO se consulta `prefers-color-scheme` (#373): hacerlo abría
+   la web en oscuro a cualquiera con el SO en oscuro, que no es el aspecto por
+   defecto de TerraShare. Quien prefiera el oscuro lo elige en el conmutador y
+   la elección se recuerda. */
 
 export type ThemeChoice = "light" | "dark";
+
+/** Tema con el que arranca quien nunca ha tocado el conmutador. */
+export const DEFAULT_THEME: ThemeChoice = "light";
 
 export const THEME_STORAGE_KEY = "ts-theme";
 
@@ -13,21 +21,13 @@ export const THEME_STORAGE_KEY = "ts-theme";
    en vivo al toggle. */
 export const THEME_EVENT = "ts-themechange";
 
-export function systemPrefersDark(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches
-  );
-}
-
-/** Preferencia efectiva: la guardada, o la del sistema si no hay elección. */
+/** Preferencia efectiva: la guardada, o el tema por defecto si no hay elección. */
 export function getInitialTheme(): ThemeChoice {
   if (typeof localStorage !== "undefined") {
     const stored = localStorage.getItem(THEME_STORAGE_KEY);
     if (stored === "light" || stored === "dark") return stored;
   }
-  return systemPrefersDark() ? "dark" : "light";
+  return DEFAULT_THEME;
 }
 
 export function applyTheme(theme: ThemeChoice): void {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -63,11 +63,12 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     <html lang="es" data-theme="light" suppressHydrationWarning>
       <head>
         {/* Anti-flash de tema (#278): fija data-theme antes del primer pintado,
-            replicando la lógica de lib/theme.ts (preferencia guardada o del SO). */}
+            replicando la lógica de lib/theme.ts (preferencia guardada, o claro
+            por defecto — el SO no decide, ver #373). */}
         <script
           dangerouslySetInnerHTML={{
             __html:
-              "(function(){try{var k='ts-theme',v=localStorage.getItem(k);var t=(v==='light'||v==='dark')?v:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();",
+              "(function(){try{var k='ts-theme',v=localStorage.getItem(k);document.documentElement.setAttribute('data-theme',v==='dark'?'dark':'light');}catch(e){}})();",
           }}
         />
         <HeadContent />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -22,8 +22,8 @@
    degradado blanco — es decir, título verde oscuro sobre fondo oscuro y texto
    crema sobre panel casi blanco.
    Se redefinen aquí las mismas variables para que la hoja siga al tema, en vez
-   de retocar cada regla que las consume. El selector replica la cascada de
-   `styles/tokens.css`: elección explícita primero, preferencia del SO después. */
+   de retocar cada regla que las consume. Se aplican solo con la elección
+   explícita del usuario: el SO no decide el tema (#373). */
 :root[data-theme="dark"] {
   --leaf-700: #4f8a61;
   --leaf-900: #7fae8a;         /* títulos: sube a un verde claro legible sobre oscuro */
@@ -35,21 +35,6 @@
   --glass-bg: rgba(38, 48, 40, 0.72);
   --glass-border: rgba(236, 228, 211, 0.12);
   --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --leaf-700: #4f8a61;
-    --leaf-900: #7fae8a;
-    --ink-900: #ece4d3;
-    --paper: #1b241d;
-    --danger: #e08074;
-    --success: #6fbf94;
-    --ring: rgba(127, 174, 138, 0.35);
-    --glass-bg: rgba(38, 48, 40, 0.72);
-    --glass-border: rgba(236, 228, 211, 0.12);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
-  }
 }
 
 * {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -2,7 +2,7 @@
    Fuente de verdad: design/DESIGN_SYSTEM.md + design/prototipo-editorial.html.
    Tema claro por defecto + tema oscuro (#278). El tema se controla con el
    atributo `data-theme` en <html> (lo fija `lib/theme.ts` sin flash); si no
-   hay elección explícita se respeta `prefers-color-scheme`. */
+   hay elección se usa el claro (#373). */
 
 :root {
   /* superficies (papel) */
@@ -83,10 +83,9 @@
 /* ─── Tema oscuro (#278) ──────────────────────────────────────────────────────
    Editorial oscuro: papel → tinta cálida verdosa, mucho aire, verde y terracota
    ligeramente más luminosos para leerse sobre superficies oscuras.
-   Los valores se declaran una sola vez en `%dark-vars` (mixin manual) y se
-   aplican en dos contextos:
-     1. Elección explícita del usuario:  :root[data-theme="dark"]
-     2. Preferencia del SO sin elección:  @media (prefers-color-scheme: dark)
+   Se aplica en un único contexto: la elección explícita del usuario
+   (`:root[data-theme="dark"]`). El SO no decide el tema — sin elección
+   guardada se usa el claro, ver #373 y `lib/theme.ts`.
    `--ts-on-green` y `--ts-on-ink` permanecen crema: son texto sobre rellenos
    verdes/oscuros que existen en ambos temas. */
 
@@ -136,44 +135,3 @@
   color-scheme: dark;
 }
 
-/* Preferencia del SO cuando el usuario no ha elegido explícitamente (data-theme
-   ausente o "system"). Se anula en cuanto se fija data-theme="light". */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]):not([data-theme="dark"]) {
-    --ts-bg: #161c18;
-    --ts-surface: #1e2621;
-    --ts-surface-alt: #19201b;
-    --ts-paper-tint: #212a24;
-
-    --ts-green: #4f8a61;
-    --ts-green-ink: #0f140f;
-    --ts-green-soft: #8aa891;
-    --ts-sage: #9fb0a0;
-    --ts-sage-2: #97a998;
-    --ts-sage-3: #6c7c6e;
-
-    --ts-tint-green: #223026;
-    --ts-tint-green-2: #26362b;
-    --ts-tint-green-3: #33463a;
-
-    --ts-clay: #d07a54;
-    --ts-clay-tint: #3a241c;
-
-    --ts-border: #33403a;
-    --ts-beige: #2a332c;
-    --ts-beige-2: #313a33;
-    --ts-tint-2: #2f3a33;
-    --ts-ink-3: #97a998;
-
-    --ts-text: #ece4d3;
-    --ts-text-secondary: #b7c1b3;
-    --ts-text-muted: #9aa694;
-
-    --ts-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --ts-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
-
-    --ts-ring: 0 0 0 3px rgba(122, 170, 138, 0.42);
-
-    color-scheme: dark;
-  }
-}


### PR DESCRIPTION
## El problema

Al entrar a TerraShare por primera vez la web aparecía en **tema oscuro**, aunque el predeterminado de la marca es el **claro**.

## La causa

`getInitialTheme()` caía a la preferencia del sistema operativo cuando no había nada guardado:

```ts
return systemPrefersDark() ? "dark" : "light";
```

El script anti-flash de `__root.tsx` replicaba la misma lógica, así que el oscuro se aplicaba ya antes del primer pintado. Con Windows en modo oscuro —el caso de la máquina de pruebas— la primera visita salía oscura.

## El arreglo

- Sin elección guardada → **claro**, siempre. El SO deja de decidir.
- La elección explícita del usuario en el conmutador se sigue guardando en `localStorage` y manda sobre todo.
- Se eliminan los dos bloques `@media (prefers-color-scheme: dark)` de `tokens.css` y `styles.css`. Ya eran código muerto (el SSR siempre pinta `data-theme` en `<html>`, así que sus selectores `:root:not([data-theme=…])` nunca casaban) y su único efecto posible era reintroducir el fallo en un futuro refactor.

## Comprobado

Con el SO en oscuro (`matchMedia('(prefers-color-scheme: dark)').matches === true`) y `localStorage` limpio:

| | antes | después |
|---|---|---|
| `data-theme` | `dark` | `light` |
| `--ts-bg` | `#161c18` | `#f4efe4` |

Y eligiendo oscuro en el conmutador sigue funcionando: `data-theme=dark`, `--ts-bg: #161c18`, y la paleta heredada también cambia (`--leaf-900: #7fae8a`), o sea el bloque `:root[data-theme="dark"]` de `styles.css` sigue vivo.

- 29/29 pruebas unitarias de web en verde (3 nuevas en `src/lib/theme.test.ts`, que falsean `matchMedia` para que diga siempre «oscuro»: si alguien vuelve a consultarlo, fallan).
- `typecheck` limpio.

Closes #373
