### PR TITLE
feat(web): botón de volver y Busco/Ofrezco que navega de verdad (#377)

### DIFF
--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -1,10 +1,11 @@
 import { createContext, useContext, useState } from "react";
 import type { ReactNode } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import { Navbar } from "./ui";
 import type { BuscoOfrezcoMode } from "./ui";
 import ThemeToggle from "./ThemeToggle";
+import BackLink from "./BackLink";
 import { getDisplayName, isAdminUser } from "./authDisplay";
 import type { UserMenuItem } from "./ui";
 import "../pages/app-shell.css";
@@ -59,17 +60,31 @@ function ChatIcon() {
   );
 }
 
-export default function AppLayout({ children }: { children?: ReactNode }) {
+export default function AppLayout({
+  children,
+  backTo,
+}: {
+  children?: ReactNode;
+  /** Si se indica, se pinta un control de «volver» sobre el contenido (#377).
+   *  El inicio lo omite: no hay pantalla anterior a la raíz de la cuenta. */
+  backTo?: string;
+}) {
   const navigate = useNavigate();
   const { user } = useUser();
   const { signOut } = useClerk();
   const [mode, setModeState] = useState<BuscoOfrezcoMode>(readStoredMode);
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
 
   const setMode = (next: BuscoOfrezcoMode) => {
     setModeState(next);
     // TODO(#137): persistir el modo (Busco/Ofrezco) en el perfil del usuario.
     // Por ahora se guarda localmente para que sobreviva a recargas.
     window.localStorage.setItem(MODE_STORAGE_KEY, next);
+    // Solo el inicio pinta algo distinto según el modo. Desde el catálogo el
+    // conmutador parecía roto: cambiaba de pestaña activa y nada más (#377).
+    // Estando ya en el inicio no se navega, o cada clic apilaría una entrada
+    // en el historial y el «volver» del navegador se llenaría de basura.
+    if (pathname !== "/dashboard") navigate({ to: "/dashboard" });
   };
 
   const context: AppLayoutContext = { mode, setMode };
@@ -109,6 +124,7 @@ export default function AppLayout({ children }: { children?: ReactNode }) {
         onSignOut={() => signOut({ redirectUrl: "/" })}
       />
       <main id="contenido" className="app-main">
+        {backTo && <BackLink fallbackTo={backTo} />}
         <AppModeContext.Provider value={context}>{children}</AppModeContext.Provider>
       </main>
     </div>

--- a/apps/web/src/components/BackLink.tsx
+++ b/apps/web/src/components/BackLink.tsx
@@ -1,0 +1,42 @@
+import { ArrowLeft } from "lucide-react";
+import { useCanGoBack, useRouter } from "@tanstack/react-router";
+import "./back-link.css";
+
+interface BackLinkProps {
+  /**
+   * Destino de respaldo cuando no hay pantalla anterior dentro de la aplicación
+   * (enlace compartido, pestaña nueva, recarga). Sin esto el control sería un
+   * callejón sin salida justo en el caso en que más falta hace.
+   */
+  fallbackTo: string;
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Control de «volver» (#377).
+ *
+ * Retrocede en el historial del enrutador, que es lo que la persona espera:
+ * deshacer el último paso, sea cual sea. `useCanGoBack()` distingue el caso en
+ * que TanStack Router tiene una entrada previa propia de aquel en que se entró
+ * directo a la URL; en el segundo se navega al padre de la sección en vez de
+ * dejar un botón que no hace nada (o que saca de la aplicación).
+ */
+export default function BackLink({ fallbackTo, label = "Volver", className }: BackLinkProps) {
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+
+  return (
+    <button
+      type="button"
+      className={["ts-back", className].filter(Boolean).join(" ")}
+      onClick={() => {
+        if (canGoBack) router.history.back();
+        else router.navigate({ to: fallbackTo });
+      }}
+    >
+      <ArrowLeft size={16} aria-hidden="true" />
+      {label}
+    </button>
+  );
+}

--- a/apps/web/src/components/UserDashboardLayout.tsx
+++ b/apps/web/src/components/UserDashboardLayout.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import { useClerk, useUser } from "@clerk/clerk-react";
 import { Bell, MessageCircle, Sprout } from "lucide-react";
 import { Navbar } from "./ui";
+import BackLink from "./BackLink";
 import type { UserMenuItem } from "./ui";
 import { getDisplayName, isAdminUser } from "./authDisplay";
 import "../pages/app-shell.css";
@@ -10,6 +11,12 @@ import "../pages/app-shell.css";
 interface UserDashboardLayoutProps {
   children?: ReactNode;
   onSignOut?: () => void;
+  /**
+   * Destino del control de «volver» cuando se llegó por enlace directo y no hay
+   * pantalla anterior (#377). El inicio de la cuenta sirve para casi todas; las
+   * pantallas de detalle pasan el listado del que cuelgan.
+   */
+  backTo?: string;
 }
 
 function BrandMark() {
@@ -24,7 +31,11 @@ function BrandMark() {
 /** Layout editorial de las páginas de cuenta (terrenos, chats, notificaciones,
  *  pagos, perfil). Reutiliza la Navbar del sistema para igualar al AppLayout,
  *  sin el switch Busco/Ofrezco. */
-export default function UserDashboardLayout({ children, onSignOut }: UserDashboardLayoutProps) {
+export default function UserDashboardLayout({
+  children,
+  onSignOut,
+  backTo = "/dashboard",
+}: UserDashboardLayoutProps) {
   const navigate = useNavigate();
   const { user } = useUser();
   const { signOut } = useClerk();
@@ -66,7 +77,11 @@ export default function UserDashboardLayout({ children, onSignOut }: UserDashboa
         userMenuItems={userMenuItems}
         onSignOut={handleSignOut}
       />
-      <main className="app-main">{children}</main>
+      <main className="app-main">
+        {/* Volver (#377): estas pantallas solo tenían la flecha del navegador. */}
+        <BackLink fallbackTo={backTo} />
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/web/src/components/back-link.css
+++ b/apps/web/src/components/back-link.css
@@ -1,0 +1,29 @@
+/* Control de «volver» (#377). Discreto: es un apoyo, no una acción principal,
+   así que va como enlace de texto y solo gana fondo al pasar por encima. */
+
+.ts-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--ts-font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ts-sage-2);
+  padding: 7px 12px 7px 8px;
+  margin-left: -8px; /* alinea el texto con el contenido de la página */
+  border-radius: var(--ts-radius);
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.ts-back:hover {
+  color: var(--ts-green);
+  background: var(--ts-tint-green);
+}
+
+.ts-back:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}

--- a/apps/web/src/routes/catalog.tsx
+++ b/apps/web/src/routes/catalog.tsx
@@ -5,6 +5,10 @@ import CatalogPage from "../pages/CatalogPage";
 
 export const Route = createFileRoute("/catalog")({
   component: () => (
-    <ProtectedRoute><AppLayout><CatalogPage /></AppLayout></ProtectedRoute>
+    <ProtectedRoute>
+      <AppLayout backTo="/dashboard">
+        <CatalogPage />
+      </AppLayout>
+    </ProtectedRoute>
   ),
 });

--- a/apps/web/src/routes/dashboard.contracts.$id.tsx
+++ b/apps/web/src/routes/dashboard.contracts.$id.tsx
@@ -5,6 +5,12 @@ import ContractDetailPage from "../pages/ContractDetailPage";
 
 export const Route = createFileRoute("/dashboard/contracts/$id")({
   component: () => (
-    <ProtectedRoute><UserDashboardLayout><ContractDetailPage /></UserDashboardLayout></ProtectedRoute>
+    <ProtectedRoute>
+      {/* Entrando por enlace directo, «volver» debe llevar al listado de
+          contratos, no al inicio de la cuenta (#377). */}
+      <UserDashboardLayout backTo="/dashboard/contracts">
+        <ContractDetailPage />
+      </UserDashboardLayout>
+    </ProtectedRoute>
   ),
 });


### PR DESCRIPTION
## Los problemas

**1. No había forma de volver sin los botones del navegador.** Las diez pantallas que montan `UserDashboardLayout` (`chats`, `contracts`, `contracts/$id`, `lands`, `notifications`, `payments`, `privacy`, `profile`, `searches`, `visits`) no ofrecían ningún control de vuelta. Las pantallas de detalle públicas —terreno, comparador, reserva, pago, detalle de reporte del admin— sí lo tenían; estas se quedaron fuera.

**2. Busco/Ofrezco no hacía nada visible fuera del inicio.** El conmutador solo cambia un estado que únicamente lee `HomePage`:

```tsx
return mode === "ofrezco" ? <OfrezcoHome /> : <BuscoHome name={name} />;
```

Estando en `/catalog` (el mapa), pulsar «Busco» u «Ofrezco» cambiaba la pestaña activa y nada más. Parecía un control roto.

## El arreglo

### `<BackLink>`

Un control nuevo, discreto (enlace de texto que solo gana fondo al pasar por encima), que:

- retrocede en el historial del enrutador — deshacer el último paso, sea cual sea, que es lo que la persona espera del control;
- si `useCanGoBack()` dice que TanStack Router no tiene entrada previa propia (enlace compartido, pestaña nueva, recarga), navega a un destino de respaldo. Sin eso el botón sería un callejón sin salida justo en el caso en que más falta hace.

Se monta en `UserDashboardLayout` (las diez pantallas de golpe) y en `AppLayout` cuando se le pasa `backTo` — hoy solo el catálogo. **El inicio lo omite a propósito**: no hay pantalla anterior a la raíz de la cuenta.

El respaldo por defecto es `/dashboard`; `/dashboard/contracts/$id` pasa `/dashboard/contracts`, que es el listado del que cuelga.

### Busco/Ofrezco

Cambiar de modo lleva al inicio en ese modo. Estando ya en el inicio no navega: cada clic apilaría una entrada y llenaría de basura el «atrás» del navegador.

## Comprobado

- 41/41 E2E en chromium (el mismo proyecto que corre el CI) en verde.
- 49 pruebas en chromium + webkit locales en verde. Firefox no corre en esta máquina por falta del binario, cosa ajena a este cambio.
- `typecheck` limpio.

Verificación visual pendiente: las once pantallas viven tras `ProtectedRoute`, así que no puedo abrirlas sin iniciar sesión.

Closes #377
