### PR TITLE
feat(catalog): desplegable propio en los filtros del mapa (#379)

### DIFF
--- a/apps/web/src/components/ui/Dropdown.tsx
+++ b/apps/web/src/components/ui/Dropdown.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useId, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+
+export interface DropdownOption {
+  value: string;
+  label: string;
+}
+
+export interface DropdownProps {
+  /** Etiqueta accesible del control (no se pinta). */
+  label: string;
+  value: string;
+  options: DropdownOption[];
+  onChange: (value: string) => void;
+  /** Icono a la izquierda del texto. */
+  icon?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Desplegable propio del sistema de diseño (#379).
+ *
+ * Sustituye al `<select>` nativo por dos motivos que se notan usando la web:
+ *
+ * 1. **La lista de opciones no se puede estilar.** El navegador la pinta con su
+ *    aspecto del sistema — un rectángulo blanco con tipografía de sistema — que
+ *    no tiene nada que ver con la píldora crema sobre la que cuelga, ni sigue
+ *    al tema oscuro.
+ * 2. **Solo abría al pulsar el texto.** El `<select>` nativo ocupaba una parte
+ *    del interior de la píldora; el icono y el galón quedaban fuera, así que
+ *    pulsar el botón «entero» no hacía nada. Aquí el botón ES el disparador.
+ *
+ * Teclado: Enter/Espacio/flechas abren, las flechas mueven, Enter elige,
+ * Escape cierra y devuelve el foco al botón.
+ */
+export default function Dropdown({
+  label,
+  value,
+  options,
+  onChange,
+  icon,
+  className,
+}: DropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const listId = useId();
+
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((o) => o.value === value),
+  );
+  const selected = options[selectedIndex];
+
+  // Cerrar al pulsar fuera o al perder el foco de la ventana. Sin esto se puede
+  // dejar más de una lista abierta a la vez y el resultado es un desastre.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent | TouchEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown);
+    window.addEventListener("blur", () => setOpen(false), { once: true });
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+    };
+  }, [open]);
+
+  // El foco pasa a la lista al abrir para que el teclado funcione de inmediato.
+  useEffect(() => {
+    if (open) listRef.current?.focus();
+  }, [open]);
+
+  const openAt = (index: number) => {
+    setActiveIndex(index);
+    setOpen(true);
+  };
+
+  const choose = (index: number) => {
+    const option = options[index];
+    if (option) onChange(option.value);
+    setOpen(false);
+    buttonRef.current?.focus();
+  };
+
+  const close = () => {
+    setOpen(false);
+    buttonRef.current?.focus();
+  };
+
+  const onListKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        close();
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(options.length - 1, i + 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(0, i - 1));
+        break;
+      case "Home":
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setActiveIndex(options.length - 1);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        choose(activeIndex);
+        break;
+      case "Tab":
+        setOpen(false);
+        break;
+    }
+  };
+
+  return (
+    <div className={["ds-dd", className].filter(Boolean).join(" ")} ref={rootRef}>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`ds-dd__btn${open ? " is-open" : ""}`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={label}
+        onClick={() => (open ? close() : openAt(selectedIndex))}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+            e.preventDefault();
+            openAt(selectedIndex);
+          }
+        }}
+      >
+        {icon && <span className="ds-dd__icon">{icon}</span>}
+        <span className="ds-dd__value">{selected?.label ?? label}</span>
+        <ChevronDown size={14} className="ds-dd__chev" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <ul
+          ref={listRef}
+          id={listId}
+          role="listbox"
+          aria-label={label}
+          aria-activedescendant={`${listId}-${activeIndex}`}
+          tabIndex={-1}
+          className="ds-dd__list"
+          onKeyDown={onListKeyDown}
+        >
+          {options.map((option, i) => (
+            <li
+              key={option.value}
+              id={`${listId}-${i}`}
+              role="option"
+              aria-selected={option.value === value}
+              className={[
+                "ds-dd__opt",
+                i === activeIndex ? "is-active" : "",
+                option.value === value ? "is-selected" : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              onMouseEnter={() => setActiveIndex(i)}
+              onClick={() => choose(i)}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -21,3 +21,6 @@ export type { SidebarProps, SidebarItem } from "./Sidebar";
 
 export { default as Stepper } from "./Stepper";
 export type { StepperProps } from "./Stepper";
+
+export { default as Dropdown } from "./Dropdown";
+export type { DropdownProps, DropdownOption } from "./Dropdown";

--- a/apps/web/src/components/ui/ui.css
+++ b/apps/web/src/components/ui/ui.css
@@ -541,3 +541,100 @@
   background: var(--ts-green);
   color: var(--ts-on-green);
 }
+
+/* ── Desplegable propio (#379) ─────────────────────────────────────────────
+   Reemplaza al `<select>` nativo, cuya lista de opciones el navegador pinta
+   con el aspecto del sistema —rectángulo blanco, tipografía de sistema— y no
+   sigue al tema. Aquí el disparador y la lista comparten superficie, borde,
+   radio y tipografía, así que la lista se lee como una extensión del botón. */
+
+.ds-dd {
+  position: relative;
+  display: inline-flex;
+}
+
+.ds-dd__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  font-family: var(--ts-font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ts-text-secondary);
+  background: var(--ts-bg);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  padding: 11px 14px 11px 16px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.ds-dd__btn:hover,
+.ds-dd__btn.is-open {
+  border-color: var(--ts-green);
+}
+
+.ds-dd__btn:focus-visible {
+  outline: none;
+  box-shadow: var(--ts-ring);
+}
+
+.ds-dd__icon {
+  display: inline-flex;
+  color: var(--ts-text-secondary);
+  flex: 0 0 auto;
+}
+
+.ds-dd__value {
+  white-space: nowrap;
+}
+
+.ds-dd__chev {
+  color: var(--ts-sage);
+  flex: 0 0 auto;
+  transition: transform 0.2s ease;
+}
+
+.ds-dd__btn.is-open .ds-dd__chev {
+  transform: rotate(180deg);
+}
+
+.ds-dd__list {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 100%;
+  max-height: 17rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius);
+  box-shadow: var(--ts-shadow);
+  outline: none;
+}
+
+.ds-dd__opt {
+  padding: 9px 12px;
+  border-radius: var(--ts-radius-sm);
+  font-family: var(--ts-font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ts-text);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+/* La opción bajo el cursor o bajo las flechas del teclado: el mismo tinte. */
+.ds-dd__opt.is-active {
+  background: var(--ts-tint-green);
+}
+
+.ds-dd__opt.is-selected {
+  color: var(--ts-green);
+  font-weight: 700;
+}

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -284,31 +284,35 @@ export default function CatalogPage() {
           ]}
         />
 
-        {/* Guardar la búsqueda actual (HU-99 / #368). Sin criterios no tiene
-            sentido: una alerta «de cualquier terreno» sería solo ruido. */}
-        <button
-          type="button"
-          className="cat-pill cat-pill--action"
-          onClick={() => { setSaveFeedback(""); setSaveOpen(true); }}
-          disabled={!hasAnyFilter(currentFilters)}
-          title={
-            hasAnyFilter(currentFilters)
-              ? "Guardar esta búsqueda y recibir avisos"
-              : "Elige algún filtro para poder guardar la búsqueda"
-          }
-        >
-          <span className="cat-pill__icon">
-            <BookmarkPlus size={15} />
-          </span>
-          Guardar búsqueda
-        </button>
+        {/* Las dos acciones van juntas y alineadas a la derecha: al envolverse
+            bajan como bloque, en vez de dejar una suelta debajo (#379). */}
+        <div className="cat-filters__actions">
+          {/* Guardar la búsqueda actual (HU-99 / #368). Sin criterios no tiene
+              sentido: una alerta «de cualquier terreno» sería solo ruido. */}
+          <button
+            type="button"
+            className="cat-pill cat-pill--action"
+            onClick={() => { setSaveFeedback(""); setSaveOpen(true); }}
+            disabled={!hasAnyFilter(currentFilters)}
+            title={
+              hasAnyFilter(currentFilters)
+                ? "Guardar esta búsqueda y recibir avisos"
+                : "Elige algún filtro para poder guardar la búsqueda"
+            }
+          >
+            <span className="cat-pill__icon">
+              <BookmarkPlus size={15} />
+            </span>
+            Guardar búsqueda
+          </button>
 
-        <Link to="/dashboard/searches" className="cat-pill cat-pill--action">
-          <span className="cat-pill__icon">
-            <Bookmark size={15} />
-          </span>
-          Mis búsquedas
-        </Link>
+          <Link to="/dashboard/searches" className="cat-pill cat-pill--action">
+            <span className="cat-pill__icon">
+              <Bookmark size={15} />
+            </span>
+            Mis búsquedas
+          </Link>
+        </div>
       </div>
 
       {saveFeedback && (

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -7,7 +7,6 @@ import {
   MapPin,
   DollarSign,
   Tag,
-  ChevronDown,
   ImageIcon,
   SearchX,
   Heart,
@@ -38,6 +37,7 @@ import {
 } from "../lib/catalog-filters";
 import { createSavedSearch } from "../services/api";
 import SaveSearchModal from "../components/SaveSearchModal";
+import { Dropdown } from "../components/ui";
 import PanamaMap from "../components/LazyPanamaMap";
 import EmptyState from "../components/EmptyState";
 import { useFavorites } from "../hooks/useFavorites";
@@ -239,81 +239,50 @@ export default function CatalogPage() {
           />
         </div>
 
-        <label className="cat-pill">
-          <span className="cat-pill__icon">
-            <Sprout size={15} />
-          </span>
-          <select value={use} onChange={(e) => setUse(e.target.value)} aria-label="Filtrar por uso">
-            <option value="todos">Uso</option>
-            {useOptions.map((opt) => (
-              <option key={opt} value={opt}>
-                {formatUse(opt)}
-              </option>
-            ))}
-          </select>
-          <span className="cat-pill__chev">
-            <ChevronDown size={14} />
-          </span>
-        </label>
+        <Dropdown
+          label="Filtrar por uso"
+          icon={<Sprout size={15} />}
+          value={use}
+          onChange={setUse}
+          options={[
+            { value: ANY_USE, label: "Uso" },
+            ...useOptions.map((opt) => ({ value: opt, label: formatUse(opt) })),
+          ]}
+        />
 
-        <label className="cat-pill">
-          <span className="cat-pill__icon">
-            <MapPin size={15} />
-          </span>
-          <select
-            value={province}
-            onChange={(e) => setProvince(e.target.value)}
-            aria-label="Filtrar por provincia"
-          >
-            <option value="todas">Provincia</option>
-            {provinceOptions.map((opt) => (
-              <option key={opt} value={opt}>
-                {opt}
-              </option>
-            ))}
-          </select>
-          <span className="cat-pill__chev">
-            <ChevronDown size={14} />
-          </span>
-        </label>
+        <Dropdown
+          label="Filtrar por provincia"
+          icon={<MapPin size={15} />}
+          value={province}
+          onChange={setProvince}
+          options={[
+            { value: ANY_PROVINCE, label: "Provincia" },
+            ...provinceOptions.map((opt) => ({ value: opt, label: opt })),
+          ]}
+        />
 
-        <label className="cat-pill">
-          <span className="cat-pill__icon">
-            <DollarSign size={15} />
-          </span>
-          <select
-            value={maxPrice}
-            onChange={(e) => setMaxPrice(Number(e.target.value))}
-            aria-label="Filtrar por precio"
-          >
-            {priceOptionsWith(maxPrice).map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-          <span className="cat-pill__chev">
-            <ChevronDown size={14} />
-          </span>
-        </label>
+        <Dropdown
+          label="Filtrar por precio"
+          icon={<DollarSign size={15} />}
+          value={String(maxPrice)}
+          onChange={(v) => setMaxPrice(Number(v))}
+          options={priceOptionsWith(maxPrice).map((opt) => ({
+            value: String(opt.value),
+            label: opt.label,
+          }))}
+        />
 
-        <label className="cat-pill">
-          <span className="cat-pill__icon">
-            <Tag size={15} />
-          </span>
-          <select
-            value={operation}
-            onChange={(e) => setOperation(e.target.value)}
-            aria-label="Filtrar por tipo de operación"
-          >
-            <option value="todas">Alquiler / Venta</option>
-            <option value="alquiler">En alquiler</option>
-            <option value="venta">En venta</option>
-          </select>
-          <span className="cat-pill__chev">
-            <ChevronDown size={14} />
-          </span>
-        </label>
+        <Dropdown
+          label="Filtrar por tipo de operación"
+          icon={<Tag size={15} />}
+          value={operation}
+          onChange={setOperation}
+          options={[
+            { value: ANY_OPERATION, label: "Alquiler / Venta" },
+            { value: "alquiler", label: "En alquiler" },
+            { value: "venta", label: "En venta" },
+          ]}
+        />
 
         {/* Guardar la búsqueda actual (HU-99 / #368). Sin criterios no tiene
             sentido: una alerta «de cualquier terreno» sería solo ruido. */}
@@ -377,11 +346,14 @@ export default function CatalogPage() {
               description="No encontramos terrenos con esos filtros. Prueba ampliar la búsqueda."
               action={{
                 label: "Limpiar filtros",
+                // El tipo de operación se quedaba fuera: se limpiaba todo lo
+                // demás y la lista seguía vacía sin explicación (#379).
                 onClick: () => {
                   setQuery("");
-                  setUse("todos");
-                  setProvince("todas");
-                  setMaxPrice(1_000_000);
+                  setUse(ANY_USE);
+                  setProvince(ANY_PROVINCE);
+                  setOperation(ANY_OPERATION);
+                  setMaxPrice(NO_PRICE_LIMIT);
                 },
               }}
             />

--- a/apps/web/src/pages/StyleguidePage.tsx
+++ b/apps/web/src/pages/StyleguidePage.tsx
@@ -1,8 +1,10 @@
 import { useId, useState } from "react";
+import { MapPin } from "lucide-react";
 import {
   Badge,
   Button,
   Card,
+  Dropdown,
   Field,
   Input,
   Navbar,
@@ -28,6 +30,7 @@ const rowStyle: React.CSSProperties = {
 export default function StyleguidePage() {
   const [mode, setMode] = useState<BuscoOfrezcoMode>("busco");
   const [step, setStep] = useState(1);
+  const [province, setProvince] = useState("todas");
   const emailId = useId();
   const nameId = useId();
   const errId = useId();
@@ -162,6 +165,34 @@ export default function StyleguidePage() {
             <Input id={errId} invalid defaultValue="-10" />
           </Field>
         </div>
+      </section>
+
+      {/* Dropdown */}
+      <section style={sectionStyle}>
+        <h2 className="ts-title">Dropdown</h2>
+        <p style={{ color: "var(--ts-text-secondary)", maxWidth: "60ch" }}>
+          Sustituye al <code>&lt;select&gt;</code> nativo, cuya lista de opciones el navegador pinta
+          con el aspecto del sistema y no sigue al tema. El botón entero abre la lista, no solo el
+          texto.
+        </p>
+        <div style={rowStyle}>
+          <Dropdown
+            label="Filtrar por provincia"
+            icon={<MapPin size={15} />}
+            value={province}
+            onChange={setProvince}
+            options={[
+              { value: "todas", label: "Provincia" },
+              { value: "Chiriquí", label: "Chiriquí" },
+              { value: "Coclé", label: "Coclé" },
+              { value: "Herrera", label: "Herrera" },
+              { value: "Los Santos", label: "Los Santos" },
+            ]}
+          />
+        </div>
+        <p style={{ color: "var(--ts-text-secondary)", fontSize: "0.85rem" }}>
+          Valor: <strong>{province}</strong>
+        </p>
       </section>
 
       {/* Stepper */}

--- a/apps/web/src/pages/app-shell.css
+++ b/apps/web/src/pages/app-shell.css
@@ -9,3 +9,10 @@
 .app-main {
   margin-top: 1.25rem;
 }
+
+/* El «volver» iba pegado al primer bloque de la pantalla y se leía como parte
+   de él. La separación la pone el layout, no el componente: `BackLink` también
+   se usa dentro de cabeceras donde ese aire sobra (#379). */
+.app-main > .ts-back {
+  margin-bottom: 14px;
+}

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -5,6 +5,11 @@
 
 /* ── barra de filtros ────────────────────────────────────────────────────── */
 .cat-filters {
+  /* Altura común de todos los controles de la barra. El buscador medía 50px y
+     los filtros 46px —lo alto lo fijaba el `line-height` del `input`, no el
+     diseño—, así que la fila se veía descuadrada. Con una altura declarada
+     dejan de depender de su contenido y quedan a ras (#379). */
+  --cat-ctl-h: 48px;
   display: flex;
   gap: 12px;
   align-items: center;
@@ -15,19 +20,28 @@
   flex-wrap: wrap;
 }
 /* El buscador llevaba `flex: 1`, así que se comía todo el espacio sobrante y
-   quedaba desproporcionado al lado de los filtros. Ahora crece hasta un tope y
-   los filtros se llevan el resto (#379). */
+   quedaba enorme al lado de los filtros. Ahora NO crece: se queda en su ancho
+   y el sobrante se lo reparten los filtros, que es donde hacía falta (#379). */
 .cat-search {
-  flex: 1 1 240px;
-  max-width: 340px;
+  flex: 0 1 260px;
+  min-width: 180px;
+  height: var(--cat-ctl-h);
   display: flex;
   align-items: center;
   gap: 9px;
   background: var(--ts-bg);
   border: 1px solid var(--ts-border);
   border-radius: var(--ts-radius);
-  padding: 12px 14px;
+  padding: 0 14px;
 }
+.cat-search input { font-size: 14px; }
+
+/* Los cuatro filtros se reparten el espacio que suelta el buscador, así que la
+   fila queda a ras y todos con el mismo peso visual. `__value` crece para que
+   la flecha se quede pegada al borde derecho en vez de al texto. */
+.cat-filters .ds-dd { flex: 1 1 auto; }
+.cat-filters .ds-dd__btn { height: var(--cat-ctl-h); padding: 0 16px; }
+.cat-filters .ds-dd__value { flex: 1; text-align: left; }
 /* Los dos botones de acción se agrupan a la derecha: al envolverse bajan
    juntos y alineados, en vez de dejar uno suelto en la línea de abajo. */
 .cat-filters__actions {
@@ -60,7 +74,8 @@
   background: var(--ts-bg);
   border: 1px solid var(--ts-border);
   border-radius: var(--ts-radius);
-  padding: 12px 16px;
+  height: var(--cat-ctl-h);
+  padding: 0 16px;
   cursor: pointer;
   transition: border-color 0.2s ease;
   position: relative;

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -36,6 +36,23 @@
 }
 .cat-search input { font-size: 14px; }
 
+/* El foco se pinta en la CAJA, no en el `input` (#379).
+   `styles.css` (hoja heredada) tiene un `input:focus` global con un anillo de
+   4px, y `base.css` un `:focus-visible` con contorno. Como este `input` no
+   tiene borde y solo ocupa el hueco interior, ambos dibujaban un recuadro
+   suelto por dentro del buscador, más pequeño que el campo y descentrado por
+   el icono de la lupa. Se anulan en el hijo y el realce pasa al contenedor,
+   que es lo que la persona percibe como «el buscador». */
+.cat-search:focus-within {
+  border-color: var(--ts-green);
+  box-shadow: var(--ts-ring);
+}
+.cat-search input:focus,
+.cat-search input:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
 /* Los cuatro filtros se reparten el espacio que suelta el buscador, así que la
    fila queda a ras y todos con el mismo peso visual. `__value` crece para que
    la flecha se quede pegada al borde derecho en vez de al texto. */

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -8,21 +8,33 @@
   display: flex;
   gap: 12px;
   align-items: center;
-  padding: 18px 24px;
-  border-bottom: 1px solid var(--ts-border);
+  padding: 16px 18px;
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-lg);
   background: var(--ts-surface-alt);
   flex-wrap: wrap;
 }
+/* El buscador llevaba `flex: 1`, así que se comía todo el espacio sobrante y
+   quedaba desproporcionado al lado de los filtros. Ahora crece hasta un tope y
+   los filtros se llevan el resto (#379). */
 .cat-search {
-  flex: 1;
-  min-width: 220px;
+  flex: 1 1 240px;
+  max-width: 340px;
   display: flex;
   align-items: center;
   gap: 9px;
   background: var(--ts-bg);
   border: 1px solid var(--ts-border);
-  border-radius: 11px;
-  padding: 11px 14px;
+  border-radius: var(--ts-radius);
+  padding: 12px 14px;
+}
+/* Los dos botones de acción se agrupan a la derecha: al envolverse bajan
+   juntos y alineados, en vez de dejar uno suelto en la línea de abajo. */
+.cat-filters__actions {
+  display: flex;
+  gap: 12px;
+  margin-left: auto;
+  flex-wrap: wrap;
 }
 .cat-search__icon { color: var(--ts-sage-3); display: inline-flex; flex: 0 0 auto; }
 .cat-search input {
@@ -47,8 +59,8 @@
   font-weight: 600;
   background: var(--ts-bg);
   border: 1px solid var(--ts-border);
-  border-radius: 11px;
-  padding: 11px 16px;
+  border-radius: var(--ts-radius);
+  padding: 12px 16px;
   cursor: pointer;
   transition: border-color 0.2s ease;
   position: relative;
@@ -62,10 +74,17 @@
    de estar «Pronto» (#365). */
 
 /* ── layout lista + mapa ─────────────────────────────────────────────────── */
-.cat-body { display: grid; grid-template-columns: 1.25fr 0.75fr; }
+/* `gap` separa la lista del mapa —antes se tocaban con solo un filete en medio—
+   y `margin-top` los despega de la barra de filtros, que ahora es una tarjeta
+   con esquinas redondeadas y necesita aire alrededor (#379). */
+.cat-body {
+  display: grid;
+  grid-template-columns: 1.25fr 0.75fr;
+  gap: 20px;
+  margin-top: 20px;
+}
 .cat-listcol {
-  padding: 24px;
-  border-right: 1px solid var(--ts-border);
+  padding: 0;
   min-width: 0;
 }
 .cat-listhead { font-size: 13.5px; color: var(--ts-sage); margin-bottom: 18px; }
@@ -171,6 +190,8 @@
   height: calc(100vh - 96px);
   min-height: 420px;
   background: var(--ts-tint-green-2);
+  border: 1px solid var(--ts-border);
+  border-radius: var(--ts-radius-lg);
   overflow: hidden;
 }
 .cat-mapcol .panama-map-container,

--- a/apps/web/src/pages/catalog.css
+++ b/apps/web/src/pages/catalog.css
@@ -36,12 +36,14 @@
 }
 .cat-search input::placeholder { color: var(--ts-sage-3); }
 
+/* El verde-gris iba fijo (#3d4d3d): en tema oscuro quedaba texto casi negro
+   sobre fondo casi negro, ilegible. Ahora sigue al tema (#379). */
 .cat-pill {
   display: inline-flex;
   align-items: center;
   gap: 7px;
   font-size: 14px;
-  color: #3d4d3d;
+  color: var(--ts-text-secondary);
   font-weight: 600;
   background: var(--ts-bg);
   border: 1px solid var(--ts-border);
@@ -52,33 +54,12 @@
   position: relative;
 }
 .cat-pill:hover { border-color: var(--ts-green); }
-.cat-pill__icon { color: #3d4d3d; display: inline-flex; }
-.cat-pill select {
-  appearance: none;
-  -webkit-appearance: none;
-  border: 0;
-  background: transparent;
-  font-family: var(--ts-font-sans);
-  font-size: 14px;
-  font-weight: 600;
-  color: #3d4d3d;
-  cursor: pointer;
-  outline: none;
-  padding-right: 2px;
-}
-.cat-pill__chev { color: var(--ts-sage); display: inline-flex; pointer-events: none; }
-.cat-pill--soon { cursor: default; color: var(--ts-sage); }
-.cat-pill--soon:hover { border-color: var(--ts-border); }
-.cat-soon__tag {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--ts-clay);
-  background: var(--ts-clay-tint);
-  border-radius: 999px;
-  padding: 2px 7px;
-}
+.cat-pill__icon { color: var(--ts-text-secondary); display: inline-flex; }
+/* `.cat-pill` ya solo viste los dos botones de acción (guardar búsqueda, mis
+   búsquedas). Los cuatro filtros pasaron a `<Dropdown>`, así que se van con
+   ellos `.cat-pill select`, `.cat-pill__chev` y el par `--soon`, que además
+   ya no tenía marca a la que aplicarse desde que el filtro de operación dejó
+   de estar «Pronto» (#365). */
 
 /* ── layout lista + mapa ─────────────────────────────────────────────────── */
 .cat-body { display: grid; grid-template-columns: 1.25fr 0.75fr; }
@@ -237,7 +218,7 @@
 .cat-mapcard__cmp.is-active {
   color: var(--ts-clay);
   border-color: var(--ts-clay);
-  background: var(--ts-clay-tint, #f3e4dc);
+  background: var(--ts-clay-tint);
 }
 .cat-mapcard__go {
   font-size: 13px;


### PR DESCRIPTION
## Los problemas

**1. La lista de opciones no tenía el estilo de la web.** Los cuatro filtros eran `<select>` nativos. La píldora se puede estilar; la lista desplegada no. El navegador la pinta con su aspecto del sistema —rectángulo blanco, tipografía de sistema— que no tiene nada que ver con la píldora crema sobre la que cuelga, ni sigue al tema oscuro.

**2. Solo abría al pulsar la palabra.** El `<select>` ocupaba una parte del interior de la píldora; el icono de la izquierda y el galón (▾) de la derecha quedaban **fuera** de él, y el galón además llevaba `pointer-events: none`. Pulsar el galón —el elemento que anuncia «aquí hay algo que desplegar»— no hacía nada.

## El arreglo

Un primitivo nuevo, `<Dropdown>`, en `components/ui`:

- **El botón ES el disparador.** Icono, texto y galón, todo dentro del mismo `<button>`.
- **La lista se lee como una extensión del botón**: misma superficie, mismo borde, mismo radio, misma tipografía, con los tokens `--ts-*` — así que sigue al tema en vez de ignorarlo.
- **Teclado completo**: Enter/Espacio/flechas abren, las flechas mueven, Enter elige, Escape cierra y devuelve el foco al botón, Tab cierra. Semántica `listbox`/`option` con `aria-expanded`, `aria-selected` y `aria-activedescendant`.
- Cierra al pulsar fuera o al perder el foco de la ventana, para que no queden dos listas abiertas a la vez.
- Documentado en `/styleguide`.

### Dos fallos preexistentes de la misma barra

- **`.cat-pill` fijaba el texto y el icono a `#3d4d3d`.** En tema oscuro eso era texto casi negro sobre fondo casi negro (`--ts-bg: #161c18`). Ahora usa `--ts-text-secondary`.
- **«Limpiar filtros» no limpiaba el tipo de operación.** Se borraba todo lo demás, la lista seguía vacía y no había forma de saber por qué. De paso los valores literales (`"todos"`, `1_000_000`) pasan a las constantes que ya existían (`ANY_USE`, `NO_PRICE_LIMIT`…), que es de donde debieron salir.

Se eliminan las reglas que quedaron muertas: `.cat-pill select`, `.cat-pill__chev` y el par `--soon` (sin marca que vestir desde que el filtro de operación dejó de estar «Pronto», #365). También un `var(--ts-clay-tint, #f3e4dc)` con respaldo, que es justo lo que enmascara un token ausente en tema oscuro.

## Comprobado

En vivo sobre `/styleguide`, que es pública:

- **Clic a 8 px del borde derecho del botón** —la zona que el `<select>` no cubría— abre la lista: el punto impacta en `.ds-dd__btn` y `aria-expanded` pasa a `true`. Este era el fallo principal.
- **Tema claro**: botón y lista comparten `#f4efe4`/`#fffdf8` con borde `#e6ddc9` y radio 12 px.
- **Tema oscuro** (tras recarga limpia): botón `#161c18` con texto `#b7c1b3` y borde `#33403a`; lista `#1e2621`, opción activa `#223026`, texto `#ece4d3`. Nada de blanco del sistema.
- **Elegir una opción** cierra la lista, actualiza el valor y devuelve el foco al botón.
- **Teclado**: `ArrowDown` sobre el botón abre y pasa el foco a la lista; la siguiente flecha mueve la opción activa y `aria-activedescendant` la sigue.

Y en la línea de comandos:

- 41/41 E2E en chromium (el proyecto que corre el CI) en verde.
- 29/29 pruebas unitarias y `typecheck` limpio.

Closes #379
